### PR TITLE
feat: Plan A — causal within-window depth recurrence (proof + verdict)

### DIFF
--- a/ablation_harness.py
+++ b/ablation_harness.py
@@ -31,12 +31,41 @@ def cumulative_task(key, batch, seq, mod):
     return x.astype(jnp.int32), targets.astype(jnp.int32), mask
 
 
+def state_tracking_task(key, batch, seq, n_states=5, n_gen=4):
+    """Non-commutative state tracking: each input token picks one of `n_gen` fixed
+    permutations of `n_states`; the target at position t is the state reached by
+    composing those permutations over the prefix, starting from state 0. Because
+    composition is non-abelian, there is no sum/count shortcut — getting position t
+    right requires sequentially tracking the state, so it genuinely rewards depth
+    (the Liu et al. "Transformers Learn Shortcuts to Automata" regime)."""
+    gen_key = jax.random.PRNGKey(12345)  # fixed generators across all calls
+    perms = jnp.stack([
+        jax.random.permutation(jax.random.fold_in(gen_key, i), n_states) for i in range(n_gen)
+    ])  # [n_gen, n_states]
+
+    toks = jax.random.randint(key, (batch, seq), 0, n_gen)
+
+    def track(tok_row):
+        def step(state, t):
+            new = perms[t][state]
+            return new, new
+        _, states = jax.lax.scan(step, jnp.int32(0), tok_row)
+        return states
+
+    targets = jax.vmap(track)(toks).astype(jnp.int32)
+    mask = jnp.ones((batch, seq), dtype=jnp.float32)
+    return toks.astype(jnp.int32), targets, mask
+
+
 SEQ = 24
 TASKS = {
     "parity": lambda key, batch: cumulative_task(key, batch, SEQ, 2),
     "cumsum5": lambda key, batch: cumulative_task(key, batch, SEQ, 5),
+    "statetrack": lambda key, batch: state_tracking_task(key, batch, SEQ, 5, 4),
 }
-VOCAB = {"parity": 2, "cumsum5": 5}
+# Vocab must cover both input tokens and targets. statetrack: inputs in [0,n_gen),
+# targets (states) in [0,n_states) -> vocab = max(n_gen, n_states).
+VOCAB = {"parity": 2, "cumsum5": 5, "statetrack": 5}
 
 
 def evaluate(model, task_fn, depth, key, batch=2048):

--- a/ablation_harness.py
+++ b/ablation_harness.py
@@ -57,11 +57,11 @@ def state_tracking_task(key, batch, seq, n_states=5, n_gen=4):
     return toks.astype(jnp.int32), targets, mask
 
 
-SEQ = 24
+SEQ = 24  # default train length
 TASKS = {
-    "parity": lambda key, batch: cumulative_task(key, batch, SEQ, 2),
-    "cumsum5": lambda key, batch: cumulative_task(key, batch, SEQ, 5),
-    "statetrack": lambda key, batch: state_tracking_task(key, batch, SEQ, 5, 4),
+    "parity": lambda key, batch, seq: cumulative_task(key, batch, seq, 2),
+    "cumsum5": lambda key, batch, seq: cumulative_task(key, batch, seq, 5),
+    "statetrack": lambda key, batch, seq: state_tracking_task(key, batch, seq, 5, 4),
 }
 # Vocab must cover both input tokens and targets. statetrack: inputs in [0,n_gen),
 # targets (states) in [0,n_states) -> vocab = max(n_gen, n_states).
@@ -76,20 +76,24 @@ def _masked_acc_ce(logits, tgt, mask):
 
 
 def train_one(task_fn, vocab, depth, *, dim=96, heads=4, enc=2, steps=2500,
-              batch=256, lr=2e-3, wd=0.01, seed=0, gate_bias=0.0, n_pool=32768, n_test=4096):
+              batch=256, lr=2e-3, wd=0.01, seed=0, gate_bias=0.0, n_pool=32768, n_test=4096,
+              train_seq=SEQ, test_seq=None):
+    # When test_seq > train_seq this is a length-generalization probe: the model
+    # trains on length train_seq and is evaluated on longer sequences, so it must
+    # use RoPE positions it never saw in training. test_seq=None -> same length.
+    test_seq = train_seq if test_seq is None else test_seq
     key = jax.random.PRNGKey(seed)
-    # Generate the data pool ONCE — the task's perms/scan are expensive, and doing
-    # them per step starved the tiny model's GPU (host-bound at ~10% util). Train on
-    # minibatches sampled on-device inside the jitted step; eval on a held-out slice
-    # so the depth comparison also reflects generalization, not just fit.
-    key, dk = jax.random.split(key)
-    inp_all, tgt_all, mask_all = task_fn(dk, n_pool + n_test)
-    tr_inp, tr_tgt, tr_mask = inp_all[:n_pool], tgt_all[:n_pool], mask_all[:n_pool]
-    te_inp, te_tgt, te_mask = inp_all[n_pool:], tgt_all[n_pool:], mask_all[n_pool:]
+    # Generate each pool ONCE — the task's perms/scan are expensive, and doing them
+    # per step starved the tiny model's GPU (host-bound at ~10% util). Train on
+    # minibatches sampled on-device inside the jitted step; eval on a separately
+    # drawn held-out pool so the comparison reflects generalization, not just fit.
+    key, dk_tr, dk_te = jax.random.split(key, 3)
+    tr_inp, tr_tgt, tr_mask = task_fn(dk_tr, n_pool, train_seq)
+    te_inp, te_tgt, te_mask = task_fn(dk_te, n_test, test_seq)
 
     model = CausalRefiner(dim=dim, vocab_size=vocab, num_heads=heads,
                           num_encoder_layers=enc, max_depth=max(depth, 1),
-                          max_seq_len=SEQ, gate_bias=gate_bias, rngs=nnx.Rngs(seed))
+                          max_seq_len=max(train_seq, test_seq), gate_bias=gate_bias, rngs=nnx.Rngs(seed))
     opt = nnx.Optimizer(model, optax.adamw(lr, weight_decay=wd), wrt=nnx.Param)
 
     @nnx.jit(static_argnames=["depth"])
@@ -125,18 +129,24 @@ def main():
     ap.add_argument("--gate-bias", type=float, default=0.0,
                     help="init bias of the update gate; negative = retention-biased (stabilizes deep recurrence)")
     ap.add_argument("--lr", type=float, default=2e-3)
+    ap.add_argument("--train-seq", type=int, default=SEQ)
+    ap.add_argument("--test-seq", type=int, default=None,
+                    help="eval length; > train-seq makes it a length-generalization probe (default: = train-seq)")
     args = ap.parse_args()
 
     task_fn = TASKS[args.task]
     vocab = VOCAB[args.task]
     depths = [int(d) for d in args.depths.split(",")]
+    test_seq = args.train_seq if args.test_seq is None else args.test_seq
 
-    print(f"== Plan A depth ablation: task={args.task} (seq={SEQ}, vocab={vocab}) steps={args.steps} seed={args.seed} gate_bias={args.gate_bias} ==")
+    print(f"== Plan A depth ablation: task={args.task} (train_seq={args.train_seq}, test_seq={test_seq}, vocab={vocab}) steps={args.steps} seed={args.seed} gate_bias={args.gate_bias} lr={args.lr} ==")
     print(f"{'depth':>6} {'val_acc':>9} {'val_ce':>9} {'sec':>7}")
     results = {}
     for d in depths:
         t0 = time.time()
-        acc, ce = train_one(task_fn, vocab, d, steps=args.steps, seed=args.seed, gate_bias=args.gate_bias, lr=args.lr)
+        acc, ce = train_one(task_fn, vocab, d, steps=args.steps, seed=args.seed,
+                            gate_bias=args.gate_bias, lr=args.lr,
+                            train_seq=args.train_seq, test_seq=test_seq)
         results[d] = (acc, ce)
         print(f"{d:>6} {acc:>9.4f} {ce:>9.4f} {time.time() - t0:>7.1f}")
 

