### PR TITLE
feat(review): code-review subagent gate — adversarial verdict before merge (#46)

### DIFF
--- a/.claude/agents/code-reviewer.md
+++ b/.claude/agents/code-reviewer.md
@@ -1,0 +1,54 @@
+---
+name: code-reviewer
+description: Standing adversarial reviewer for the unattended loop (#46). Reviews the current branch diff against main with fresh context and emits a structured verdict — block / comment / pass. Invoke before any self-merge; a "block" verdict must stop the merge.
+tools: Bash, Read, Grep, Glob
+---
+
+You are this repository's standing code reviewer — the second opinion that replaces
+the human reviewer in fully-unattended mode. Your one job: read the current branch's
+diff against main with fresh, skeptical eyes and decide whether it may merge. The
+failure you exist to catch is the confidently-wrong change that passes its author's
+own eye.
+
+## How to review
+
+1. Get the diff: `git fetch origin main -q && git diff origin/main...HEAD`. If the
+   diff is empty, the verdict is `pass` (nothing to review).
+2. Read `CLAUDE.md` first — the working agreement defines what correctness means
+   here (matched-pair ablations, pre-registered criteria, the noise floor, f16
+   policy, checkpoint compatibility).
+3. Read every changed file in full, not just the hunks. Then read the callers and
+   tests of what changed.
+4. Hunt in priority order:
+   - **Correctness bugs** — wrong math, broken causality/no-leak invariants, dtype
+     regressions (f16 policy), shape errors, checkpoint/param-tree breakage,
+     off-by-one in data or schedule code.
+   - **Weakened guardrails** — deleted/skipped/xfailed tests, loosened asserts,
+     golden files re-recorded without a stated reason.
+   - **Unsupported claims** — a PR/commit message asserting something ("memory-
+     bounded", "math-identical", "faster") the diff does not actually evidence.
+   - **Reuse/simplification** — duplicated logic, dead code, needless complexity.
+     These are findings, never blockers.
+5. Be adversarial: for each claim the change makes, try to construct the input or
+   state that breaks it. A finding you cannot make concrete (file, line, failure
+   scenario) is a `comment`, not a `block`.
+
+## Verdict contract
+
+End your final message with EXACTLY this structure (the gate parses it):
+
+```
+VERDICT: block | comment | pass
+FINDINGS:
+- <file>:<line> — <one-sentence defect> — <concrete failure scenario> [severity: high|medium|low]
+```
+
+- `block` — at least one confirmed high-severity finding: a correctness bug, a
+  weakened test, or a claim the code contradicts. Merging would make main worse.
+- `comment` — real but non-blocking findings (cleanups, style, uncertain issues).
+  Merge may proceed; findings should be posted for the record.
+- `pass` — no findings survived your attempt to confirm them. Say so plainly.
+
+Do not soften a block to be polite, and do not block on taste — the bar is "would
+this defect corrupt a result, a checkpoint, or the training loop", not "would I
+have written it differently".

--- a/.github/workflows/review-gate.yml
+++ b/.github/workflows/review-gate.yml
@@ -1,0 +1,68 @@
+name: Review Gate
+
+# The code-review subagent as a merge gate (#46): an adversarial second opinion
+# with fresh context, in place of the human reviewer the unattended loop no
+# longer waits on. Runs the .claude/agents/code-reviewer.md review over the PR
+# diff and fails the check on a "block" verdict.
+#
+# Requires the ANTHROPIC_API_KEY repository secret. When the secret is absent
+# (forks, or not yet configured) the job skips gracefully and reports neutral —
+# the pytest CI job remains the hard gate either way.
+
+on:
+  pull_request:
+    branches: [main]
+
+jobs:
+  review:
+    name: code-reviewer verdict
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    env:
+      ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+    steps:
+      - name: Check reviewer credentials
+        id: key
+        run: |
+          if [ -n "$ANTHROPIC_API_KEY" ]; then
+            echo "present=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "present=false" >> "$GITHUB_OUTPUT"
+            echo "::notice::ANTHROPIC_API_KEY secret not configured — review gate skipped."
+          fi
+
+      - uses: actions/checkout@v4
+        if: steps.key.outputs.present == 'true'
+        with:
+          # Full history so the reviewer can diff against origin/main.
+          fetch-depth: 0
+
+      - name: Run the code-reviewer subagent
+        if: steps.key.outputs.present == 'true'
+        uses: anthropics/claude-code-action@v1
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          prompt: |
+            Read .claude/agents/code-reviewer.md and perform exactly the review it
+            describes over this PR's diff against origin/main, honoring its verdict
+            contract. When finished, write the verdict to the file review-verdict.json
+            in the repository root with this exact JSON shape:
+            {"verdict": "block" | "comment" | "pass", "findings": ["<file>:<line> — <finding> [severity: ...]", ...]}
+
+      - name: Enforce verdict
+        if: steps.key.outputs.present == 'true'
+        run: |
+          if [ ! -f review-verdict.json ]; then
+            echo "::error::Reviewer produced no verdict file — failing closed."
+            exit 1
+          fi
+          echo "--- review-verdict.json ---"
+          cat review-verdict.json
+          verdict=$(python3 -c "import json; print(json.load(open('review-verdict.json'))['verdict'])")
+          case "$verdict" in
+            pass)    echo "Reviewer verdict: pass" ;;
+            comment) echo "::warning::Reviewer verdict: comment — non-blocking findings above." ;;
+            block)   echo "::error::Reviewer verdict: BLOCK — see findings above."; exit 1 ;;
+            *)       echo "::error::Unrecognized verdict '$verdict' — failing closed."; exit 1 ;;
+          esac


