### PR TITLE
feat(harness): memorization probe + matched-compute vanilla arm (#34)

### DIFF
--- a/ablation_harness.py
+++ b/ablation_harness.py
@@ -139,16 +139,9 @@ VOCAB = {"parity": 2, "cumsum5": 5, "statetrack": 5}
 # `memorize` is built per-run (vocab = --mem-pairs), see main().
 
 
-def _masked_acc_ce(logits, tgt, mask):
-    pred = logits.argmax(-1)
-    acc = jnp.sum((pred == tgt) * mask) / jnp.sum(mask)
-    ce = jnp.sum(optax.softmax_cross_entropy_with_integer_labels(logits=logits, labels=tgt) * mask) / jnp.sum(mask)
-    return acc, ce
-
-
 def train_one(task_fn, vocab, depth, *, arch="refiner", dim=96, heads=4, enc=2, steps=2500,
               batch=256, lr=2e-3, wd=0.01, seed=0, gate_bias=0.0, n_pool=32768, n_test=4096,
-              train_seq=SEQ, test_seq=None):
+              eval_batch=256, train_seq=SEQ, test_seq=None):
     # When test_seq > train_seq this is a length-generalization probe: the model
     # trains on length train_seq and is evaluated on longer sequences, so it must
     # use RoPE positions it never saw in training. test_seq=None -> same length.
@@ -188,15 +181,27 @@ def train_one(task_fn, vocab, depth, *, arch="refiner", dim=96, heads=4, enc=2, 
         return loss
 
     @nnx.jit(static_argnames=["depth"])
-    def eval_step(model, inp, tgt, mask, depth):
-        return _masked_acc_ce(model(inp, depth=depth), tgt, mask)
+    def eval_chunk_sums(model, inp, tgt, mask, depth):
+        logits = model(inp, depth=depth)
+        pred = logits.argmax(-1)
+        acc_sum = jnp.sum((pred == tgt) * mask)
+        ce_sum = jnp.sum(optax.softmax_cross_entropy_with_integer_labels(logits=logits, labels=tgt) * mask)
+        return acc_sum, ce_sum, jnp.sum(mask)
 
     for _ in range(steps):
         key, k = jax.random.split(key)
         step(model, opt, k, tr_inp, tr_tgt, tr_mask, depth)
 
-    acc, ce = eval_step(model, te_inp, te_tgt, te_mask, depth)
-    return float(acc), float(ce), n_params
+    # Eval in fixed-size chunks: a full-pool eval materializes [n_test, seq, vocab]
+    # f32 logits, which OOMs at large --mem-pairs (6.4 GB at N=16384 — already past
+    # the 6 GB card; 51 GB at N=65536). Keep n_test a multiple of eval_batch or
+    # the ragged last chunk pays one extra compile.
+    acc_sum = ce_sum = count = 0.0
+    for i in range(0, te_inp.shape[0], eval_batch):
+        s = slice(i, i + eval_batch)
+        a, c, m = eval_chunk_sums(model, te_inp[s], te_tgt[s], te_mask[s], depth)
+        acc_sum, ce_sum, count = acc_sum + float(a), ce_sum + float(c), count + float(m)
+    return acc_sum / count, ce_sum / count, n_params
 
 
 def main():
@@ -206,6 +211,8 @@ def main():
                     help="refiner = one shared block looped `depth` times; vanilla = `depth` distinct blocks (matched FLOPs, ~depth× block params)")
     ap.add_argument("--mem-pairs", type=int, default=1024,
                     help="memorize task: size N of the fixed random key→value dictionary (vocab = N); sweep N to read capacity")
+    ap.add_argument("--dim", type=int, default=96,
+                    help="model width (must divide heads=4 evenly); shrink it to make capacity bind sooner on the memorize probe")
     ap.add_argument("--depths", default="1,2,4,8")
     ap.add_argument("--steps", type=int, default=2500)
     ap.add_argument("--seed", type=int, default=0)
@@ -228,14 +235,14 @@ def main():
     depths = [int(d) for d in args.depths.split(",")]
     test_seq = args.train_seq if args.test_seq is None else args.test_seq
 