--- a/ablation_harness.py
+++ b/ablation_harness.py
@@ -1,0 +1,105 @@
+"""Tiny-config ablation harness for Plan A — the proof instrument.
+
+Trains the CausalRefiner at fixed depths on depth-sensitive toy tasks and reports
+val accuracy / CE per depth. The question Plan A has to answer: does looping the
+shared block more times let it solve a task a shallow model can't? Fineweb
+perplexity can't show this (recurrent-depth wins live on algorithmic tasks), so we
+test where depth provably has to do work — cumulative scans, which require
+aggregating all prior tokens.
+
+    venv/bin/python ablation_harness.py --task parity --depths 1,2,4,8
+"""
+
+import argparse
+import time
+
+import jax
+import jax.numpy as jnp
+from flax import nnx
+import optax
+
+from plan_a_model import CausalRefiner
+
+
+def cumulative_task(key, batch, seq, mod):
+    """Predict the running sum mod `mod` of the inputs so far — a sequential scan.
+    Position t's target needs every input <= t, so it rewards aggregation depth.
+    mod=2 is parity. Input and target share the vocab {0..mod-1}."""
+    x = jax.random.randint(key, (batch, seq), 0, mod)
+    targets = jnp.cumsum(x, axis=1) % mod
+    mask = jnp.ones((batch, seq), dtype=jnp.float32)
+    return x.astype(jnp.int32), targets.astype(jnp.int32), mask
+
+
+SEQ = 24
+TASKS = {
+    "parity": lambda key, batch: cumulative_task(key, batch, SEQ, 2),
+    "cumsum5": lambda key, batch: cumulative_task(key, batch, SEQ, 5),
+}
+VOCAB = {"parity": 2, "cumsum5": 5}
+
+
+def evaluate(model, task_fn, depth, key, batch=2048):
+    inp, tgt, mask = task_fn(key, batch)
+    logits = model(inp, depth=depth)
+    pred = logits.argmax(-1)
+    acc = float(jnp.sum((pred == tgt) * mask) / jnp.sum(mask))
+    ce = float(jnp.sum(optax.softmax_cross_entropy_with_integer_labels(logits=logits, labels=tgt) * mask) / jnp.sum(mask))
+    return acc, ce
+
+
+def train_one(task_fn, vocab, depth, *, dim=96, heads=4, enc=2, steps=2500,
+              batch=256, lr=2e-3, wd=0.01, seed=0):
+    key = jax.random.PRNGKey(seed)
+    model = CausalRefiner(dim=dim, vocab_size=vocab, num_heads=heads,
+                          num_encoder_layers=enc, max_depth=max(depth, 1),
+                          max_seq_len=SEQ, rngs=nnx.Rngs(seed))
+    opt = nnx.Optimizer(model, optax.adamw(lr, weight_decay=wd), wrt=nnx.Param)
+
+    @nnx.jit(static_argnames=["depth"])
+    def step(model, opt, inp, tgt, mask, depth):
+        def loss_fn(m):
+            logits = m(inp, depth=depth)
+            ce = optax.softmax_cross_entropy_with_integer_labels(logits=logits, labels=tgt)
+            return jnp.sum(ce * mask) / jnp.sum(mask)
+        loss, grads = nnx.value_and_grad(loss_fn)(model)
+        opt.update(model, grads)
+        return loss
+
+    for _ in range(steps):
+        key, k = jax.random.split(key)
+        inp, tgt, mask = task_fn(k, batch)
+        step(model, opt, inp, tgt, mask, depth)
+
+    key, k = jax.random.split(key)
+    return evaluate(model, task_fn, depth, k)
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--task", default="parity", choices=list(TASKS))
+    ap.add_argument("--depths", default="1,2,4,8")
+    ap.add_argument("--steps", type=int, default=2500)
+    ap.add_argument("--seed", type=int, default=0)
+    args = ap.parse_args()
+
+    task_fn = TASKS[args.task]
+    vocab = VOCAB[args.task]
+    depths = [int(d) for d in args.depths.split(",")]
+
+    print(f"== Plan A depth ablation: task={args.task} (seq={SEQ}, vocab={vocab}) steps={args.steps} seed={args.seed} ==")
+    print(f"{'depth':>6} {'val_acc':>9} {'val_ce':>9} {'sec':>7}")
+    results = {}
+    for d in depths:
+        t0 = time.time()
+        acc, ce = train_one(task_fn, vocab, d, steps=args.steps, seed=args.seed)
+        results[d] = (acc, ce)
+        print(f"{d:>6} {acc:>9.4f} {ce:>9.4f} {time.time() - t0:>7.1f}")
+
+    base_acc = results[depths[0]][0]
+    best_d = max(results, key=lambda d: results[d][0])
+    print(f"\ndepth {depths[0]}: acc {base_acc:.4f}  ->  best depth {best_d}: acc {results[best_d][0]:.4f}  |  gain {results[best_d][0] - base_acc:+.4f}")
+
+
+if __name__ == "__main__":
+    main()

--- a/ablation_harness.py
+++ b/ablation_harness.py
@@ -76,7 +76,7 @@ def _masked_acc_ce(logits, tgt, mask):
 
 
 def train_one(task_fn, vocab, depth, *, dim=96, heads=4, enc=2, steps=2500,
-              batch=256, lr=2e-3, wd=0.01, seed=0, n_pool=32768, n_test=4096):
+              batch=256, lr=2e-3, wd=0.01, seed=0, gate_bias=0.0, n_pool=32768, n_test=4096):
     key = jax.random.PRNGKey(seed)
     # Generate the data pool ONCE — the task's perms/scan are expensive, and doing
     # them per step starved the tiny model's GPU (host-bound at ~10% util). Train on
@@ -89,7 +89,7 @@ def train_one(task_fn, vocab, depth, *, dim=96, heads=4, enc=2, steps=2500,
 
     model = CausalRefiner(dim=dim, vocab_size=vocab, num_heads=heads,
                           num_encoder_layers=enc, max_depth=max(depth, 1),
-                          max_seq_len=SEQ, rngs=nnx.Rngs(seed))
+                          max_seq_len=SEQ, gate_bias=gate_bias, rngs=nnx.Rngs(seed))
     opt = nnx.Optimizer(model, optax.adamw(lr, weight_decay=wd), wrt=nnx.Param)
 
     @nnx.jit(static_argnames=["depth"])
@@ -122,18 +122,20 @@ def main():
     ap.add_argument("--depths", default="1,2,4,8")
     ap.add_argument("--steps", type=int, default=2500)
     ap.add_argument("--seed", type=int, default=0)
+    ap.add_argument("--gate-bias", type=float, default=0.0,
+                    help="init bias of the update gate; negative = retention-biased (stabilizes deep recurrence)")
     args = ap.parse_args()
 
     task_fn = TASKS[args.task]
     vocab = VOCAB[args.task]
     depths = [int(d) for d in args.depths.split(",")]
 
-    print(f"== Plan A depth ablation: task={args.task} (seq={SEQ}, vocab={vocab}) steps={args.steps} seed={args.seed} ==")
+    print(f"== Plan A depth ablation: task={args.task} (seq={SEQ}, vocab={vocab}) steps={args.steps} seed={args.seed} gate_bias={args.gate_bias} ==")
     print(f"{'depth':>6} {'val_acc':>9} {'val_ce':>9} {'sec':>7}")
     results = {}
     for d in depths:
         t0 = time.time()
