### PR TITLE
fix(nnx): migrate deprecated Variable.value access to the indexing API

### DIFF
--- a/grad_step.py
+++ b/grad_step.py
@@ -69,7 +69,7 @@ def compute_grad_step(model, batch_tokens, step, max_steps, doc_boundary=False):
 
     (loss, out), grads = nnx.value_and_grad(loss_fn, has_aux=True)(model)
     
-    current_hunch = model.hunch_cache.value
+    current_hunch = model.hunch_cache[...]
     cleared_hunch = jnp.zeros_like(current_hunch)
     
     # After the step, carry the hunch forward UNLESS a document boundary was hit
@@ -79,7 +79,7 @@ def compute_grad_step(model, batch_tokens, step, max_steps, doc_boundary=False):
         lambda: jax.lax.stop_gradient(current_hunch)
     )
     
-    model.hunch_cache.value = carried_hunch
+    model.hunch_cache[...] = carried_hunch
 
     sq_norms = jax.tree_util.tree_map(lambda x: jnp.sum(jnp.square(x)), grads)
     grad_norm = jnp.sqrt(sum(jax.tree_util.tree_leaves(sq_norms)))

--- a/model.py
+++ b/model.py
@@ -140,7 +140,7 @@ class UniversalReasoner(nnx.Module):
             else:
                 forget_val = jnp.zeros((batch_size,))
 
-            tau = jax.nn.softplus(raw_tau_param.value) + 1e-4
+            tau = jax.nn.softplus(raw_tau_param[...]) + 1e-4
 
             step_div = calculate_slot_stability_loss(new_shared, curr_shared, tau)
 
@@ -172,15 +172,15 @@ class UniversalReasoner(nnx.Module):
 
     def __call__(self, tokens, max_steps=MAX_STEPS_LIMIT, training=False, should_refresh=True):
         batch_size = tokens.shape[0]
