### PR TITLE
refactor: share RoPE tables and rotation via a single rope.py

### DIFF
--- a/layers.py
+++ b/layers.py
@@ -5,6 +5,7 @@ from flax import nnx, struct
 from typing import Dict, Any
 
 from config import MAX_SEQ_LEN, MAX_STEPS_LIMIT, SHARED_SLOTS, NUM_GROUPS, COMPUTE_DTYPE
+from rope import rope_tables, apply_rope
 
 @struct.dataclass
 class ScanStepOutput:
@@ -20,28 +21,17 @@ class ReasonerOutput:
     diag: Dict[str, Any]
     final_shared: jnp.ndarray
 
-def apply_rope(x, cos, sin):
-    x1, x2 = jnp.split(x, 2, axis=-1)
-    
-    x_complex = jax.lax.complex(x1, x2)
-    rope_complex = jax.lax.complex(cos, sin)
-    rotated = x_complex * rope_complex
-    
-    return jnp.concatenate([rotated.real, rotated.imag], axis=-1).astype(x.dtype)
-
 class RotaryAttention(nnx.Module):
     def __init__(self, num_heads, in_features, num_groups=4, rngs=None):
         self.num_heads = num_heads
         self.num_groups = num_groups
         self.head_dim = in_features // num_heads
 
-        inv_freq = 1.0 / (10000 ** (jnp.arange(0, self.head_dim, 2) / self.head_dim))
         # Extended to cover MAX_SEQ_LEN + MAX_STEPS_LIMIT * SHARED_SLOTS positions
         # so that slot query positions can advance with each reasoning iteration
-        t = jnp.arange(MAX_SEQ_LEN + MAX_STEPS_LIMIT * SHARED_SLOTS)
-        freqs = jnp.outer(t, inv_freq)
-        self.sin_cached = jnp.sin(freqs)
-        self.cos_cached = jnp.cos(freqs)
+        self.cos_cached, self.sin_cached = rope_tables(
+            MAX_SEQ_LEN + MAX_STEPS_LIMIT * SHARED_SLOTS, self.head_dim
+        )
 
         self.q_proj = nnx.Linear(in_features, in_features, rngs=rngs, dtype=COMPUTE_DTYPE)
         self.k_proj = nnx.Linear(in_features, self.num_groups * self.head_dim, rngs=rngs, dtype=COMPUTE_DTYPE)

--- a/plan_a_model.py
+++ b/plan_a_model.py
@@ -6,7 +6,7 @@ only to positions <= t on every iteration, so depth refines the prediction with 
 future-token leak (contrast docs/findings/2026-06-13-cross-window-hunch-inert.md,
 where the loop could only reach the next window and the gradient killed it).
 
