### PR TITLE
ci(review-gate): accept a Claude subscription token, not just an API key

### DIFF
--- a/.github/workflows/review-gate.yml
+++ b/.github/workflows/review-gate.yml
@@ -5,9 +5,12 @@ name: Review Gate
 # longer waits on. Runs the .claude/agents/code-reviewer.md review over the PR
 # diff and fails the check on a "block" verdict.
 #
-# Requires the ANTHROPIC_API_KEY repository secret. When the secret is absent
-# (forks, or not yet configured) the job skips gracefully and reports neutral —
-# the pytest CI job remains the hard gate either way.
+# Credentials: the CLAUDE_CODE_OAUTH_TOKEN repository secret (from a Claude
+# Pro/Max subscription — run `claude setup-token` locally and paste the result
+# into Settings → Secrets → Actions). An ANTHROPIC_API_KEY secret also works
+# as the pay-per-token alternative; the OAuth token wins when both exist.
+# When neither secret is set (forks, or not yet configured) the job skips
+# gracefully — the pytest CI job remains the hard gate either way.
 
 on:
   pull_request:
@@ -20,26 +23,41 @@ jobs:
     permissions:
       contents: read
     env:
+      CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
       ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
     steps:
       - name: Check reviewer credentials
         id: key
         run: |
-          if [ -n "$ANTHROPIC_API_KEY" ]; then
-            echo "present=true" >> "$GITHUB_OUTPUT"
+          if [ -n "$CLAUDE_CODE_OAUTH_TOKEN" ]; then
+            echo "cred=oauth" >> "$GITHUB_OUTPUT"
+          elif [ -n "$ANTHROPIC_API_KEY" ]; then
+            echo "cred=apikey" >> "$GITHUB_OUTPUT"
           else
-            echo "present=false" >> "$GITHUB_OUTPUT"
-            echo "::notice::ANTHROPIC_API_KEY secret not configured — review gate skipped."
+            echo "cred=none" >> "$GITHUB_OUTPUT"
+            echo "::notice::No CLAUDE_CODE_OAUTH_TOKEN or ANTHROPIC_API_KEY secret — review gate skipped."
           fi
 
       - uses: actions/checkout@v4
-        if: steps.key.outputs.present == 'true'
+        if: steps.key.outputs.cred != 'none'
         with:
           # Full history so the reviewer can diff against origin/main.
           fetch-depth: 0
 
-      - name: Run the code-reviewer subagent
-        if: steps.key.outputs.present == 'true'
+      - name: Run the code-reviewer subagent (subscription token)
+        if: steps.key.outputs.cred == 'oauth'
+        uses: anthropics/claude-code-action@v1
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          prompt: |
+            Read .claude/agents/code-reviewer.md and perform exactly the review it
+            describes over this PR's diff against origin/main, honoring its verdict
+            contract. When finished, write the verdict to the file review-verdict.json
+            in the repository root with this exact JSON shape:
+            {"verdict": "block" | "comment" | "pass", "findings": ["<file>:<line> — <finding> [severity: ...]", ...]}
+
+      - name: Run the code-reviewer subagent (API key)
+        if: steps.key.outputs.cred == 'apikey'
         uses: anthropics/claude-code-action@v1
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
@@ -51,7 +69,7 @@ jobs:
             {"verdict": "block" | "comment" | "pass", "findings": ["<file>:<line> — <finding> [severity: ...]", ...]}
 
       - name: Enforce verdict
-        if: steps.key.outputs.present == 'true'
+        if: steps.key.outputs.cred != 'none'
         run: |
           if [ ! -f review-verdict.json ]; then
             echo "::error::Reviewer produced no verdict file — failing closed."


### PR DESCRIPTION
## Summary
The review gate (#46) can now authenticate with a Claude Pro/Max subscription token (`CLAUDE_CODE_OAUTH_TOKEN`) instead of a pay-per-token API key — reviews draw from the subscription's limits. Follow-up to PR #54 per maintainer request.

## What & why
The credential check becomes three-way: subscription token (preferred) → API key → skip gracefully. Two mutually-exclusive action steps pass the matching credential input to `claude-code-action@v1`; the verdict enforcement is unchanged.

**To arm the gate:** run `claude setup-token` on your machine (it prints a long-lived token minted from your Max login), then add it as a repository secret named `CLAUDE_CODE_OAUTH_TOKEN` (Settings → Secrets and variables → Actions → New repository secret). No API key or billing setup needed.

## Validation / smoke-test performed
- [x] `JAX_PLATFORMS=cpu pytest tests/ -q` — no Python touched (workflow-only diff); this PR's own checks exercise the skip path (no secret configured yet).

## Risk
Workflow-only. With no secret the behavior is identical to today (skip + notice). No training-path, numerics, or dependency impact.

## Checklist
- [x] Did not weaken or delete any test (no skips/xfails/loosened asserts to make it pass)
- [x] Smoke-tested; no multi-hour run was launched without sign-off
- [x] Pinned deps unchanged, or the bump is justified above
- [x] Findings/claims backed by evidence in the PR or a linked finding issue

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HjZBFh2K2krkZJmFaxh6V2

---
_Generated by [Claude Code](https://claude.ai/code/session_01HjZBFh2K2krkZJmFaxh6V2)_