### PR TITLE
feat(config): per-run MODEL_SEED / DATA_SEED — the #17 prep

### DIFF
--- a/config.py
+++ b/config.py
@@ -69,6 +69,12 @@ PAD_TOKEN_ID = 50256
 # and updating VOCAB_SIZE/PAD_TOKEN_ID to match the new encoding.
 TOKENIZER_NAME = "r50k_base"
 
-# Seed for data-pipeline randomness (start-offset augmentation, mixture draws).
-# Recorded in run_metadata.json so runs are reproducible.
-DATA_SEED = 42
+# Seeds — env-overridable per run (#17: the seed-variance noise floor needs
+# same-config runs differing ONLY in seed). Both are recorded in
+# run_metadata.json so every run stays reproducible.
+#   DATA_SEED  — data-pipeline randomness (start-offset augmentation, mixture
+#                draws, per-step depth sampling).
+#   MODEL_SEED — parameter initialization (the nnx.Rngs the trainer builds
+#                the model with).
+DATA_SEED = int(os.environ.get("DATA_SEED", "42"))
+MODEL_SEED = int(os.environ.get("MODEL_SEED", "42"))

--- a/run_tracker.py
+++ b/run_tracker.py
@@ -18,6 +18,7 @@ from config import (
     NUM_HEADS,
     NUM_GROUPS,
     DATA_SEED,
+    MODEL_SEED,
 )
 
 class RunTracker:
@@ -70,6 +71,7 @@ class RunTracker:
             "NUM_HEADS": NUM_HEADS,
             "NUM_GROUPS": NUM_GROUPS,
             "DATA_SEED": DATA_SEED,
+            "MODEL_SEED": MODEL_SEED,
         }
 
     def _check_compatibility(self, metadata_path):

--- a/tests/test_seed_config.py
+++ b/tests/test_seed_config.py
@@ -1,0 +1,33 @@
+"""Per-run seed configurability (#17 prep): the noise-floor protocol needs
+same-config runs that differ ONLY in seed, so both seeds must be overridable
+from the environment and recorded in run metadata. Subprocess-based because
+config.py reads the env at import time."""
+
+import json
+import os
+import subprocess
+import sys
+
+REPO = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+
+
+def _read_config(env_overrides):
+    env = {**os.environ, **env_overrides}
+    out = subprocess.check_output(
+        [sys.executable, "-c",
+         "import json, config; print(json.dumps({'model': config.MODEL_SEED, 'data': config.DATA_SEED}))"],
+        env=env, cwd=REPO,
+    )
+    return json.loads(out)
+
+
+def test_seeds_default_and_override():
+    assert _read_config({}) == {"model": 42, "data": 42}
+    assert _read_config({"MODEL_SEED": "7", "DATA_SEED": "1234"}) == {"model": 7, "data": 1234}
+
+
+def test_seeds_recorded_in_run_metadata():
+    from run_tracker import RunTracker
+    params = RunTracker().get_hyperparameters()
+    assert params["MODEL_SEED"] == 42
+    assert params["DATA_SEED"] == 42

--- a/trainer.py
+++ b/trainer.py
@@ -21,6 +21,8 @@ from config import (
     MODEL_ARCH,
     REFINER_ENCODER_LAYERS,
     MAX_STEPS_LIMIT,
+    DATA_SEED,
+    MODEL_SEED,
     resolve_root,
 )
 from model import UniversalReasoner
@@ -155,12 +157,13 @@ def init_model_and_optimizer():
         from plan_a_trainer import RefinerForTraining
         print(f"🚀 Initializing Plan A CausalRefiner "
               f"(Dim={LATENT_DIM}, encoder_layers={REFINER_ENCODER_LAYERS}, max_depth={MAX_STEPS_LIMIT})...")
-        model = RefinerForTraining(LATENT_DIM, nnx.Rngs(42))
+        model = RefinerForTraining(LATENT_DIM, nnx.Rngs(MODEL_SEED))
     else:
         print(f"🚀 Initializing Dynamic Latent Reasoner (Dim={LATENT_DIM})...")
-        model = UniversalReasoner(LATENT_DIM, nnx.Rngs(42))
+        model = UniversalReasoner(LATENT_DIM, nnx.Rngs(MODEL_SEED))
 
-    print(f"📐 Architecture '{MODEL_ARCH}': {_param_count(model) / 1e6:.1f}M parameters")
+    print(f"📐 Architecture '{MODEL_ARCH}': {_param_count(model) / 1e6:.1f}M parameters "
+          f"(MODEL_SEED={MODEL_SEED}, DATA_SEED={DATA_SEED})")
     optimizer = nnx.Optimizer(model, optimizer_chain, wrt=nnx.Param)
 
     return model, optimizer


### PR DESCRIPTION
## Summary
Removes #17's stated blocker: model and data seeds are now configurable per run via env (`MODEL_SEED`, `DATA_SEED`) and both are recorded in `run_metadata.json`. Relates #17 — the issue stays open, since the noise-floor runs themselves are GPU-lane.

## What & why
The seed-variance protocol needs 2–3 same-config runs differing *only* in seed. Before this: the trainer's parameter-init `nnx.Rngs(42)` was hardcoded and unrecorded (a run's init seed wasn't even part of its reproducibility record), and `DATA_SEED` was a bare constant. Now both read from the environment with unchanged defaults, the trainer prints them at init, and `RunTracker.get_hyperparameters()` records both — which also means the existing metadata-compatibility check will flag a resume under a different seed.

Launching a noise-floor run on the box becomes: `MODEL_SEED=1 DATA_SEED=1 python start_training.py --new-run` (and 2, 3, …).

## Validation / smoke-test performed
- [x] `JAX_PLATFORMS=cpu pytest tests/ -q` passes locally
- Other checks run: two new tests — env override round-trip via subprocess (config reads env at import time), and both seeds present in run metadata.

## Risk
Defaults unchanged (42/42), so every existing invocation behaves identically; golden-run and determinism tests pass untouched. No checkpoint or data-path impact.

## Checklist
- [x] Did not weaken or delete any test (no skips/xfails/loosened asserts to make it pass)
- [x] Smoke-tested; no multi-hour run was launched without sign-off
- [x] Pinned deps unchanged, or the bump is justified above
- [x] Findings/claims backed by evidence in the PR or a linked finding issue

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HjZBFh2K2krkZJmFaxh6V2

---
_Generated by [Claude Code](https://claude.ai/code/session_01HjZBFh2K2krkZJmFaxh6V2)_