-        acc, ce = train_one(task_fn, vocab, d, steps=args.steps, seed=args.seed)
+        acc, ce = train_one(task_fn, vocab, d, steps=args.steps, seed=args.seed, gate_bias=args.gate_bias)
         results[d] = (acc, ce)
         print(f"{d:>6} {acc:>9.4f} {ce:>9.4f} {time.time() - t0:>7.1f}")
 

--- a/ablation_harness.py
+++ b/ablation_harness.py
@@ -124,6 +124,7 @@ def main():
     ap.add_argument("--seed", type=int, default=0)
     ap.add_argument("--gate-bias", type=float, default=0.0,
                     help="init bias of the update gate; negative = retention-biased (stabilizes deep recurrence)")
+    ap.add_argument("--lr", type=float, default=2e-3)
     args = ap.parse_args()
 
     task_fn = TASKS[args.task]
@@ -135,7 +136,7 @@ def main():
     results = {}
     for d in depths:
         t0 = time.time()
-        acc, ce = train_one(task_fn, vocab, d, steps=args.steps, seed=args.seed, gate_bias=args.gate_bias)
+        acc, ce = train_one(task_fn, vocab, d, steps=args.steps, seed=args.seed, gate_bias=args.gate_bias, lr=args.lr)
         results[d] = (acc, ce)
         print(f"{d:>6} {acc:>9.4f} {ce:>9.4f} {time.time() - t0:>7.1f}")
 

--- a/ablation_harness.py
+++ b/ablation_harness.py
@@ -68,25 +68,34 @@ TASKS = {
 VOCAB = {"parity": 2, "cumsum5": 5, "statetrack": 5}
 
 
-def evaluate(model, task_fn, depth, key, batch=2048):
-    inp, tgt, mask = task_fn(key, batch)
-    logits = model(inp, depth=depth)
+def _masked_acc_ce(logits, tgt, mask):
     pred = logits.argmax(-1)
-    acc = float(jnp.sum((pred == tgt) * mask) / jnp.sum(mask))
-    ce = float(jnp.sum(optax.softmax_cross_entropy_with_integer_labels(logits=logits, labels=tgt) * mask) / jnp.sum(mask))
+    acc = jnp.sum((pred == tgt) * mask) / jnp.sum(mask)
+    ce = jnp.sum(optax.softmax_cross_entropy_with_integer_labels(logits=logits, labels=tgt) * mask) / jnp.sum(mask)
     return acc, ce
 
 
 def train_one(task_fn, vocab, depth, *, dim=96, heads=4, enc=2, steps=2500,
-              batch=256, lr=2e-3, wd=0.01, seed=0):
+              batch=256, lr=2e-3, wd=0.01, seed=0, n_pool=32768, n_test=4096):
     key = jax.random.PRNGKey(seed)
+    # Generate the data pool ONCE — the task's perms/scan are expensive, and doing
+    # them per step starved the tiny model's GPU (host-bound at ~10% util). Train on
+    # minibatches sampled on-device inside the jitted step; eval on a held-out slice
+    # so the depth comparison also reflects generalization, not just fit.
+    key, dk = jax.random.split(key)
+    inp_all, tgt_all, mask_all = task_fn(dk, n_pool + n_test)
+    tr_inp, tr_tgt, tr_mask = inp_all[:n_pool], tgt_all[:n_pool], mask_all[:n_pool]
+    te_inp, te_tgt, te_mask = inp_all[n_pool:], tgt_all[n_pool:], mask_all[n_pool:]
+
     model = CausalRefiner(dim=dim, vocab_size=vocab, num_heads=heads,
                           num_encoder_layers=enc, max_depth=max(depth, 1),
                           max_seq_len=SEQ, rngs=nnx.Rngs(seed))
     opt = nnx.Optimizer(model, optax.adamw(lr, weight_decay=wd), wrt=nnx.Param)
 
     @nnx.jit(static_argnames=["depth"])
-    def step(model, opt, inp, tgt, mask, depth):
+    def step(model, opt, key, inp_all, tgt_all, mask_all, depth):
+        idx = jax.random.randint(key, (batch,), 0, inp_all.shape[0])
+        inp, tgt, mask = inp_all[idx], tgt_all[idx], mask_all[idx]
         def loss_fn(m):
             logits = m(inp, depth=depth)
             ce = optax.softmax_cross_entropy_with_integer_labels(logits=logits, labels=tgt)
@@ -95,13 +104,16 @@ def train_one(task_fn, vocab, depth, *, dim=96, heads=4, enc=2, steps=2500,
         opt.update(model, grads)
         return loss
 
+    @nnx.jit(static_argnames=["depth"])
+    def eval_step(model, inp, tgt, mask, depth):
+        return _masked_acc_ce(model(inp, depth=depth), tgt, mask)
+
     for _ in range(steps):
         key, k = jax.random.split(key)
-        inp, tgt, mask = task_fn(k, batch)
-        step(model, opt, inp, tgt, mask, depth)
+        step(model, opt, k, tr_inp, tr_tgt, tr_mask, depth)
 
-    key, k = jax.random.split(key)
-    return evaluate(model, task_fn, depth, k)
+    acc, ce = eval_step(model, te_inp, te_tgt, te_mask, depth)
+    return float(acc), float(ce)
 
 
 def main():

--- a/ablation_results.md
+++ b/ablation_results.md
@@ -83,3 +83,25 @@ manifest at real scale — but a depth-aware LR is the safe rule.
 
 Depths 1,2,4,8 all at lr 1e-3 (the stable LR), to give one rigorous monotonic
 curve instead of the mixed-LR numbers above. This is the capstone figure.
+
+| depth | val_acc | val_ce |
+|---|---|---|
+| 1 | 0.8480 | 0.3651 |
+| 2 | 0.9194 | 0.2010 |
+| 4 | **0.9837** | 0.0510 |
+| 8 | 0.9755 | 0.0755 |
+
+**Definitive: depth helps monotonically 1 -> 2 -> 4** (+0.136 acc, 7x lower CE),
+and depth 8 holds strong (0.976, no collapse) at a stable LR. Diminishing returns
+past depth 4 on this task (4 ≈ 8), so depth 4 is the sweet spot here.
+
+## Conclusion (2026-06-13 overnight)
+
+Causal within-window depth recurrence (Plan A) does real work where the
+cross-window hunch did not: on a task that requires sequential composition, more
+recurrence iterations monotonically improve held-out accuracy. The depth-8
+instability was LR-driven, not structural — fixed by a lower LR (use a
+depth-aware LR schedule). Open items for Matheus: (1) wire CausalRefiner into the
+production fineweb trainer (different interface from UniversalReasoner), (2) run
+the full test battery on that integration, (3) only then the gated cl100k run.
+Not started — they need review/go per docs/AUTONOMY.md.

--- a/ablation_results.md
+++ b/ablation_results.md
@@ -118,3 +118,47 @@ depth-aware LR schedule). Open items for Matheus: (1) wire CausalRefiner into th
 production fineweb trainer (different interface from UniversalReasoner), (2) run
 the full test battery on that integration, (3) only then the gated cl100k run.
 Not started — they need review/go per docs/AUTONOMY.md.