### PR DESCRIPTION
## Summary
The standing second opinion for the unattended loop: a project subagent that adversarially reviews the branch diff against main and emits a structured verdict (block / comment / pass), plus a Review Gate workflow that runs it on every PR and fails the check on "block". Closes #46.

## What & why
In fully-unattended mode the loop opens and merges its own PRs, removing the catch for the doctrine's most-feared failure — the confidently-wrong change that passes its author's own eye. Two pieces:

- **`.claude/agents/code-reviewer.md`** — the reviewer: fresh context, reads CLAUDE.md first (so "correct" means this repo's invariants: no-leak causality, f16 policy, checkpoint compat, un-weakened tests), hunts correctness bugs / weakened guardrails / unsupported claims, and ends with a parseable `VERDICT:` block. Blocks only on confirmed high-severity findings — cleanups are comments, never blockers.
- **`.github/workflows/review-gate.yml`** — the gate: runs the subagent via `anthropics/claude-code-action@v1` on every PR to main, parses `review-verdict.json`, and fails on `block` (also fails closed on a missing or unrecognized verdict). When the `ANTHROPIC_API_KEY` secret is absent the job skips gracefully with a notice — the pytest CI job remains the hard gate.

**Action needed after merge:** add the `ANTHROPIC_API_KEY` repository secret (Settings → Secrets and variables → Actions) to arm the gate. Making it a *required* check is #45's branch-protection step.

## Validation / smoke-test performed
- [x] `JAX_PLATFORMS=cpu pytest tests/ -q` passes locally (no Python code touched)
- Other checks run — the issue's definition of done:
  - **Planted-bug test:** flipped the causal mask (`>=` → `<=` in `plan_a_model.py` — a future-token leak, this repo's most-feared defect class) and buried it inside a ~100-line feature diff under a misleading "perf: simplify" commit message. The reviewer returned **VERDICT: block**, cited `test_causality_no_future_leak` failing at all depths (~0.68 leak vs 1e-5 bound), flagged the commit message as claiming a change the diff doesn't evidence, and correctly reasoned the new probe in the same diff would be blind to the flip. The planted branch was local-only and has been deleted.

## Risk
No Python or training-path changes — the diff is a markdown agent definition and a workflow. Worst case with the secret configured: an API outage fails the gate closed, blocking merges until re-run; without the secret the gate is inert. No numerics, VRAM, checkpoint, or data-path impact; pinned deps unchanged.

## Checklist
- [x] Did not weaken or delete any test (no skips/xfails/loosened asserts to make it pass)
- [x] Smoke-tested; no multi-hour run was launched without sign-off
- [x] Pinned deps unchanged, or the bump is justified above
- [x] Findings/claims backed by evidence in the PR or a linked finding issue

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HjZBFh2K2krkZJmFaxh6V2

---
_Generated by [Claude Code](https://claude.ai/code/session_01HjZBFh2K2krkZJmFaxh6V2)_