-    print(f"== depth ablation: arch={args.arch} task={task_desc} (train_seq={args.train_seq}, test_seq={test_seq}, vocab={vocab}) steps={args.steps} seed={args.seed} gate_bias={args.gate_bias} lr={args.lr} ==")
+    print(f"== depth ablation: arch={args.arch} dim={args.dim} task={task_desc} (train_seq={args.train_seq}, test_seq={test_seq}, vocab={vocab}) steps={args.steps} seed={args.seed} gate_bias={args.gate_bias} lr={args.lr} ==")
     print(f"{'depth':>6} {'params':>9} {'val_acc':>9} {'val_ce':>9} {'sec':>7}")
     results = {}
     for d in depths:
         t0 = time.time()
-        acc, ce, n_params = train_one(task_fn, vocab, d, arch=args.arch, steps=args.steps,
-                                      seed=args.seed, gate_bias=args.gate_bias, lr=args.lr,
-                                      train_seq=args.train_seq, test_seq=test_seq)
+        acc, ce, n_params = train_one(task_fn, vocab, d, arch=args.arch, dim=args.dim,
+                                      steps=args.steps, seed=args.seed, gate_bias=args.gate_bias,
+                                      lr=args.lr, train_seq=args.train_seq, test_seq=test_seq)
         results[d] = (acc, ce)
         print(f"{d:>6} {n_params / 1e6:>8.2f}M {acc:>9.4f} {ce:>9.4f} {time.time() - t0:>7.1f}")
 

--- a/ablation_harness.py
+++ b/ablation_harness.py
@@ -7,7 +7,23 @@ perplexity can't show this (recurrent-depth wins live on algorithmic tasks), so 
 test where depth provably has to do work — cumulative scans, which require
 aggregating all prior tokens.
 