+
+## Run 7 — 2026-06-13 (post-PR #15) — length generalization (train seq 24, eval seq 48)
+
+The open question run 5/6 did not answer: does the depth benefit survive when the
+sequence is *longer than training*? Same task/config (statetrack, dim 96, enc 2,
+lr 1e-3, 6000 steps), but the model trains on length-24 sequences and is evaluated
+on length-48 — so it must use RoPE positions 24-47 it never saw, on a state chain
+twice as long. Baseline for comparison: run 6 (same task, eval length 24).
+
+3 seeds (0,1,2), mean accuracy [range] at eval length 48:
+
+| depth | mean acc @ 48 | range | (ref) acc @ 24, run 6 mean |
+|---|---|---|---|
+| 1 | 0.542 | 0.537–0.545 | 0.856 |
+| 2 | 0.600 | 0.597–0.605 | 0.934 |
+| 4 | 0.639 | 0.633–0.643 | 0.983 |
+| 8 | **0.683** | 0.674–0.691 | 0.981 |
+
+Two findings, opposite signs:
+
+1. **Absolute length generalization is poor.** Best accuracy at 2x length is 0.68
+   vs 0.98 in-distribution. The model leans partly on length-bound structure and
+   cannot freely extrapolate RoPE to unseen positions — a real limitation to flag
+   before any scale claim. (Above chance 0.20, so the algorithm *partially*
+   transfers, but far from solved.)
+2. **Depth is the component that helps under length shift — and now monotonically
+   to 8.** In-distribution, accuracy saturated at depth 4 (4 ≈ 8). Out-of-distribution
+   it keeps climbing 1 -> 2 -> 4 -> 8 (+0.138, depth 8 best). Mechanistically
+   sensible: a length-48 chain is a *longer* sequential composition than length-24,
+   so it needs *more* refinement iterations. This is depth-as-compute scaling with
+   problem size — the same reasoning that motivates adaptive/length-aware depth
+   (the untried idea, not a documented dead-end).
+
+Robust across 3 seeds: monotonic 1<2<4<8 on every seed, with no overlap between
+adjacent depths (depth-1 max 0.545 < depth-2 min 0.597 < depth-4 min 0.633 <
+depth-8 min 0.674); mean gain depth1->8 = +0.141. The elevated depth-2 CE on seed
+0 (1.81) was single-seed noise — accuracy is clean. The model-build difference from
+run 6 (max_seq_len 48 vs 24) is immaterial to training: RoPE positions 0-23 are
+identical regardless of table size, only the eval length differs.
+
+Read forward: this does NOT block anything — it's a property measurement, not a
+gate. It says (a) report length-gen honestly as weak, (b) depth genuinely buys
+extrapolation headroom, strengthening the case that the inference depth dial
+should perhaps scale with context length rather than being a fixed 4.

--- a/ablation_results.md
+++ b/ablation_results.md
@@ -1,0 +1,29 @@
+# Plan A ablation results log
+
+Branch `feat/ablation-harness`. Each run: train `CausalRefiner` from scratch at a
+fixed depth, same budget, report held-out accuracy/CE. Question: does looping the
+shared block more times help a depth-needing task?
+
+## Run 1 — 2026-06-13 — cumsum tasks (dim 96, enc 2, seq 24)
+
+| task | depth 1 | depth 2 | depth 4 | depth 8 |
+|---|---|---|---|---|
+| cumsum mod 5 (3000 steps) | 0.9851 | 0.9572 | 0.9868 | 0.9874 |
+| parity / mod 2 (4000 steps) | 0.7381 | **0.7909** | 0.6535 | 0.5784 |
+
+**Read:** inconclusive, leaning negative, but the tasks are miscalibrated:
+- cumsum-mod-5 is too *easy* — depth 1 already solves it (98.5%), so there's no
+  headroom for depth to show value. A cumulative sum is computable by one
+  attention layer (uniform attend + sum), so it doesn't need sequential depth.
+- parity is too *hard/noisy* — nothing solves it, and crucially depth **degrades**
+  past 2 (depth 8 ≈ chance). That is the documented instability of deep
+  weight-shared recurrence (looping a shared block 8× without depth-aware
+  init/LR), not evidence about whether depth helps the function.
+
+**Decisions forward:**
+- Do NOT launch the cl100k run — proof gate is not green.
+- Need a task depth-1 genuinely *cannot* shortcut: non-commutative state tracking
+  (permutation composition), where the answer requires sequential composition.
+- Watch whether the depth-8 degradation persists on the harder task. If it does,
+  Plan A needs a stability fix (e.g. depth-scaled residual / lower LR for deep)
+  before high depth is usable — a real finding worth knowing before any big run.

--- a/ablation_results.md
+++ b/ablation_results.md
@@ -95,6 +95,19 @@ curve instead of the mixed-LR numbers above. This is the capstone figure.
 and depth 8 holds strong (0.976, no collapse) at a stable LR. Diminishing returns
 past depth 4 on this task (4 ≈ 8), so depth 4 is the sweet spot here.
 
+## Run 6 — multi-seed robustness (statetrack, lr 1e-3, seeds 0/1/2)
+
+| depth | mean acc | range |
+|---|---|---|
+| 1 | 0.856 | 0.848-0.871 |
+| 2 | 0.934 | 0.919-0.943 |
+| 4 | 0.983 | 0.982-0.984 |
+| 8 | 0.981 | 0.976-0.985 |
+
+depth-1 -> depth-4 gain robust (+0.127 mean, no seed overlap: depth-1 best 0.871
+< depth-4 worst 0.982). Depth 4 ≈ depth 8 (saturation). depth 8 stable across all
+seeds at lr 1e-3. Single-seed caveat retired.
+
 ## Conclusion (2026-06-13 overnight)
 
 Causal within-window depth recurrence (Plan A) does real work where the

--- a/ablation_results.md
+++ b/ablation_results.md
@@ -57,3 +57,17 @@ iterations and diverges. Biasing the gate to retention at init (gate_bias=-2 ->
 sigmoid=0.12, small early steps) should stabilize deep recurrence. Re-running the
 full depth sweep with --gate-bias -2; success = depth 8 recovers toward depth-4
 accuracy without hurting depths 1-4.
+
+Result (gate_bias=-2): depth 1 0.871, depth 2 **0.959**, depth 4 0.982, depth 8
+**0.274**. Hypothesis **falsified** — retention bias did not rescue depth 8 (still
+collapsed, slightly worse). Depth 2 did improve. So the collapse is not a gate-init
+issue. Collapse to *near-chance* (not partial) points to training instability, not
+slow convergence — next probe: lower LR at depth 8 (LR-driven divergence is the
+likeliest culprit for deep unrolled recurrence).
+
+## Run 4 (in progress) — depth-8 LR probe
+
+depth 8 at lr 5e-4 and 1e-3 (vs the 2e-3 default). If a lower LR recovers depth 8,
+the fix is a depth-aware LR schedule (trivial). If depth 8 still collapses at low
+LR, the instability is structural (signal degradation through the shared loop) and
+needs a design decision — escalate to Matheus rather than brute-force overnight.

--- a/ablation_results.md
+++ b/ablation_results.md
@@ -27,3 +27,33 @@ shared block more times help a depth-needing task?
 - Watch whether the depth-8 degradation persists on the harder task. If it does,
   Plan A needs a stability fix (e.g. depth-scaled residual / lower LR for deep)
   before high depth is usable — a real finding worth knowing before any big run.
+
+## Run 2 — 2026-06-13 — state tracking (dim 96, enc 2, seq 24, 6000 steps, held-out eval)
+
+| depth | val_acc | val_ce |
+|---|---|---|
+| 1 | 0.8772 | 0.2941 |
+| 2 | 0.8965 | 0.2553 |
+| 4 | **0.9843** | 0.0473 |
+| 8 | 0.3743 | 1.3416 |
+
+**The headline positive result of the night:** on a task that genuinely needs
+sequential composition (non-commutative, no sum shortcut), **depth helps
+monotonically 1 -> 2 -> 4**: +0.107 accuracy and 6x lower CE from depth 1 to 4.
+This is the depth-helps signal the cross-window hunch never produced — causal
+within-window depth recurrence does real work. Plan A's core thesis is supported
+on the right instrument.
+
+**But depth 8 collapses to chance (0.37, chance=0.20)** — the same collapse seen
+on parity in run 1, so it is reproducible: deep weight-shared recurrence is
+training-unstable past ~4 with the current (balanced-gate) setup. Production
+MAX_STEPS_LIMIT=8 sits squarely in the broken regime, so the cl100k run stays
+held until this is fixed.
+
+## Run 3 (in progress) — stability probe: gate biased to retention
+
+Hypothesis: a balanced gate (sigmoid(0)=0.5) compounds large updates over many
+iterations and diverges. Biasing the gate to retention at init (gate_bias=-2 ->
+sigmoid=0.12, small early steps) should stabilize deep recurrence. Re-running the
+full depth sweep with --gate-bias -2; success = depth 8 recovers toward depth-4
+accuracy without hurting depths 1-4.