-        assert batch_size == self.hunch_cache.value.shape[0], (
+        assert batch_size == self.hunch_cache[...].shape[0], (
             f"Batch size {batch_size} does not match the hunch cache built for batch "
-            f"size {self.hunch_cache.value.shape[0]}; construct UniversalReasoner with "
+            f"size {self.hunch_cache[...].shape[0]}; construct UniversalReasoner with "
             f"batch_size={batch_size}."
         )
 
         z_seq, pad_mask, seq_pos = self._encode_sequence(tokens, training=training)
 
-        z_shared_base = jnp.tile(self.shared_token.value, (batch_size, 1, 1))
+        z_shared_base = jnp.tile(self.shared_token[...], (batch_size, 1, 1))
         
         def get_fresh():
             return z_shared_base
@@ -190,7 +190,7 @@ class UniversalReasoner(nnx.Module):
             # window's content must not enter here: these slots feed the decoder at
             # every position, so conditioning on the window mean (as this once did)
             # leaks future tokens into past predictions.
-            current_hunch = self.hunch_cache.value
+            current_hunch = self.hunch_cache[...]
             gate_in = jnp.concatenate([self.hunch_norm(current_hunch), self.hunch_norm(z_shared_base)], axis=-1)
             gate = jax.nn.sigmoid(self.hunch_gate(gate_in))
             return gate * current_hunch + (1.0 - gate) * z_shared_base
@@ -234,7 +234,7 @@ class UniversalReasoner(nnx.Module):
         # 2026-06-10, see docs/PERFORMANCE_PLAN.md P3). Inputs are rounded to f16
         # but products accumulate in f32, so logits stay f32 for the softmax.
         normed = self.seq_norm(z_seq_out).astype(COMPUTE_DTYPE)
-        embed_t = self.embed.embedding.value.astype(COMPUTE_DTYPE).T
+        embed_t = self.embed.embedding[...].astype(COMPUTE_DTYPE).T
         logits = jnp.matmul(normed, embed_t, preferred_element_type=jnp.float32)
         
         total_f_cost = jnp.mean(jnp.sum(all_outputs.forget_val, axis=0))
@@ -253,11 +253,11 @@ class UniversalReasoner(nnx.Module):
         diag = {
             'temporal_drift': temporal_drift,
             'forget_density': jnp.mean(all_outputs.forget_val),
-            'tau': jax.nn.softplus(self.raw_tau.value) + 1e-4,
+            'tau': jax.nn.softplus(self.raw_tau[...]) + 1e-4,
         }
 
         # Carry the final slot state forward as the next segment's hunch.
-        self.hunch_cache.value = final_shared
+        self.hunch_cache[...] = final_shared
 
         return ReasonerOutput(
             logits=logits,

--- a/plan_a_model.py
+++ b/plan_a_model.py
@@ -149,6 +149,6 @@ class CausalRefiner(nnx.Module):
                 z = z_new
 
         z = self.out_norm(z)
-        embed_t = self.embed.embedding.value.astype(self.dtype).T
+        embed_t = self.embed.embedding[...].astype(self.dtype).T
         logits = jnp.matmul(z.astype(self.dtype), embed_t, preferred_element_type=jnp.float32)
         return logits

--- a/plan_a_trainer.py
+++ b/plan_a_trainer.py
@@ -14,7 +14,7 @@ machinery the trainer threads through degrades to honest no-ops:
   - the two training windows are independent (no carried state), so should_refresh
     is ignored — each window is a standalone causal LM prediction;
   - hunch_cache is a vestigial zero buffer, never read in the forward, kept only so
-    the trainer's `model.hunch_cache.value` bookkeeping writes stay valid.
+    the trainer's `model.hunch_cache[...]` bookkeeping writes stay valid.
 `max_steps` maps to the refinement depth (sampled per step in training, fixed at
 inference) — the one dial Plan A actually uses.
 """

--- a/tests/test_plan_a_integration.py
+++ b/tests/test_plan_a_integration.py
@@ -49,7 +49,7 @@ def test_adapter_interface_and_zero_regularizers():
     assert float(out.forget_cost) == 0.0
     assert float(out.diversity_loss) == 0.0
     # Vestigial buffer exists for the trainer's bookkeeping writes.
-    assert m.hunch_cache.value.shape == (1, 1, DIM)
+    assert m.hunch_cache[...].shape == (1, 1, DIM)
 
 
 def test_grad_step_runs_and_reduces_loss():

--- a/tests/test_validation_probe.py
+++ b/tests/test_validation_probe.py
@@ -21,14 +21,14 @@ def test_validation_probe_scores_and_preserves_training_state(tiny_model, monkey
     monkeypatch.setattr(trainer, "VAL_BATCHES", 1)
 
     probe = trainer.ValidationProbe()
-    sentinel = jnp.ones_like(tiny_model.hunch_cache.value) * 0.123
-    tiny_model.hunch_cache.value = sentinel
+    sentinel = jnp.ones_like(tiny_model.hunch_cache[...]) * 0.123
+    tiny_model.hunch_cache[...] = sentinel
 
     val_ce = probe.run(tiny_model)
 
     assert val_ce is not None and np.isfinite(val_ce), f"validation CE not finite: {val_ce}"
     assert 0.0 < val_ce < 20.0, f"validation CE out of any plausible range: {val_ce}"
     np.testing.assert_array_equal(
-        np.asarray(tiny_model.hunch_cache.value), np.asarray(sentinel),
+        np.asarray(tiny_model.hunch_cache[...]), np.asarray(sentinel),
         err_msg="validation perturbed the training stream's carried hunch",
     )

--- a/tools/eval_depth_curve.py
+++ b/tools/eval_depth_curve.py
@@ -77,7 +77,7 @@ def main():
         window1 = batch[:, :MAX_SEQ_LEN]
         hard_mask = None
         for cond in conditions:
-            model.hunch_cache.value = jnp.zeros_like(model.hunch_cache.value)
+            model.hunch_cache[...] = jnp.zeros_like(model.hunch_cache[...])
             if cond == "fresh":
                 token_ce, mask = score_window2(model, batch, use_hunch=False)
             else:

--- a/trainer.py
+++ b/trainer.py
@@ -111,14 +111,14 @@ class ValidationProbe:
             self._batches = self._load()
         if not self._batches:
             return None
-        saved_hunch = model.hunch_cache.value
+        saved_hunch = model.hunch_cache[...]
         total, count = 0.0, 0
         for batch in self._batches:
-            model.hunch_cache.value = jnp.zeros_like(saved_hunch)
+            model.hunch_cache[...] = jnp.zeros_like(saved_hunch)
             ce_sum, ce_count = _val_ce_sums(model, batch)
             total += float(ce_sum)
             count += int(ce_count)
-        model.hunch_cache.value = saved_hunch
+        model.hunch_cache[...] = saved_hunch
         return total / max(count, 1)
 
 
@@ -297,7 +297,7 @@ def train_loop(model, optimizer, data_queue, mngr, best_mngr, monitor, start_ste
                     f"⚠️ Non-finite loss/grad at micro-step {step} "
                     f"(loss={current_loss}, grad_norm={current_grad_norm}, streak={nonfinite_streak}) — skipping update."
                 )
-                model.hunch_cache.value = jnp.zeros_like(model.hunch_cache.value)
+                model.hunch_cache[...] = jnp.zeros_like(model.hunch_cache[...])
                 if nonfinite_streak >= MAX_NONFINITE_STREAK:
                     raise RuntimeError(
                         f"Training diverged: {MAX_NONFINITE_STREAK} consecutive non-finite micro-steps "


### PR DESCRIPTION
## Summary
Migrates every deprecated `Variable.value` read/write to the Flax 0.12 indexing API (`variable[...]` / `variable[...] = x`). Behavior-neutral hygiene; no issue per the maintainer's direct request.

## What & why
Flax 0.12.3 deprecates `.value` on `nnx.Variable`/`nnx.Param` — the pinned version already emits `DeprecationWarning` walls in every test run, and the access pattern breaks on the next unpin. All 21 sites are migrated: `hunch_cache`, `shared_token`, `raw_tau`, and the tied-embedding reads across `model.py`, `grad_step.py`, `trainer.py`, `plan_a_model.py`, `tools/eval_depth_curve.py`, and the tests. `nnx.value_and_grad` is a different, non-deprecated API and is untouched.

## Validation / smoke-test performed
- [x] `JAX_PLATFORMS=cpu pytest tests/ -q` passes locally
- Other checks run:
  - Full suite also passes with `-W error::DeprecationWarning` — the migration removes every Flax deprecation warning rather than silencing it.
  - `grep -rn "\.value"` over `*.py` confirms zero remaining Variable `.value` accesses (only `nnx.value_and_grad` and dict `.values()` remain).

## Risk
None expected: `variable[...]` is the same read/write path `.value` proxied to, verified warning-free on the pinned Flax 0.12.3. The step-determinism and golden-run tests pass, so the traced computation is unchanged. No checkpoint-format, VRAM, or data-path impact; pinned deps untouched.

## Checklist
- [x] Did not weaken or delete any test (no skips/xfails/loosened asserts to make it pass)
- [x] Smoke-tested; no multi-hour run was launched without sign-off
- [x] Pinned deps unchanged, or the bump is justified above
- [x] Findings/claims backed by evidence in the PR or a linked finding issue

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HjZBFh2K2krkZJmFaxh6V2

---
_Generated by [Claude Code](https://claude.ai/code/session_01HjZBFh2K2krkZJmFaxh6V2)_