### PR TITLE
ci: promote load-bearing checks to named required jobs (#45)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,17 @@ on:
   pull_request:
     branches: [main]
 
+# Three named jobs so each load-bearing check is a separately visible (and
+# separately requireable) status (#45):
+#   pytest (CPU)        — the broad unit/invariant suite
+#   golden-run (CPU)    — the opt-in exact-trajectory regression, forced on here
+#                         so silent numeric drift can't go unnoticed (the
+#                         committed golden went stale once already, pre-#50)
+#   overfit smoke (CPU) — end-to-end training-path smoke at tiny scale: the
+#                         real grad step must collapse CE on one batch
+# CPU-only throughout (FORCE_F32_COMPUTE via tests/conftest.py or explicit env)
+# so CI runs while the GPU trains; the real f16 path stays RUN_TESTS_ON_GPU=1.
+
 jobs:
   test:
     name: pytest (CPU)
@@ -33,3 +44,57 @@ jobs:
 
       - name: Run tests
         run: pytest tests/ -q
+
+  golden:
+    name: golden-run (CPU)
+    runs-on: ubuntu-latest
+    env:
+      JAX_PLATFORMS: cpu
+      RUN_GOLDEN: "1"
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.14"
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install "jax==0.9.1"
+          grep -v '^jax\[cuda12\]' requirements.txt | pip install -r /dev/stdin
+
+      - name: Golden trajectory + reference numerics + determinism
+        # The exact-loss-trajectory regression (opt-in locally, mandatory here),
+        # plus the two test classes that catch silent numeric drift: the
+        # reference-numerics suite (caught the double-applied attention scaling)
+        # and step determinism (what makes golden comparisons meaningful at all).
+        run: pytest tests/test_golden_run.py tests/test_attention_numerics.py tests/test_step_determinism.py -q
+
+  smoke:
+    name: overfit smoke (CPU)
+    runs-on: ubuntu-latest
+    env:
+      JAX_PLATFORMS: cpu
+      FORCE_F32_COMPUTE: "1"
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.14"
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install "jax==0.9.1"
+          grep -v '^jax\[cuda12\]' requirements.txt | pip install -r /dev/stdin
+
+      - name: Overfit one synthetic batch (tiny config)
+        # The real grad step must drive CE down on a single fixed batch — wrong
+        # labels, target off-by-ones, broken gradient flow, and dead loss terms
+        # fail here in minutes. Tiny dim/blocks so it's CPU-fast; the full-scale
+        # variant stays a pre-launch GPU check (tools/overfit_smoke.py defaults).
+        run: PYTHONPATH=. python tools/overfit_smoke.py --synthetic --dim 64 --blocks 2 --steps 80

--- a/tools/overfit_smoke.py
+++ b/tools/overfit_smoke.py
@@ -8,6 +8,13 @@ dead loss components all fail this in minutes instead of an overnight run.
 Run it on a free GPU before launching any training run after an architecture
 change:
     PYTHONPATH=. python tools/overfit_smoke.py [--steps 120] [--lr 1e-3]
+
+CI / no-corpus mode (#45): --synthetic overfits a fixed random batch instead of
+DATA_ROOT, and --dim/--blocks shrink the model so the whole thing runs in CPU
+minutes. Wrong labels, target off-by-ones, broken gradient flow, and dead loss
+components fail at tiny scale exactly as they would at full scale:
+    FORCE_F32_COMPUTE=1 JAX_PLATFORMS=cpu PYTHONPATH=. \
+        python tools/overfit_smoke.py --synthetic --dim 64 --blocks 2 --steps 80
 """
 
 import os
@@ -16,17 +23,17 @@ os.environ.setdefault("XLA_PYTHON_CLIENT_MEM_FRACTION", "0.7")
 
 import argparse
 
+import jax.numpy as jnp
+import numpy as np
 import optax
 from flax import nnx
 from dotenv import load_dotenv
 
-from config import LATENT_DIM
+from config import LATENT_DIM, MAX_SEQ_LEN, NUM_BLOCKS
 from model import UniversalReasoner
 from grad_step import compute_grad_step, apply_grads
 
 load_dotenv()
-
-from tools.common import load_eval_batches
 
 
 def main():
@@ -34,15 +41,26 @@ def main():
     parser.add_argument("--steps", type=int, default=120)
     parser.add_argument("--lr", type=float, default=1e-3)
     parser.add_argument("--depth", type=int, default=2, help="fixed reasoning depth (one compile)")
+    parser.add_argument("--synthetic", action="store_true",
+                        help="fixed random token batch instead of DATA_ROOT (CI / no-corpus mode)")
+    parser.add_argument("--dim", type=int, default=LATENT_DIM,
+                        help="model width (shrink for CPU CI; must divide NUM_HEADS)")
+    parser.add_argument("--blocks", type=int, default=NUM_BLOCKS,
+                        help="number of blocks (shrink for CPU CI; must be even)")
     args = parser.parse_args()
 
-    model = UniversalReasoner(LATENT_DIM, nnx.Rngs(0))
+    model = UniversalReasoner(args.dim, nnx.Rngs(0), num_blocks=args.blocks)
     optimizer = nnx.Optimizer(
         model,
         optax.chain(optax.clip_by_global_norm(1.0), optax.adamw(args.lr)),
         wrt=nnx.Param,
     )
-    batch = load_eval_batches(num_batches=1, skip=0)[0]
+    if args.synthetic:
+        rng = np.random.default_rng(21)
+        batch = jnp.asarray(rng.integers(1, 5000, size=(1, 2 * MAX_SEQ_LEN + 1)), dtype=jnp.int32)
+    else:
+        from tools.common import load_eval_batches
+        batch = load_eval_batches(num_batches=1, skip=0)[0]
 
     initial_ce = None
     final_ce = None


### PR DESCRIPTION
## Summary
Hardens CI toward the self-merge guardrail: the single pytest job becomes three named, separately-requireable checks — the broad suite, the golden-run/numerics/determinism drift net (now mandatory in CI), and a tiny CPU overfit smoke of the real training path. Closes #45.

## What & why
Three jobs in `ci.yml`, each a distinct status a branch-protection rule can require:

- **`pytest (CPU)`** — the broad unit/invariant suite, unchanged.
- **`golden-run (CPU)`** — `RUN_GOLDEN=1` forces the exact-loss-trajectory regression that is opt-in locally. This is the direct fix for the failure PR #50 uncovered: the committed golden had gone stale unnoticed because nothing ran it. Bundled with the reference-numerics tests (the class that caught the double-applied attention scaling) and step-determinism (what makes golden comparisons meaningful at all).
- **`overfit smoke (CPU)`** — end-to-end training-path smoke: the real `compute_grad_step` must collapse CE on one fixed batch. `tools/overfit_smoke.py` gains `--synthetic` (fixed random batch, no `DATA_ROOT`) and `--dim`/`--blocks` (tiny config) so it runs in CPU minutes; the full-scale defaults are untouched for the pre-launch GPU check. Wrong labels, target off-by-ones, broken gradient flow, and dead loss terms fail at tiny scale exactly as at full scale.

CPU stays the default everywhere (`RUN_TESTS_ON_GPU=1` remains the opt-in f16 path), so CI runs while the GPU trains.

**Branch protection — the one step that needs repo admin (Settings → Branches → Add rule for `main`):**
- ✅ Require status checks to pass before merging, with these checks: `pytest (CPU)`, `golden-run (CPU)`, `overfit smoke (CPU)`, and — once #46's secret is armed — `code-reviewer verdict`
- ✅ Require branches to be up to date before merging
- (No API for this in my toolset, so it's a one-time click for you; everything else in this PR is live on merge.)

## Validation / smoke-test performed
- [x] `JAX_PLATFORMS=cpu pytest tests/ -q` passes locally
- Other checks run:
  - The exact new CI commands, locally: golden job green (4 passed); tiny overfit smoke **PASS** — CE 11.40 → 2.53 in 80 steps, ~1m43s wall on CPU.
  - This PR's own checks will demonstrate all three jobs running.

## Risk
`overfit_smoke.py` changes are flag-gated additions — default behavior (full dim, `DATA_ROOT` batch) is byte-for-byte the old path. CI-only otherwise: no model, trainer, data, or checkpoint code touched. Worst case is CI wall-clock (+~8 min for the two new jobs, parallel with the suite).

## Checklist
- [x] Did not weaken or delete any test (no skips/xfails/loosened asserts to make it pass — one opt-in test became mandatory in CI)
- [x] Smoke-tested; no multi-hour run was launched without sign-off
- [x] Pinned deps unchanged, or the bump is justified above
- [x] Findings/claims backed by evidence in the PR or a linked finding issue

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HjZBFh2K2krkZJmFaxh6V2

---
_Generated by [Claude Code](https://claude.ai/code/session_01HjZBFh2K2krkZJmFaxh6V2)_