+Two arms (#34), selected with --arch:
+  refiner  — CausalRefiner: ONE shared block looped `depth` times (the live bet).
+  vanilla  — VanillaTransformer: `depth` DISTINCT blocks, no weight sharing, no
+             time embedding. Approximately matched per-token FLOPs at equal depth
+             (the refiner spends a little extra on its update gate and time
+             embedding), ~depth× the block parameters — the arm that can afford
+             to memorize.
+
+Two probe families:
+  generalization (parity / cumsum5 / statetrack) — a rule exists; held-out
+             accuracy measures whether the model learned the procedure.
+  memorization (memorize, --mem-pairs N) — NO rule exists (fixed random
+             key→value dictionary), so the only way to be right is storage.
+             Recall over the trained pairs measures capacity; sweep N to read it.
+
     venv/bin/python ablation_harness.py --task parity --depths 1,2,4,8
+    venv/bin/python ablation_harness.py --task memorize --mem-pairs 4096 --arch vanilla
 """
 
 import argparse
@@ -18,7 +34,45 @@ import jax.numpy as jnp
 from flax import nnx
 import optax
 
-from plan_a_model import CausalRefiner
+from plan_a_model import Block, CausalRefiner
+
+
+class VanillaTransformer(nnx.Module):
+    """Matched-compute control arm: same embed / encoder / tied head as the
+    CausalRefiner, but the refinement loop is `num_blocks` DISTINCT Blocks — no
+    weight sharing, no time embedding, no update gate. At num_blocks == depth the
+    per-token FLOPs approximately match the refiner (which additionally spends
+    gate + time-embedding FLOPs per iteration); parameter count is ~depth× larger."""
+
+    def __init__(self, *, dim, vocab_size, num_heads=4, num_encoder_layers=2,
+                 num_blocks=8, max_seq_len=512, rngs, dtype=jnp.float32):
+        self.dtype = dtype
+        self.embed = nnx.Embed(vocab_size, dim, rngs=rngs, dtype=dtype)
+        self.encoder = nnx.List([
+            Block(dim, num_heads, max_seq_len, rngs, dtype) for _ in range(num_encoder_layers)
+        ])
+        self.blocks = nnx.List([
+            Block(dim, num_heads, max_seq_len, rngs, dtype) for _ in range(num_blocks)
+        ])
+        self.out_norm = nnx.RMSNorm(dim, epsilon=1e-6, rngs=rngs, dtype=dtype)
+
+    def __call__(self, tokens, depth=None, pad_mask=None):
+        # `depth` is accepted for interface parity with CausalRefiner and ignored:
+        # this arm's depth is its (fixed) number of distinct blocks.
+        pad_bias = None
+        if pad_mask is not None:
+            pad_bias = (pad_mask.astype(jnp.float32) - 1.0) * 1e9
+            pad_bias = pad_bias[:, None, None, :]
+
+        z = self.embed(tokens)
+        for blk in self.encoder:
+            z = blk(z, pad_bias)
+        for blk in self.blocks:
+            z = blk(z, pad_bias)
+
+        z = self.out_norm(z)
+        embed_t = self.embed.embedding[...].astype(self.dtype).T
+        return jnp.matmul(z.astype(self.dtype), embed_t, preferred_element_type=jnp.float32)
 
 
 def cumulative_task(key, batch, seq, mod):
@@ -57,6 +111,22 @@ def state_tracking_task(key, batch, seq, n_states=5, n_gen=4):
     return toks.astype(jnp.int32), targets, mask
 
 
+def memorize_task(n_pairs):
+    """Pure-memorization probe: a FIXED dictionary of n_pairs random key→value pairs
+    (values drawn once from a constant seed, same dictionary every call). No rule
+    exists — the values are random — so the only way to be right is to store the
+    pairs. The target at position t is dict[input[t]] (per-position lookup, causal-
+    safe). Recall over the trained dictionary is the capacity metric; sweep n_pairs
+    to find where it saturates."""
+    values = jax.random.randint(jax.random.PRNGKey(424242), (n_pairs,), 0, n_pairs)
+
+    def fn(key, batch, seq):
+        x = jax.random.randint(key, (batch, seq), 0, n_pairs)
+        mask = jnp.ones((batch, seq), dtype=jnp.float32)
+        return x.astype(jnp.int32), values[x].astype(jnp.int32), mask
+    return fn
+
+
 SEQ = 24  # default train length
 TASKS = {
     "parity": lambda key, batch, seq: cumulative_task(key, batch, seq, 2),
@@ -66,6 +136,7 @@ TASKS = {
 # Vocab must cover both input tokens and targets. statetrack: inputs in [0,n_gen),
 # targets (states) in [0,n_states) -> vocab = max(n_gen, n_states).
 VOCAB = {"parity": 2, "cumsum5": 5, "statetrack": 5}
+# `memorize` is built per-run (vocab = --mem-pairs), see main().
 
 
 def _masked_acc_ce(logits, tgt, mask):
@@ -75,7 +146,7 @@ def _masked_acc_ce(logits, tgt, mask):
     return acc, ce
 
 
-def train_one(task_fn, vocab, depth, *, dim=96, heads=4, enc=2, steps=2500,
+def train_one(task_fn, vocab, depth, *, arch="refiner", dim=96, heads=4, enc=2, steps=2500,
               batch=256, lr=2e-3, wd=0.01, seed=0, gate_bias=0.0, n_pool=32768, n_test=4096,
               train_seq=SEQ, test_seq=None):
     # When test_seq > train_seq this is a length-generalization probe: the model
@@ -87,13 +158,21 @@ def train_one(task_fn, vocab, depth, *, dim=96, heads=4, enc=2, steps=2500,
     # per step starved the tiny model's GPU (host-bound at ~10% util). Train on
     # minibatches sampled on-device inside the jitted step; eval on a separately
     # drawn held-out pool so the comparison reflects generalization, not just fit.
+    # (For `memorize` the dictionary is fixed, so the "held-out" pool is new
+    # sequences over the SAME trained pairs — i.e. recall, which is the point.)
     key, dk_tr, dk_te = jax.random.split(key, 3)
     tr_inp, tr_tgt, tr_mask = task_fn(dk_tr, n_pool, train_seq)
     te_inp, te_tgt, te_mask = task_fn(dk_te, n_test, test_seq)
 
-    model = CausalRefiner(dim=dim, vocab_size=vocab, num_heads=heads,
-                          num_encoder_layers=enc, max_depth=max(depth, 1),
-                          max_seq_len=max(train_seq, test_seq), gate_bias=gate_bias, rngs=nnx.Rngs(seed))
+    if arch == "vanilla":
+        model = VanillaTransformer(dim=dim, vocab_size=vocab, num_heads=heads,
+                                   num_encoder_layers=enc, num_blocks=max(depth, 1),
+                                   max_seq_len=max(train_seq, test_seq), rngs=nnx.Rngs(seed))
+    else:
+        model = CausalRefiner(dim=dim, vocab_size=vocab, num_heads=heads,
+                              num_encoder_layers=enc, max_depth=max(depth, 1),
+                              max_seq_len=max(train_seq, test_seq), gate_bias=gate_bias, rngs=nnx.Rngs(seed))
+    n_params = sum(int(x.size) for x in jax.tree_util.tree_leaves(nnx.state(model, nnx.Param)))
     opt = nnx.Optimizer(model, optax.adamw(lr, weight_decay=wd), wrt=nnx.Param)
 
     @nnx.jit(static_argnames=["depth"])
@@ -117,38 +196,48 @@ def train_one(task_fn, vocab, depth, *, dim=96, heads=4, enc=2, steps=2500,
         step(model, opt, k, tr_inp, tr_tgt, tr_mask, depth)
 
     acc, ce = eval_step(model, te_inp, te_tgt, te_mask, depth)
-    return float(acc), float(ce)
+    return float(acc), float(ce), n_params
 
 
 def main():
     ap = argparse.ArgumentParser()
-    ap.add_argument("--task", default="parity", choices=list(TASKS))
+    ap.add_argument("--task", default="parity", choices=list(TASKS) + ["memorize"])
+    ap.add_argument("--arch", default="refiner", choices=["refiner", "vanilla"],
+                    help="refiner = one shared block looped `depth` times; vanilla = `depth` distinct blocks (matched FLOPs, ~depth× block params)")
+    ap.add_argument("--mem-pairs", type=int, default=1024,
+                    help="memorize task: size N of the fixed random key→value dictionary (vocab = N); sweep N to read capacity")
     ap.add_argument("--depths", default="1,2,4,8")
     ap.add_argument("--steps", type=int, default=2500)
     ap.add_argument("--seed", type=int, default=0)
     ap.add_argument("--gate-bias", type=float, default=0.0,
-                    help="init bias of the update gate; negative = retention-biased (stabilizes deep recurrence)")
+                    help="init bias of the update gate; negative = retention-biased (stabilizes deep recurrence). refiner-only.")
     ap.add_argument("--lr", type=float, default=2e-3)
     ap.add_argument("--train-seq", type=int, default=SEQ)
     ap.add_argument("--test-seq", type=int, default=None,
                     help="eval length; > train-seq makes it a length-generalization probe (default: = train-seq)")
     args = ap.parse_args()
 
-    task_fn = TASKS[args.task]
-    vocab = VOCAB[args.task]
+    if args.task == "memorize":
+        task_fn = memorize_task(args.mem_pairs)
+        vocab = args.mem_pairs
+        task_desc = f"memorize[N={args.mem_pairs}]"
+    else:
+        task_fn = TASKS[args.task]
+        vocab = VOCAB[args.task]
+        task_desc = args.task
     depths = [int(d) for d in args.depths.split(",")]
     test_seq = args.train_seq if args.test_seq is None else args.test_seq
 
-    print(f"== Plan A depth ablation: task={args.task} (train_seq={args.train_seq}, test_seq={test_seq}, vocab={vocab}) steps={args.steps} seed={args.seed} gate_bias={args.gate_bias} lr={args.lr} ==")
-    print(f"{'depth':>6} {'val_acc':>9} {'val_ce':>9} {'sec':>7}")
+    print(f"== depth ablation: arch={args.arch} task={task_desc} (train_seq={args.train_seq}, test_seq={test_seq}, vocab={vocab}) steps={args.steps} seed={args.seed} gate_bias={args.gate_bias} lr={args.lr} ==")
+    print(f"{'depth':>6} {'params':>9} {'val_acc':>9} {'val_ce':>9} {'sec':>7}")
     results = {}
     for d in depths:
         t0 = time.time()
-        acc, ce = train_one(task_fn, vocab, d, steps=args.steps, seed=args.seed,
-                            gate_bias=args.gate_bias, lr=args.lr,
-                            train_seq=args.train_seq, test_seq=test_seq)
+        acc, ce, n_params = train_one(task_fn, vocab, d, arch=args.arch, steps=args.steps,
+                                      seed=args.seed, gate_bias=args.gate_bias, lr=args.lr,
+                                      train_seq=args.train_seq, test_seq=test_seq)
         results[d] = (acc, ce)
-        print(f"{d:>6} {acc:>9.4f} {ce:>9.4f} {time.time() - t0:>7.1f}")
+        print(f"{d:>6} {n_params / 1e6:>8.2f}M {acc:>9.4f} {ce:>9.4f} {time.time() - t0:>7.1f}")
 
     base_acc = results[depths[0]][0]
     best_d = max(results, key=lambda d: results[d][0])

--- a/tests/test_ablation_harness.py
+++ b/tests/test_ablation_harness.py
@@ -1,0 +1,54 @@
+"""The #34 additions to the proof instrument: the memorization probe and the
+matched-compute vanilla arm. Tiny configs — these guard wiring, not results."""
+
+import jax
+import jax.numpy as jnp
+from flax import nnx
+import numpy as np
+
+from ablation_harness import VanillaTransformer, memorize_task, train_one
+from plan_a_model import CausalRefiner
+
+
+def test_memorize_dictionary_is_fixed_across_calls():
+    """Same key → same value on every call: recall over TRAINED pairs is only a
+    capacity metric if the dictionary never resamples."""
+    fn_a, fn_b = memorize_task(64), memorize_task(64)
+    xa, ta, _ = fn_a(jax.random.PRNGKey(0), 8, 12)
+    xb, tb, _ = fn_b(jax.random.PRNGKey(1), 8, 12)
+    lut = {}
+    for x, t in [(xa, ta), (xb, tb)]:
+        for k, v in zip(np.asarray(x).ravel(), np.asarray(t).ravel()):
+            assert lut.setdefault(int(k), int(v)) == int(v), f"key {k} mapped to two values"
+
+
+def test_vanilla_arm_shapes_and_param_scaling():
+    """The vanilla arm produces logits of the right shape, and its parameters grow
+    with depth (distinct blocks) while the refiner's stay flat (shared block)."""
+    def params(m):
+        return sum(int(x.size) for x in jax.tree_util.tree_leaves(nnx.state(m, nnx.Param)))
+
+    kw = dict(dim=32, vocab_size=16, num_heads=4, num_encoder_layers=1, max_seq_len=16)
+    v2 = VanillaTransformer(**kw, num_blocks=2, rngs=nnx.Rngs(0))
+    v4 = VanillaTransformer(**kw, num_blocks=4, rngs=nnx.Rngs(0))
+    r2 = CausalRefiner(**kw, max_depth=2, rngs=nnx.Rngs(0))
+    r4 = CausalRefiner(**kw, max_depth=4, rngs=nnx.Rngs(0))
+
+    tokens = jnp.zeros((2, 16), dtype=jnp.int32)
+    assert v4(tokens).shape == (2, 16, 16)
+    assert params(v4) > params(v2), "distinct blocks must add parameters with depth"
+    # The refiner's block is shared: depth only grows the (tiny) time embedding.
+    assert params(r4) - params(r2) < params(v4) - params(v2)
+
+
+def test_train_one_runs_both_arms_on_memorize():
+    """The harness's full train/eval path works for both arms on the new task and
+    beats chance on a trivially small dictionary."""
+    fn = memorize_task(8)
+    for arch in ("refiner", "vanilla"):
+        acc, ce, n_params = train_one(fn, 8, 2, arch=arch, dim=32, heads=4, enc=1,
+                                      steps=60, batch=64, n_pool=512, n_test=128,
+                                      train_seq=8)
+        assert np.isfinite(ce), f"{arch}: CE not finite"
+        assert n_params > 0
+        assert acc > 1.0 / 8, f"{arch}: recall {acc} not above chance"


### PR DESCRIPTION
## Summary
The two missing pieces of the memorization-vs-generalization lens (#35): a pure-storage `memorize` probe (fixed random key→value dictionary, recall = capacity, swept via `--mem-pairs`) and a `--arch vanilla` control arm (`depth` DISTINCT blocks — no weight sharing, no time embedding, no gate; ~matched per-token FLOPs, ~depth× the block params). Plus a chunked eval so large-N runs fit in memory. Closes #34.

## What & why
- **`memorize_task`** — N random key→value pairs from a constant seed (same dictionary every call, guarded by a test). No rule exists, so the only path to recall is storage. Eval pool is fresh sequences over the same trained pairs — i.e. recall, the capacity metric.
- **`VanillaTransformer`** — reuses `Block` from `plan_a_model.py` verbatim; only the loop structure differs from the refiner. Param counts now print per run so the two arms' budgets are visible in every table.
- **Chunked eval + `--dim`** — the old full-pool eval materialized `[n_test, seq, vocab]` f32 logits: 6.4 GB at N=16,384 (already past the 6 GB card) and 51 GB at N=65,536 (OOM'd the first sweep attempt). Eval now accumulates over `eval_batch` chunks; `--dim` is exposed for width sweeps. This is what makes capacity sweeps runnable on the RTX 2060 at all.

## Validation / smoke-test performed
- [x] `JAX_PLATFORMS=cpu pytest tests/ -q` passes locally (incl. 3 new tests: dictionary fixedness, vanilla param scaling vs refiner, both arms train on memorize)
- Acceptance smoke (CPU, single seed 0, depth 4, 600 steps memorize / 2500 statetrack):

| probe | config | refiner | vanilla |
|---|---|---|---|
| memorize N=16384 | dim 32 | 0.58M params, recall 1.000, CE 0.0733 | 0.63M params, recall 1.000, CE 0.0606 |
| memorize N=16384 | dim 96 | 1.93M, recall 1.000, CE 0.0061 | 2.24M, recall 1.000, CE 0.0057 |
| statetrack | dim 96 | 0.36M, **acc 0.982**, CE 0.051 | 0.67M, acc 0.927, CE 0.190 |

**Honest read (per the working agreement, this is the instrument — no findings claim):**
- *Generalization half of the sanity baseline: clear.* The refiner learns the state-tracking rule better (+5.6 acc points) with **half** the parameters — single seed, but far outside the deltas we've called noise before.
- *Memorization half: directional only.* Both arms saturate recall at every CPU-feasible config — the tied embedding itself is a large lookup table, so the capacity edge sits above N=16,384 even at dim 32. Vanilla's CE is consistently lower (the expected direction) but the deltas are single-seed and small. Locating the actual recall cliff needs a larger-N sweep — feasible now with chunked eval, GPU lane, and should be its own pre-registered run under #35 rather than a claim smuggled in here.

## Risk
Harness/instrument only — `plan_a_model.py` is imported, not modified; no trainer, data, or checkpoint impact. The eval change reorders a float sum (per-chunk accumulation) in the harness's own metrics; nothing golden-tracked.

## Checklist
- [x] Did not weaken or delete any test (no skips/xfails/loosened asserts to make it pass)
- [x] Smoke-tested; no multi-hour run was launched without sign-off
- [x] Pinned deps unchanged, or the bump is justified above
- [x] Findings/claims backed by evidence in the PR or a linked finding issue

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HjZBFh2K2krkZJmFaxh6V2

---
_Generated by [Claude Code](https://claude.ai/code/session_01HjZBFh2K2krkZJmFaxh6V2)_