--- a/ablation_results.md
+++ b/ablation_results.md
@@ -71,3 +71,15 @@ depth 8 at lr 5e-4 and 1e-3 (vs the 2e-3 default). If a lower LR recovers depth 
 the fix is a depth-aware LR schedule (trivial). If depth 8 still collapses at low
 LR, the instability is structural (signal degradation through the shared loop) and
 needs a design decision — escalate to Matheus rather than brute-force overnight.
+
+Result: depth 8 @ lr 2e-3 = 0.374 (collapsed); @ **lr 1e-3 = 0.985**; @ lr 5e-4 =
+0.981. **The collapse was LR-driven instability, not structural.** At a sane LR
+depth 8 solves the task, matching depth 4 and far above depth 1. Fix: deeper
+recurrence needs a lower LR (depth-aware LR schedule). The production schedule's
+peak LR is already 1e-4 (10x below the rescuing 1e-3), so this likely won't even
+manifest at real scale — but a depth-aware LR is the safe rule.
+
+## Run 5 (in progress) — clean confirmatory depth curve, single LR
+
+Depths 1,2,4,8 all at lr 1e-3 (the stable LR), to give one rigorous monotonic
+curve instead of the mixed-LR numbers above. This is the capstone figure.

--- a/docs/design/plan-a.md
+++ b/docs/design/plan-a.md
@@ -1,0 +1,95 @@
+# Plan A — causal within-window depth recurrence
+
+Design doc. Implementation follows on the `feat/ablation-harness` branch, gated by
+the test battery before any real run.
+
+## Why
+
+The cross-window hunch is inert (docs/findings/2026-06-13-cross-window-hunch-inert.md).
+After the leak fix, the reasoning loop's only pathway was a compressed slot memory
+carried to the *next* window, and the gradient killed it within ~750 steps. The
+documented-working alternative — Universal Transformer / recurrent-depth — loops a
+shared block **causally over the current positions** and feeds refinement back into
+the prediction it refines. Plan A switches to that pathway.
+
+## Core idea
+
+Refine each position's representation by looping a shared transformer block K times
+under a causal mask, then predict from the refined representation. Position t only
+ever attends to positions ≤ t, on every iteration — so there is **no future-token
+leak by construction**, and depth (K) directly affects the prediction for tokens it
+is allowed to see (unlike the current arch, where the loop can't touch its own
+window at all). K is sampled per micro-step in training (random depth, as today),
+fixed at inference (MAX_STEPS_LIMIT).
+
+## Architecture
+
+```
+embed → fixed encoder (2 layers, causal)
+      → causal refinement loop  (shared block × K, causal self-attn, time-embed/step)
+      → RMSNorm → LM head (tied embedding, f32 accumulation)
+```
+
+Refinement loop (replaces `_reasoning_loop`) — `jax.lax.scan` over K steps, carry is
+`z` of shape [B, S, D]:
+- `z_in = norm(z) + time_signal(time_embed[step])`
+- `z_new = shared_block(z_in, self-attention, mask=pad_bias, q_pos=kv_pos=seq_pos, is_causal=True)`
+- per-position update gate (kept, zero-bias init): `g = sigmoid(gate([z_new, z]))`,
+  `z = g·z_new + (1−g)·z`
+- diag per step: drift `‖z_new − z‖` (reuse temporal_drift logic).
+
+**Removed:** the 32 shared slots and slot cross-attention; the InfoNCE slot-stability
+/ diversity loss (no analogue on per-position states); `hunch_cache`, `should_refresh`,
+and the hunch gate (cross-window memory, proven dead — Plan A is within-window only);
+the slot-reading decoder cross-attention.
+
+**Kept:** `RotaryAttention` with explicit causal mask (leak-correct since the scale
+fix); random-depth sampling (`sample_reasoning_depth`); `time_embed`; the
+f32-accumulation tied LM head; zero-init residual `down_proj` (keeps init loss ≈
+ln(VOCAB)).
+
+## Leak-freedom argument
+
+Encoder causal; every refinement iteration is causal self-attention (q_pos ≥ kv_pos);
+the LM head reads only the refined position-t state. By induction over iterations,
+position t's representation depends only on input positions ≤ t at every depth, so
+logits[t] cannot depend on tokens > t for any K. The causality invariant test must
+confirm this empirically at depths 1, 2, 4, 8.
+
+## Proof instrument (the point of the overnight work)
+
+Fineweb perplexity is the wrong yardstick — recurrent-depth wins show on
+reasoning/algorithmic tasks, not raw next-token CE. So Plan A is validated on the
+tiny-config ablation harness:
+- **Depth-needing toy tasks:** parity (cumulative XOR — needs sequential
+  composition), modular addition, copy/reverse. Tiny vocab, seq ~64, dim 64–128,
+  minutes per run.
+- **Measure:** train tiny Plan A; compare held-out accuracy/CE at inference depth 1
+  vs depth K. If depth K ≫ depth 1 on a depth-needing task while depth 1 plateaus,
+  causal depth recurrence works — the claim the hunch failed to support.
+- **Grokking watch:** these tasks show clean train→generalization transitions fast;
+  depth recurrence is expected to grok where depth-1 cannot.
+
+## Test gates (all green before any real-model run)
+
+- causality invariant (no future leak) at depths 1, 2, 4, 8;
+- `overfit_smoke`: drive a single batch to ~0 loss (the loop can learn);
+- `init_loss` canary: CE ≈ ln(VOCAB) at step 0;
+- golden run: regenerate (architecture changed; old trajectory void), re-arm the
+  determinism guard on the new arch.
+
+## Open questions (decide with ablation evidence, not now)
+
+- Separate fixed-depth encoder + variable-depth loop, or one looped block from
+  embedding to head (purer UT)? Default: 2-layer encoder + looped shared block.
+- Per-position update gate: keep (ACT-adjacent, richer) or drop (pure UT loop)?
+  Default keep, zero-bias init; ablate.
+- Depth schedule: uniform random [1,K] (converged fine before) vs curriculum. Keep
+  uniform.
+
+## Risks
+
+- A new arch written in a night carries residual bug risk past the tests
+  (double-scale precedent) — morning sanity pass required.
+- Positive tiny-task depth signal is directional; confirm at real scale before
+  trusting transfer to fineweb.

--- a/docs/findings/2026-06-13-plan-a-depth-recurrence-works.md
+++ b/docs/findings/2026-06-13-plan-a-depth-recurrence-works.md
@@ -58,11 +58,40 @@ depth-aware LR (deeper recurrence wants a lower LR). The production schedule's p
 LR is already 1e-4, well below the rescuing 1e-3, so it likely won't manifest at
 real scale — but the depth-aware rule is the safe default.
 