-Self-contained and fully parametrized (dim, vocab, heads, depth, seq) so the exact
+Config-free and fully parametrized (dim, vocab, heads, depth, seq) so the exact
 same architecture runs at tiny toy-task scale and at real scale — the ablation
 harness tests the thing we'd ship, not a stand-in. See docs/design/plan-a.md.
 """
@@ -15,17 +15,7 @@ import jax
 import jax.numpy as jnp
 from flax import nnx
 
-
-def _rope_tables(max_pos, head_dim):
-    inv_freq = 1.0 / (10000 ** (jnp.arange(0, head_dim, 2) / head_dim))
-    freqs = jnp.outer(jnp.arange(max_pos), inv_freq)
-    return jnp.cos(freqs), jnp.sin(freqs)
-
-
-def apply_rope(x, cos, sin):
-    x1, x2 = jnp.split(x, 2, axis=-1)
-    rotated = jax.lax.complex(x1, x2) * jax.lax.complex(cos, sin)
-    return jnp.concatenate([rotated.real, rotated.imag], axis=-1).astype(x.dtype)
+from rope import rope_tables, apply_rope
 
 
 class CausalAttention(nnx.Module):
@@ -42,7 +32,7 @@ class CausalAttention(nnx.Module):
         self.o = nnx.Linear(dim, dim, rngs=rngs, dtype=dtype)
         self.q_norm = nnx.RMSNorm(self.head_dim, epsilon=1e-6, rngs=rngs, dtype=jnp.float32)
         self.k_norm = nnx.RMSNorm(self.head_dim, epsilon=1e-6, rngs=rngs, dtype=jnp.float32)
-        cos, sin = _rope_tables(max_pos, self.head_dim)
+        cos, sin = rope_tables(max_pos, self.head_dim)
         self.cos, self.sin = cos, sin
 
     def __call__(self, x, pad_bias=None):

--- a/rope.py
+++ b/rope.py
@@ -1,0 +1,24 @@
+"""Rotary position embedding (RoPE) — the single copy both architectures share.
+
+The rotation and the cos/sin table construction used to live twice, in
+layers.py (RotaryAttention) and plan_a_model.py, with identical math.
+Deliberately config-free: plan_a_model stays fully parametrized so the exact
+same architecture runs at toy scale and at real scale.
+"""
+
+import jax
+import jax.numpy as jnp
+
+
+def rope_tables(max_pos, head_dim):
+    """cos/sin tables for positions [0, max_pos), each [max_pos, head_dim // 2]."""
+    inv_freq = 1.0 / (10000 ** (jnp.arange(0, head_dim, 2) / head_dim))
+    freqs = jnp.outer(jnp.arange(max_pos), inv_freq)
+    return jnp.cos(freqs), jnp.sin(freqs)
+
+
+def apply_rope(x, cos, sin):
+    """Rotate feature pairs of x by position (split-half convention)."""
+    x1, x2 = jnp.split(x, 2, axis=-1)
+    rotated = jax.lax.complex(x1, x2) * jax.lax.complex(cos, sin)
+    return jnp.concatenate([rotated.real, rotated.imag], axis=-1).astype(x.dtype)


### PR DESCRIPTION
## Summary
Deduplicates the RoPE math: `apply_rope` and the cos/sin table construction existed twice with identical math (in `layers.py` and `plan_a_model.py`); both now import one config-free `rope.py`. No issue per the maintainer's direct request.

## What & why
Two copies of the rotation and table construction meant two things to keep in sync across the live arch and the control baseline. `rope.py` is deliberately config-free so `plan_a_model.py` stays fully parametrized (the same code runs at toy and real scale — its docstring is updated from "self-contained" to "config-free" to stay honest).

Scope note: the attention/Block classes are **not** merged. They differ for real reasons (GQA + cross-attention + custom positions in `RotaryAttention` vs. simple causal MHA in `CausalAttention`; different SwiGLU hidden-dim rounding), and unifying them would change param trees and break checkpoint compatibility. Only the genuinely identical math moved.

## Validation / smoke-test performed
- [x] `JAX_PLATFORMS=cpu pytest tests/ -q` passes locally
- Other checks run:
  - `tests/test_attention_numerics.py` (imports `apply_rope` via `layers` — still resolves through the re-export) and the golden-run determinism test pass, confirming the numerics are bit-identical.

## Risk
Numerics: the moved code is character-for-character the same math (`layers.py`'s version was a more verbose spelling of the identical expression); golden-run passing rules out drift. No param-tree change, so checkpoints load unchanged. No VRAM, data-path, or dependency impact.

## Checklist
- [x] Did not weaken or delete any test (no skips/xfails/loosened asserts to make it pass)
- [x] Smoke-tested; no multi-hour run was launched without sign-off
- [x] Pinned deps unchanged, or the bump is justified above
- [x] Findings/claims backed by evidence in the PR or a linked finding issue

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HjZBFh2K2krkZJmFaxh6V2

---
_Generated by [Claude Code](https://claude.ai/code/session_01HjZBFh2K2krkZJmFaxh6V2)_