+## Length generalization (run 7, 3 seeds)
+
+Train on length 24, evaluate on length 48 (RoPE positions 24-47 unseen, state chain
+2x longer). Mean accuracy [range]:
+
+| depth | acc @ 48 | range | acc @ 24 (run 6) |
+|---|---|---|---|
+| 1 | 0.542 | 0.537–0.545 | 0.856 |
+| 2 | 0.600 | 0.597–0.605 | 0.934 |
+| 4 | 0.639 | 0.633–0.643 | 0.983 |
+| 8 | **0.683** | 0.674–0.691 | 0.981 |
+
+Two-sided, and the interesting part is the sign flip vs in-distribution:
+
+- **Absolute length generalization is weak** — best 0.68 at 2x length vs 0.98
+  in-distribution (above chance 0.20, so partial transfer, not solved). Report
+  honestly: the model leans partly on length-bound structure and does not freely
+  extrapolate RoPE to unseen positions.
+- **Depth is the lever that helps under length shift, and stops saturating.**
+  In-distribution accuracy plateaued at depth 4 (4 ≈ 8); out-of-distribution it
+  climbs monotonically 1->2->4->8 (+0.141 mean, no adjacent-depth overlap on any
+  seed). A longer sequence is a longer sequential composition, so it needs more
+  refinement iterations — depth-as-compute scaling with problem size. This is
+  direct evidence for letting the inference depth dial scale with context length
+  rather than pinning it at a fixed 4 (and motivates the untried adaptive-depth
+  direction, distinct from the ACT halting removed in f6cb905).
+
 ## Limitations
 
 Tiny scale (dim 96), single synthetic task family, 3 seeds (depth gain robust
-across them), in the same-length regime (no length generalization tested). cumsum/parity tasks from run 1 were less
-informative (cumsum too easy — depth-1 saturates; parity too noisy). This shows
+across them). Length generalization tested (run 7 above) and found weak in absolute
+terms, though the depth benefit survives and grows under length shift. cumsum/parity
+tasks from run 1 were less informative (cumsum too easy — depth-1 saturates; parity
+too noisy). This shows
 depth recurrence *can* help on a task that needs it at toy scale; it does NOT yet
 show the gain transfers to fineweb language modeling at 79.6M — that requires
 wiring CausalRefiner into the production trainer and a real run, neither done.

--- a/docs/findings/2026-06-13-plan-a-depth-recurrence-works.md
+++ b/docs/findings/2026-06-13-plan-a-depth-recurrence-works.md
@@ -1,0 +1,58 @@
+# Causal within-window depth recurrence helps where the cross-window hunch did not: deeper recurrence monotonically improves a sequential-composition task
+
+Status: preliminary
+Date: 2026-06-13
+Commit: feat/ablation-harness @ HEAD  Run: tiny-config ablation (synthetic, no runs/ id)  Measured with: `venv/bin/python -u ablation_harness.py --task statetrack --depths 1,2,4,8 --steps 6000 --lr 1e-3`
+
+## Setup
+
+Plan A (docs/design/plan-a.md) replaces the inert cross-window slot-hunch loop
+[[cross-window-hunch-inert]] with Universal-Transformer-style refinement: a shared
+transformer block looped K times causally over the token representations, decode
+from the refined state (CausalRefiner in plan_a_model.py; causality verified —
+perturbing position j leaves all logits at < j bit-identical at every depth). To
+test "does depth help" on the right instrument (fineweb perplexity is the wrong
+yardstick), a tiny-config harness trains the model from scratch at fixed depths on
+a non-commutative state-tracking task (permutation composition, seq 24, 5 states,
+4 generators) — no sum shortcut, so getting position t right requires sequentially
+tracking the state. dim 96, 2 encoder layers, 6000 steps, held-out eval.
+
+## Evidence
+
+Held-out accuracy by inference depth, single LR (1e-3):
+
+| depth | val_acc | val_ce |
+|---|---|---|
+| 1 | 0.8480 | 0.3651 |
+| 2 | 0.9194 | 0.2010 |
+| 4 | 0.9837 | 0.0510 |
+| 8 | 0.9755 | 0.0755 |
+
+Depth helps monotonically 1 -> 2 -> 4 (+0.136 accuracy, 7x lower CE); depth 8
+holds (no further gain past 4 — diminishing returns, depth 4 is the sweet spot
+here). This is the depth-helps signal the cross-window hunch never produced
+[[cross-window-hunch-inert]]: there, more reasoning steps left next-window CE flat
+or slightly worse; here, more causal refinement iterations measurably improve the
+prediction they refine.
+
+Stability note worth keeping: at the harness's default lr 2e-3, depth 8 *collapsed*
+to chance (0.374), reproducibly (it also degraded parity in an earlier run). This
+was LR-driven instability in the deep unrolled loop, not structural — at lr 1e-3
+depth 8 recovers to 0.976, at 5e-4 to 0.981. Biasing the update gate toward
+retention did NOT fix it (falsified hypothesis); lowering the LR did. Fix: a
+depth-aware LR (deeper recurrence wants a lower LR). The production schedule's peak
+LR is already 1e-4, well below the rescuing 1e-3, so it likely won't manifest at
+real scale — but the depth-aware rule is the safe default.
+
+## Limitations
+
+Tiny scale (dim 96), single synthetic task family, single seed, in the same-length
+regime (no length generalization tested). cumsum/parity tasks from run 1 were less
+informative (cumsum too easy — depth-1 saturates; parity too noisy). This shows
+depth recurrence *can* help on a task that needs it at toy scale; it does NOT yet
+show the gain transfers to fineweb language modeling at 79.6M — that requires
+wiring CausalRefiner into the production trainer and a real run, neither done.
+What would strengthen it: multi-seed (noise floor), a length-generalization split,
+and confirmation at real scale. What would weaken it: no measurable depth benefit
+once integrated at scale (plausible if web-text next-token prediction rarely needs
+sequential composition — the open question the real run answers).

--- a/docs/findings/2026-06-13-plan-a-depth-recurrence-works.md
+++ b/docs/findings/2026-06-13-plan-a-depth-recurrence-works.md
@@ -35,6 +35,20 @@ here). This is the depth-helps signal the cross-window hunch never produced
 or slightly worse; here, more causal refinement iterations measurably improve the
 prediction they refine.
 
+Robust across 3 seeds (0, 1, 2), mean accuracy [range]:
+
+| depth | mean acc | range |
+|---|---|---|
+| 1 | 0.856 | 0.848-0.871 |
+| 2 | 0.934 | 0.919-0.943 |
+| 4 | 0.983 | 0.982-0.984 |
+| 8 | 0.981 | 0.976-0.985 |
+
+The depth-1 -> depth-4 gain (+0.127 mean) is unambiguous: depth-1's *best* seed
+(0.871) is below depth-4's *worst* (0.982) — no overlap. Depth 4 and 8 are
+statistically indistinguishable (saturation past 4), and depth 8 is stable across
+every seed at lr 1e-3 (the LR fix holds, not a one-seed fluke).
+
 Stability note worth keeping: at the harness's default lr 2e-3, depth 8 *collapsed*
 to chance (0.374), reproducibly (it also degraded parity in an earlier run). This
 was LR-driven instability in the deep unrolled loop, not structural — at lr 1e-3
@@ -46,8 +60,8 @@ real scale — but the depth-aware rule is the safe default.
 
 ## Limitations
 
-Tiny scale (dim 96), single synthetic task family, single seed, in the same-length
-regime (no length generalization tested). cumsum/parity tasks from run 1 were less
+Tiny scale (dim 96), single synthetic task family, 3 seeds (depth gain robust
+across them), in the same-length regime (no length generalization tested). cumsum/parity tasks from run 1 were less
 informative (cumsum too easy — depth-1 saturates; parity too noisy). This shows
 depth recurrence *can* help on a task that needs it at toy scale; it does NOT yet
 show the gain transfers to fineweb language modeling at 79.6M — that requires

--- a/plan_a_model.py
+++ b/plan_a_model.py
@@ -1,0 +1,146 @@
+"""Plan A — causal within-window depth recurrence (Universal-Transformer style).
+
+A shared transformer block is looped K times over the token representations under
+a causal mask, then the tied LM head reads the refined state. Position t attends
+only to positions <= t on every iteration, so depth refines the prediction with no
+future-token leak (contrast docs/findings/2026-06-13-cross-window-hunch-inert.md,
+where the loop could only reach the next window and the gradient killed it).
+
+Self-contained and fully parametrized (dim, vocab, heads, depth, seq) so the exact
+same architecture runs at tiny toy-task scale and at real scale — the ablation
+harness tests the thing we'd ship, not a stand-in. See docs/design/plan-a.md.
+"""
+
+import jax
+import jax.numpy as jnp
+from flax import nnx
+
+
+def _rope_tables(max_pos, head_dim):
+    inv_freq = 1.0 / (10000 ** (jnp.arange(0, head_dim, 2) / head_dim))
+    freqs = jnp.outer(jnp.arange(max_pos), inv_freq)
+    return jnp.cos(freqs), jnp.sin(freqs)
+
+
+def apply_rope(x, cos, sin):
+    x1, x2 = jnp.split(x, 2, axis=-1)
+    rotated = jax.lax.complex(x1, x2) * jax.lax.complex(cos, sin)
+    return jnp.concatenate([rotated.real, rotated.imag], axis=-1).astype(x.dtype)
+
+
+class CausalAttention(nnx.Module):
+    """Multi-head self-attention, RoPE, causal mask folded into an additive bias."""
+
+    def __init__(self, dim, num_heads, max_pos, rngs, dtype=jnp.float32):
+        assert dim % num_heads == 0, "dim must divide num_heads"
+        self.num_heads = num_heads
+        self.head_dim = dim // num_heads
+        assert self.head_dim % 2 == 0, "head_dim must be even for RoPE"
+        self.q = nnx.Linear(dim, dim, rngs=rngs, dtype=dtype)
+        self.k = nnx.Linear(dim, dim, rngs=rngs, dtype=dtype)
+        self.v = nnx.Linear(dim, dim, rngs=rngs, dtype=dtype)
+        self.o = nnx.Linear(dim, dim, rngs=rngs, dtype=dtype)
+        self.q_norm = nnx.RMSNorm(self.head_dim, epsilon=1e-6, rngs=rngs, dtype=jnp.float32)
+        self.k_norm = nnx.RMSNorm(self.head_dim, epsilon=1e-6, rngs=rngs, dtype=jnp.float32)
+        cos, sin = _rope_tables(max_pos, self.head_dim)
+        self.cos, self.sin = cos, sin
+
+    def __call__(self, x, pad_bias=None):
+        b, s, d = x.shape
+        q = self.q_norm(self.q(x).reshape(b, s, self.num_heads, self.head_dim))
+        k = self.k_norm(self.k(x).reshape(b, s, self.num_heads, self.head_dim))
+        v = self.v(x).reshape(b, s, self.num_heads, self.head_dim)
+
+        cos = self.cos[:s, None, :]
+        sin = self.sin[:s, None, :]
+        q = apply_rope(q, cos, sin)
+        k = apply_rope(k, cos, sin)
+
+        pos = jnp.arange(s)
+        causal = pos[:, None] >= pos[None, :]                       # [s, s], True = allowed
+        bias = jnp.where(causal, 0.0, -1e9)[None, None, :, :]       # [1, 1, s, s]
+        if pad_bias is not None:
+            bias = bias + pad_bias                                  # pad_bias [b, 1, 1, s]
+
+        out = jax.nn.dot_product_attention(q, k, v, bias=bias.astype(x.dtype))
+        return self.o(out.reshape(b, s, d))
+
+
+class Block(nnx.Module):
+    """Pre-norm transformer block: causal attention + SwiGLU MLP, zero-init residual."""
+
+    def __init__(self, dim, num_heads, max_pos, rngs, dtype=jnp.float32):
+        self.attn = CausalAttention(dim, num_heads, max_pos, rngs, dtype)
+        self.norm1 = nnx.RMSNorm(dim, epsilon=1e-6, rngs=rngs, dtype=dtype)
+        self.norm2 = nnx.RMSNorm(dim, epsilon=1e-6, rngs=rngs, dtype=dtype)
+        hidden = ((int(8 * dim / 3) + 63) // 64) * 64
+        self.gate_proj = nnx.Linear(dim, hidden, rngs=rngs, dtype=dtype)
+        self.up_proj = nnx.Linear(dim, hidden, rngs=rngs, dtype=dtype)
+        self.down_proj = nnx.Linear(hidden, dim, kernel_init=jax.nn.initializers.zeros, rngs=rngs, dtype=dtype)
+
+    def __call__(self, x, pad_bias=None):
+        x = x + self.attn(self.norm1(x), pad_bias)
+        h = self.norm2(x)
+        x = x + self.down_proj(jax.nn.silu(self.gate_proj(h)) * self.up_proj(h))
+        return x
+
+
+class CausalRefiner(nnx.Module):
+    """embed -> causal encoder -> (shared block looped K times) -> norm -> tied head.
+
+    `depth` is the number of refinement iterations: sampled per step in training,
+    fixed at inference. It is a static argument to __call__ so the loop unrolls and
+    compiles cleanly (depth is small, <= max_depth).
+    """
+
+    def __init__(self, *, dim, vocab_size, num_heads=4, num_encoder_layers=2,
+                 max_depth=8, max_seq_len=512, use_gate=True, rngs, dtype=jnp.float32):
+        self.dim = dim
+        self.vocab_size = vocab_size
+        self.max_depth = max_depth
+        self.use_gate = use_gate
+        self.dtype = dtype
+
+        self.embed = nnx.Embed(vocab_size, dim, rngs=rngs, dtype=dtype)
+        self.time_embed = nnx.Embed(max_depth + 1, dim, rngs=rngs, dtype=dtype)
+
+        self.encoder = nnx.List([
+            Block(dim, num_heads, max_seq_len, rngs, dtype) for _ in range(num_encoder_layers)
+        ])
+        self.refine_block = Block(dim, num_heads, max_seq_len, rngs, dtype)  # shared, looped
+
+        self.time_norm = nnx.RMSNorm(dim, epsilon=1e-6, rngs=rngs, dtype=dtype)
+        self.time_signal_norm = nnx.RMSNorm(dim, epsilon=1e-6, rngs=rngs, dtype=dtype)
+        self.out_norm = nnx.RMSNorm(dim, epsilon=1e-6, rngs=rngs, dtype=dtype)
+
+        if use_gate:
+            # sigmoid(0) = 0.5 at init: balanced refine/retain, same rationale as the
+            # old forget gate's zero-bias fix.
+            self.gate = nnx.Linear(2 * dim, dim, bias_init=jax.nn.initializers.zeros, rngs=rngs, dtype=dtype)
+
+    def __call__(self, tokens, depth=None, pad_mask=None):
+        depth = self.max_depth if depth is None else depth
+
+        pad_bias = None
+        if pad_mask is not None:
+            pad_bias = (pad_mask.astype(jnp.float32) - 1.0) * 1e9
+            pad_bias = pad_bias[:, None, None, :]
+
+        z = self.embed(tokens)
+        for blk in self.encoder:
+            z = blk(z, pad_bias)
+
+        for step in range(depth):
+            t_signal = self.time_embed(jnp.asarray(step))
+            z_in = self.time_norm(z) + self.time_signal_norm(t_signal)[None, None, :]
+            z_new = self.refine_block(z_in, pad_bias)
+            if self.use_gate:
+                g = jax.nn.sigmoid(self.gate(jnp.concatenate([z_new, z], axis=-1)))
+                z = g * z_new + (1.0 - g) * z
+            else:
+                z = z_new
+
+        z = self.out_norm(z)
+        embed_t = self.embed.embedding.value.astype(self.dtype).T
+        logits = jnp.matmul(z.astype(self.dtype), embed_t, preferred_element_type=jnp.float32)
+        return logits

--- a/plan_a_model.py
+++ b/plan_a_model.py
@@ -94,7 +94,7 @@ class CausalRefiner(nnx.Module):
     """
 
     def __init__(self, *, dim, vocab_size, num_heads=4, num_encoder_layers=2,
-                 max_depth=8, max_seq_len=512, use_gate=True, rngs, dtype=jnp.float32):
+                 max_depth=8, max_seq_len=512, use_gate=True, gate_bias=0.0, rngs, dtype=jnp.float32):
         self.dim = dim
         self.vocab_size = vocab_size
         self.max_depth = max_depth
@@ -114,9 +114,11 @@ class CausalRefiner(nnx.Module):
         self.out_norm = nnx.RMSNorm(dim, epsilon=1e-6, rngs=rngs, dtype=dtype)
 
         if use_gate:
-            # sigmoid(0) = 0.5 at init: balanced refine/retain, same rationale as the
-            # old forget gate's zero-bias fix.
-            self.gate = nnx.Linear(2 * dim, dim, bias_init=jax.nn.initializers.zeros, rngs=rngs, dtype=dtype)
+            # gate_bias sets the init retention/refine balance: sigmoid(gate_bias).
+            # 0.0 -> 0.5 (balanced); negative -> retention-biased (small early update
+            # steps), which stabilizes deep recurrence where balanced steps compound
+            # and diverge (the depth-8 collapse, ablation_results.md run 2).
+            self.gate = nnx.Linear(2 * dim, dim, bias_init=jax.nn.initializers.constant(gate_bias), rngs=rngs, dtype=dtype)
 
     def __call__(self, tokens, depth=None, pad_mask=None):
         depth = self.max_depth if depth is None else depth

--- a/tests/test_plan_a.py
+++ b/tests/test_plan_a.py
@@ -1,0 +1,80 @@
+"""Test battery for the Plan A model (plan_a_model.CausalRefiner).
+
+Self-contained (does not use the UniversalReasoner conftest fixtures) — constructs
+tiny CausalRefiners directly. Runs on CPU in f32 by default, like the rest of the
+suite.
+"""
+
+import os
+os.environ.setdefault("JAX_PLATFORMS", "cpu")
+
+import math
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+import optax
+import pytest
+from flax import nnx
+
+from plan_a_model import CausalRefiner
+
+
+def _tiny(vocab=37, dim=64, seq=32, enc=2):
+    return CausalRefiner(dim=dim, vocab_size=vocab, num_heads=4, num_encoder_layers=enc,
+                         max_depth=8, max_seq_len=seq, rngs=nnx.Rngs(0))
+
+
+@pytest.mark.parametrize("depth", [1, 2, 4, 8])
+def test_causality_no_future_leak(depth):
+    """Perturbing token at position j must not change any logit at positions < j,
+    at any depth — the leak the slot architecture could not close."""
+    m = _tiny()
+    tok = jnp.arange(1, 17)[None, :]
+    j = 8
+    a = np.asarray(m(tok, depth=depth))
+    b = np.asarray(m(tok.at[0, j].set(20), depth=depth))
+    assert np.max(np.abs(a[0, :j] - b[0, :j])) < 1e-5, "future token leaked into an earlier position"
+    assert np.max(np.abs(a[0, j:] - b[0, j:])) > 1e-4, "perturbation had no effect (sanity)"
+
+
+def test_init_loss_near_ln_vocab():
+    """At init the model should be near-uniform: CE ~ ln(vocab)."""
+    vocab = 50
+    m = _tiny(vocab=vocab)
+    tok = jax.random.randint(jax.random.PRNGKey(1), (8, 32), 0, vocab)
+    logits = m(tok, depth=4)
+    ce = float(jnp.mean(optax.softmax_cross_entropy_with_integer_labels(logits=logits, labels=tok)))
+    assert abs(ce - math.log(vocab)) < 0.7, f"init CE {ce:.3f} far from ln(vocab)={math.log(vocab):.3f}"
+
+
+def test_overfit_single_batch():
+    """The looped block can actually learn: drive a fixed batch's loss far down."""
+    vocab = 17
+    m = _tiny(vocab=vocab, seq=16)
+    opt = nnx.Optimizer(m, optax.adamw(3e-3), wrt=nnx.Param)
+    inp = jax.random.randint(jax.random.PRNGKey(0), (4, 16), 0, vocab)
+    tgt = jax.random.randint(jax.random.PRNGKey(2), (4, 16), 0, vocab)
+
+    @nnx.jit
+    def step(m, opt, inp, tgt):
+        def loss_fn(mm):
+            lg = mm(inp, depth=4)
+            return jnp.mean(optax.softmax_cross_entropy_with_integer_labels(logits=lg, labels=tgt))
+        loss, grads = nnx.value_and_grad(loss_fn)(m)
+        opt.update(m, grads)
+        return loss
+
+    first = float(step(m, opt, inp, tgt))
+    for _ in range(250):
+        last = float(step(m, opt, inp, tgt))
+    assert last < 0.15 * first, f"failed to overfit: {first:.3f} -> {last:.3f}"
+
+
+def test_depth_is_static_and_varies_output():
+    """Different depths produce different logits (the loop actually does something)."""
+    m = _tiny()
+    tok = jnp.arange(1, 17)[None, :]
+    d1 = np.asarray(m(tok, depth=1))
+    d8 = np.asarray(m(tok, depth=8))
+    assert np.max(np.abs(d1 - d8)) > 1e-3, "depth had no effect on the output"


### PR DESCRIPTION
## What this is

Replaces the disproven **cross-window slot "hunch"** mechanism with **Plan A: causal within-window depth recurrence** (Universal-Transformer style) — a shared transformer block looped K times causally over token representations, with the tied LM head reading the refined state. Leak-free by construction (causal mask at every depth).

This branch is the *proof instrument and the verdict*, not production integration. Nothing here touches the fineweb trainer yet (that's gated on your review — see "Not in this PR").

## The verdict

On a task that genuinely needs sequential composition (non-commutative state tracking — no sum shortcut), **depth helps monotonically**, which is the signal the cross-window hunch never produced:

| depth | mean acc (3 seeds) | range |
|---|---|---|
| 1 | 0.856 | 0.848–0.871 |
| 2 | 0.934 | 0.919–0.943 |
| 4 | 0.983 | 0.982–0.984 |
| 8 | 0.981 | 0.976–0.985 |

- **depth 1→4: +0.127 acc**, no seed overlap (depth-1 best 0.871 < depth-4 worst 0.982).
- Saturates at 4 (4 ≈ 8 here).
- The depth-8 collapse seen at lr 2e-3 was **LR-driven instability, not structural** — recovers fully at lr 1e-3. Fix: depth-aware LR (production peak LR is already 1e-4, so likely a non-issue at scale).

**Caveat:** toy scale (dim 96), one synthetic task family. This shows depth *can* help where it should; it does **not** yet show the gain transfers to fineweb at 79.6M. That's what the gated real run answers.

## What's in here

- `docs/design/plan-a.md` — design doc (motivation, leak-freedom argument, test gates, risks)
- `plan_a_model.py` — `CausalRefiner` (causality verified exactly)
- `ablation_harness.py` — reusable tiny-config harness + depth-sensitive toy tasks
- `tests/test_plan_a.py` — green battery: causality (depths 1/2/4/8), init-loss ~ln(vocab), single-batch overfit, depth-varies-output
- `ablation_results.md` — full run-by-run log (6 runs)
- `docs/findings/2026-06-13-plan-a-depth-recurrence-works.md` — finding (status: preliminary)

## Not in this PR (gated on your go, per docs/AUTONOMY.md)

1. Wire `CausalRefiner` into the production fineweb trainer (different interface from `UniversalReasoner`).
2. Full test battery on that integration.
3. The from-scratch cl100k run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
