### PR TITLE
feat(scratchpad): supervised serial latent scratchpad — toy proof WIN (#38)

### DIFF
--- a/docs/design/serial-scratchpad.md
+++ b/docs/design/serial-scratchpad.md
@@ -31,10 +31,12 @@ r_k = (r_{k-1} * a_k + b_k) mod m                  (k = 1..K)
 
 - **Sub-result targets:** r_1 .. r_K (one per slot).
 - **Final target:** r_K, predicted at the last input position.
-- Composition of affine maps mod m is non-commutative and has no constant-depth
-  shortcut (the cumulative-product regime, same family as statetrack) — getting
-  r_K right genuinely requires the chain, and the chain decomposes exactly into
-  the K sub-results. Chance = 1/m.
+- Composition of affine maps mod m is non-commutative, so no *order-free*
+  shortcut exists (swapping pairs changes the answer) — getting r_K right
+  genuinely requires respecting the chain's order, and the chain decomposes
+  exactly into the K sub-results. Chance = 1/m. (No stronger no-constant-depth
+  claim: the affine group mod 7 is solvable, so shallow shortcut solutions can
+  exist in principle — the empirical controls are what carry the argument.)
 - Token values a (nonzero) and b share the vocab {0..m-1}; the model never sees
   r_k as an input token.
 

--- a/docs/design/serial-scratchpad.md
+++ b/docs/design/serial-scratchpad.md
@@ -1,0 +1,109 @@
+# Design — supervised serial latent scratchpad (#38)
+
+Status: toy-proof stage. This document pins the exact wiring before any code, per
+the AUTONOMY design-doc-first rule. The bet and its history live in issue #38 and
+`docs/ROADMAP.md`; this is the buildable specification.
+
+## The bet, in one paragraph
+
+Reasoning should unroll as a serial latent scratchpad on the critical path: an
+*ordered* set of K sub-slots, each written exactly once, each **supervised to carry
+sub-result k** — a grade the loss cannot dodge, not a bonus it can ignore. The two
+prior slot designs died by bypass (the gradient starved a side memory the model
+could route around; see findings 2026-06-11 and 2026-06-13). This design is
+non-bypassable twice over: per-slot supervision (a loss term only satisfiable by
+storing the sub-result) and write-order causality (slot k reads only tokens and
+slots < k, so information cannot flow backward).
+
+## Toy task — chained affine maps (the decomposable target)
+
+**Why not the issue's literal "chained modular arithmetic sums":** a running sum
+mod m is commutative — the final answer has an order-free shortcut (add
+everything), so it cannot certify seriality. The chain must be non-commutative.
+
+**Task `affine_chain(K, m)`** with m prime (default m=7), a ∈ [1, m), b ∈ [0, m):
+
+```
+input tokens:  a_1 b_1 a_2 b_2 ... a_K b_K        (seq = 2K)
+r_0 = 0
+r_k = (r_{k-1} * a_k + b_k) mod m                  (k = 1..K)
+```
+
+- **Sub-result targets:** r_1 .. r_K (one per slot).
+- **Final target:** r_K, predicted at the last input position.
+- Composition of affine maps mod m is non-commutative and has no constant-depth
+  shortcut (the cumulative-product regime, same family as statetrack) — getting
+  r_K right genuinely requires the chain, and the chain decomposes exactly into
+  the K sub-results. Chance = 1/m.
+- Token values a (nonzero) and b share the vocab {0..m-1}; the model never sees
+  r_k as an input token.
+
+## Architecture — three arms, one variable apart
+
+All arms share the same base: `embed(tokens) → causal encoder (2 × Block)` from
+`plan_a_model.py`, dim 64, heads 4. Vocab m. Sizes are toy-lane; the harness
+parametrizes them.
+
+### Arm S — serial scratchpad (the bet)
+
+One **shared** write block (a `Block` used cross-attention-style: slot queries
+attend to a context), K write steps, slot k written once at step k:
+
+```
+slots = []
+for k in 1..K:
+    q_k    = slot_init + slot_index_embed(k)               # [1, dim] learned
+    ctx_k  = concat(encoder_states, slots[1..k-1])          # tokens + EARLIER slots only
+    s_k    = write_block(q_k, ctx_k)                        # one cross-attn + MLP pass
+    slots.append(s_k)                                       # frozen — never rewritten
+```
+
+- **Per-slot grade:** `slot_logits_k = s_k @ W_readout` (shared [dim, m] head);
+  `CE(slot_logits_k, r_k)`. This is the non-bypassable supervision.
+- **Final answer:** a readout query attends to `concat(encoder_states, all slots)`
+  → `CE(answer_logits, r_K)`. The readout may exploit the slots (that is the
+  mechanism working), but the *grade* on each slot is what forces the chain to
+  exist.
+- **Loss:** `CE_final + λ · mean_k CE_slot_k`, **λ = 1.0 fixed** — pre-registered,
+  not tuned; tuning λ after seeing results is exactly the goalpost-moving the
+  working agreement forbids.
+
+### Arm P — parallel-slot control (kills "order did nothing")
+
+Identical module, identical parameters, identical per-slot supervision. One
+change: all K slots are written in a **single step**, every slot's context is
+tokens only (`ctx_k = encoder_states` for all k — no slot sees any other slot).
+Order and slot-to-slot flow are removed; everything else is held fixed.
+
+### Arm D — depth-only control (kills "slots did nothing beyond depth")
+
+`CausalRefiner` at depth K on the same tokens, final-answer supervision only —
+Plan A as-is, no scratchpad, no auxiliary loss. Params differ from S/P (inherent
+to this control); S vs P is the matched pair, S vs D is the is-it-just-depth check.
+
+## Proof gate (pre-registered)
+
+- **Protocol:** K = 4, m = 7, dim 64, heads 4, enc 2, 2500 steps, batch 256,
+  train pool 32768 / held-out 4096 sequences, seeds {0, 1, 2}, all three arms —
+  matched pairs (same seed ⇒ same pools).
+- **Metric:** held-out final-answer accuracy. Noise floor σ = per-arm seed spread.
+- **WIN** (the issue's bar): S beats **both** P and D by ≥ 2σ_pooled on final
+  accuracy.
+- **KILL:** (a) write-path collapse — S's per-slot accuracies sit at chance while
+  final accuracy trains (the RMT forget-gate failure mode, made visible here by
+  the grades), or (b) no ≥2σ gap over P (order added nothing).
+- Anything between: inconclusive, recorded as such in `docs/findings/`, no claim.
+
+## What this stage does NOT claim
+
+Toy-scale only. A win here earns the *next* rung (harness-scale LM probes), not a
+production run — that needs the user's go per AUTONOMY. Convergence halting (#39)
+stays blocked until this gate returns a verdict.
+
+## Files
+
+| Piece | Where |
+|---|---|
+| Task + three arms + runner | `scratchpad_harness.py` (root, mirrors `ablation_harness.py`; reuses `Block`/`CausalRefiner` from `plan_a_model.py`) |
+| Wiring/causality/grade tests | `tests/test_scratchpad_harness.py` |
+| Verdict | `docs/findings/` entry + PR closing #38 |

--- a/docs/findings/2026-07-03-serial-scratchpad-beats-controls.md
+++ b/docs/findings/2026-07-03-serial-scratchpad-beats-controls.md
@@ -1,8 +1,8 @@
-# The supervised serial latent scratchpad beats both controls — order plus per-slot grades turn an unlearnable composition task into a solved one
+# The supervised serial latent scratchpad beats both controls — with identical parameters, slot order alone takes a composition task from near-chance to solved
 
 Status: toy-proof (win at the #38 gate; no LM-scale claim)
 Date: 2026-07-03
-Commit: claude/project-code-quality-5r6pbn-38 @ HEAD  Run: tiny-config ablation (synthetic, no runs/ id)  Measured with: `python scratchpad_harness.py --arms serial,parallel,depthonly --seeds 0,1,2 --K 4 --m 7 --steps 2500` (CPU, FORCE_F32_COMPUTE=1)
+Commit: 7b04d073f8009ccd59f6cbb1d3a6667a316e8927  Run: tiny-config ablation (synthetic, no runs/ id)  Measured with: `python scratchpad_harness.py --arms serial,parallel,depthonly --seeds 0,1,2 --K 4 --m 7 --steps 2500` (CPU, FORCE_F32_COMPUTE=1; independently re-run to identical numbers by the code-reviewer agent)
 
 ## Setup
 
@@ -51,9 +51,17 @@ Per-slot accuracies are the mechanism made visible:
 Parallel slots nail r₁ and r₂ (shallow token functions: r₁ = b₁,
 r₂ = b₁a₂ + b₂) then collapse to near-chance exactly where composition of a
 prior *latent* result becomes unavoidable. With the identical parameters, giving
-slot k read-access to slots < k carries the chain to the end. Depth-only at
-chance says undecomposed depth-4 recurrence cannot learn K=4 affine chains here
-at all — the win is not "the task was easy".
+slot k read-access to slots < k carries the chain to the end.
+
+**Reading the depth-only control precisely:** it sat at chance after 2500 steps
+with final-only supervision — so the win is not "the task was easy", and depth
+*without decomposition supervision* did not learn it in this budget. Note this
+control differs from serial in two ways (no slots AND no intermediate
+supervision), so it does not isolate slot structure against dense intermediate
+supervision on a plain refiner — statetrack shows a densely-supervised refiner
+CAN learn non-commutative composition. The clean one-variable claim is
+serial-vs-parallel; a "dense supervision, no slots" arm is the sharpening
+follow-up.
 
 ## Relation to prior work
 

--- a/docs/findings/2026-07-03-serial-scratchpad-beats-controls.md
+++ b/docs/findings/2026-07-03-serial-scratchpad-beats-controls.md
@@ -1,0 +1,74 @@
+# The supervised serial latent scratchpad beats both controls — order plus per-slot grades turn an unlearnable composition task into a solved one
+
+Status: toy-proof (win at the #38 gate; no LM-scale claim)
+Date: 2026-07-03
+Commit: claude/project-code-quality-5r6pbn-38 @ HEAD  Run: tiny-config ablation (synthetic, no runs/ id)  Measured with: `python scratchpad_harness.py --arms serial,parallel,depthonly --seeds 0,1,2 --K 4 --m 7 --steps 2500` (CPU, FORCE_F32_COMPUTE=1)
+
+## Setup
+
+The #38 bet: reasoning as a serial latent scratchpad — K ordered sub-slots, each
+written exactly once, each *graded* (per-slot CE against sub-result r_k), slot k
+reading only tokens and slots < k. Design pinned in
+docs/design/serial-scratchpad.md before any run; criteria pre-registered on the
+issue. Task: chained affine maps, r_k = (r_{k-1}·a_k + b_k) mod 7, K=4 — chosen
+over a running sum because affine composition is non-commutative, so no
+order-free shortcut exists and the answer decomposes exactly into the graded
+sub-results. Three arms, matched pairs (same seed ⇒ same pools):
+
+- **serial** — the bet (shared cross-attn write block, slots see earlier slots);
+- **parallel** — byte-identical parameter tree, all slots written in one step
+  from tokens only (order removed; the single variable, guarded by a
+  gradient-flow test in tests/test_scratchpad_harness.py);
+- **depthonly** — CausalRefiner at depth K, final-answer supervision only.
+
+dim 64, heads 4, enc 2, 2500 steps, held-out 4096 sequences, seeds {0,1,2},
+chance = 1/7 ≈ 0.143. Win bar (pre-registered): serial beats BOTH controls by
+≥ 2σ_pooled on held-out final accuracy.
+
+## Evidence
+
+Held-out final-answer accuracy, 3 seeds:
+
+| arm | params | seed 0 | seed 1 | seed 2 | mean | σ |
+|---|---|---|---|---|---|---|
+| serial | 0.22M | 0.9988 | 0.9790 | 0.9988 | **0.9922** | 0.011 |
+| parallel | 0.22M | 0.2185 | 0.1853 | 0.1597 | 0.1878 | 0.030 |
+| depthonly | 0.17M | 0.1482 | 0.1287 | 0.1423 | 0.1397 | 0.010 |
+
+Serial − parallel = +0.804 — roughly 36× the pooled seed σ (bar was 2σ). Serial −
+depthonly is larger still. Neither kill criterion fired: no write-path collapse
+(serial's slot accuracies all ≈ 1.0 — the grades kept every link alive, unlike
+the starved forget-gate of findings 2026-06-11/13), and the order gap is
+enormous.
+
+Per-slot accuracies are the mechanism made visible:
+
+| arm | slot 1 (r₁) | slot 2 | slot 3 | slot 4 |
+|---|---|---|---|---|
+| serial | 1.000 | 0.999 | 0.997 | 0.991 |
+| parallel | 1.000 | 0.996 | ~0.29 | ~0.15 |
+
+Parallel slots nail r₁ and r₂ (shallow token functions: r₁ = b₁,
+r₂ = b₁a₂ + b₂) then collapse to near-chance exactly where composition of a
+prior *latent* result becomes unavoidable. With the identical parameters, giving
+slot k read-access to slots < k carries the chain to the end. Depth-only at
+chance says undecomposed depth-4 recurrence cannot learn K=4 affine chains here
+at all — the win is not "the task was easy".
+
+## Relation to prior work
+
+Plain serial latent feedback is Coconut (published); the contribution here is the
+*structured, per-slot-supervised* decomposition, and this is the first
+non-bypassable slot design in this repo that survived — the two unsupervised
+predecessors died by gradient starvation and by leaking the future
+[[slot-future-leak]] [[cross-window-hunch-inert]]. The bypass principle held:
+what made the difference is precisely that the loss could not be minimized
+without the chain existing.
+
+## What this does and does not license
+
+Toy-scale only. It earns the next rung — harness-scale probes of the same wiring
+on language-shaped data — not a production run (user gate per AUTONOMY.md). It
+also unblocks #39 (convergence halting) per that issue's blocker. The λ=1.0 grade
+weight was fixed in advance and untuned; sensitivity to λ, K > 4, and larger m
+are open follow-ups.

--- a/scratchpad_harness.py
+++ b/scratchpad_harness.py
@@ -1,0 +1,222 @@
+"""Toy proof harness for the supervised serial latent scratchpad (#38).
+
+Three arms on the chained-affine-maps task (docs/design/serial-scratchpad.md):
+
+  serial    — K ordered sub-slots, each written ONCE by a shared cross-attention
+              write block reading tokens + EARLIER slots only, each graded
+              against its sub-result r_k. The bet.
+  parallel  — identical module and parameters, but all K slots written in one
+              step from tokens only (no slot-to-slot flow, no order). The
+              matched control: exactly one variable removed.
+  depthonly — CausalRefiner at depth K, final-answer supervision only. The
+              is-it-just-depth control.
+
+Task: r_0 = 0; r_k = (r_{k-1} * a_k + b_k) mod m from tokens [a_1 b_1 ... a_K b_K].
+Affine composition mod m is non-commutative — no order-free shortcut — and
+decomposes exactly into the K sub-results the slots are graded on.
+
+    python scratchpad_harness.py --arms serial,parallel,depthonly --seeds 0,1,2
+"""
+
+import argparse
+import time
+
+import jax
+import jax.numpy as jnp
+from flax import nnx
+import optax
+
+from plan_a_model import Block, CausalRefiner
+
+
+def affine_chain_task(K, m):
+    """tokens [B, 2K] = a_1 b_1 ... a_K b_K (a nonzero); sub-targets r_1..r_K
+    with r_k = (r_{k-1} * a_k + b_k) mod m; the final answer is r_K."""
+    def fn(key, batch):
+        ka, kb = jax.random.split(key)
+        a = jax.random.randint(ka, (batch, K), 1, m)   # nonzero -> invertible maps
+        b = jax.random.randint(kb, (batch, K), 0, m)
+        tokens = jnp.stack([a, b], axis=-1).reshape(batch, 2 * K)
+
+        def step(r, ab):                                # ab: [B, 2] = (a_k, b_k)
+            r_new = (r * ab[:, 0] + ab[:, 1]) % m
+            return r_new, r_new
+        _, subs = jax.lax.scan(step, jnp.zeros(batch, jnp.int32),
+                               jnp.stack([a.T, b.T], axis=-1).astype(jnp.int32))
+        sub_targets = subs.T                            # [B, K]
+        return tokens.astype(jnp.int32), sub_targets
+    return fn
+
+
+class CrossBlock(nnx.Module):
+    """Pre-norm cross-attention + SwiGLU: queries read a separate context. No
+    positional encoding on the queries — slot identity comes from the caller's
+    slot-index embedding; the context carries position from the causal encoder."""
+
+    def __init__(self, dim, num_heads, rngs, dtype=jnp.float32):
+        assert dim % num_heads == 0
+        self.num_heads = num_heads
+        self.head_dim = dim // num_heads
+        self.q = nnx.Linear(dim, dim, rngs=rngs, dtype=dtype)
+        self.k = nnx.Linear(dim, dim, rngs=rngs, dtype=dtype)
+        self.v = nnx.Linear(dim, dim, rngs=rngs, dtype=dtype)
+        self.o = nnx.Linear(dim, dim, rngs=rngs, dtype=dtype)
+        self.q_norm = nnx.RMSNorm(self.head_dim, epsilon=1e-6, rngs=rngs, dtype=jnp.float32)
+        self.k_norm = nnx.RMSNorm(self.head_dim, epsilon=1e-6, rngs=rngs, dtype=jnp.float32)
+        self.norm_q = nnx.RMSNorm(dim, epsilon=1e-6, rngs=rngs, dtype=dtype)
+        self.norm_kv = nnx.RMSNorm(dim, epsilon=1e-6, rngs=rngs, dtype=dtype)
+        self.norm2 = nnx.RMSNorm(dim, epsilon=1e-6, rngs=rngs, dtype=dtype)
+        hidden = ((int(8 * dim / 3) + 63) // 64) * 64
+        self.gate_proj = nnx.Linear(dim, hidden, rngs=rngs, dtype=dtype)
+        self.up_proj = nnx.Linear(dim, hidden, rngs=rngs, dtype=dtype)
+        self.down_proj = nnx.Linear(hidden, dim, kernel_init=jax.nn.initializers.zeros, rngs=rngs, dtype=dtype)
+
+    def __call__(self, q_in, kv_in):
+        b, nq, d = q_in.shape
+        s = kv_in.shape[1]
+        qn, kvn = self.norm_q(q_in), self.norm_kv(kv_in)
+        q = self.q_norm(self.q(qn).reshape(b, nq, self.num_heads, self.head_dim))
+        k = self.k_norm(self.k(kvn).reshape(b, s, self.num_heads, self.head_dim))
+        v = self.v(kvn).reshape(b, s, self.num_heads, self.head_dim)
+        q, k = q.astype(q_in.dtype), k.astype(q_in.dtype)
+        out = jax.nn.dot_product_attention(q, k, v)
+        x = q_in + self.o(out.reshape(b, nq, d))
+        h = self.norm2(x)
+        return x + self.down_proj(jax.nn.silu(self.gate_proj(h)) * self.up_proj(h))
+
+
+class ScratchpadNet(nnx.Module):
+    """embed -> causal encoder -> K slot writes (serial or parallel) -> readout.
+
+    serial=True:  slot k's write context is tokens + slots 1..k-1 (order by
+                  construction; each slot written exactly once, then frozen).
+    serial=False: all K slots written in ONE call, context is tokens only.
+    Both modes share the identical parameter tree — `serial` only changes the
+    data flow, which is what makes serial-vs-parallel a one-variable ablation.
+    """
+
+    def __init__(self, *, dim, vocab, num_slots, num_heads=4, num_encoder_layers=2,
+                 max_seq_len=64, serial=True, rngs, dtype=jnp.float32):
+        self.num_slots = num_slots
+        self.serial = serial
+        self.embed = nnx.Embed(vocab, dim, rngs=rngs, dtype=dtype)
+        self.encoder = nnx.List([
+            Block(dim, num_heads, max_seq_len, rngs, dtype) for _ in range(num_encoder_layers)
+        ])
+        self.write_block = CrossBlock(dim, num_heads, rngs, dtype)   # shared across k
+        self.slot_index = nnx.Embed(num_slots, dim, rngs=rngs, dtype=dtype)
+        self.slot_readout = nnx.Linear(dim, vocab, rngs=rngs, dtype=dtype)  # the grade head
+        self.read_block = CrossBlock(dim, num_heads, rngs, dtype)
+        self.answer_query = nnx.Param(
+            jax.nn.initializers.normal(0.02)(rngs(), (1, 1, dim), jnp.float32))
+        self.answer_head = nnx.Linear(dim, vocab, rngs=rngs, dtype=dtype)
+
+    def __call__(self, tokens):
+        h = self.embed(tokens)
+        for blk in self.encoder:
+            h = blk(h)
+        bsz = tokens.shape[0]
+        queries = self.slot_index(jnp.arange(self.num_slots))[None, :, :]   # [1, K, d]
+        queries = jnp.broadcast_to(queries, (bsz, self.num_slots, queries.shape[-1]))
+
+        if self.serial:
+            slots = []
+            for k in range(self.num_slots):
+                ctx = jnp.concatenate([h] + slots, axis=1) if slots else h
+                slots.append(self.write_block(queries[:, k:k + 1], ctx))    # written once
+            slots = jnp.concatenate(slots, axis=1)                          # [B, K, d]
+        else:
+            slots = self.write_block(queries, h)                            # one step, tokens only
+
+        slot_logits = self.slot_readout(slots)                              # [B, K, m]
+        aq = jnp.broadcast_to(self.answer_query[...].astype(h.dtype), (bsz, 1, h.shape[-1]))
+        a = self.read_block(aq, jnp.concatenate([h, slots], axis=1))
+        answer_logits = self.answer_head(a)[:, 0]                           # [B, m]
+        return answer_logits, slot_logits
+
+
+def n_params(model):
+    return sum(int(x.size) for x in jax.tree_util.tree_leaves(nnx.state(model, nnx.Param)))
+
+
+def train_one_arm(arm, *, K=4, m=7, dim=64, heads=4, enc=2, steps=2500, batch=256,
+                  lr=2e-3, wd=0.01, seed=0, n_pool=32768, n_test=4096, slot_lambda=1.0):
+    task = affine_chain_task(K, m)
+    key = jax.random.PRNGKey(seed)
+    key, dk_tr, dk_te = jax.random.split(key, 3)
+    tr_tok, tr_sub = task(dk_tr, n_pool)
+    te_tok, te_sub = task(dk_te, n_test)
+
+    if arm == "depthonly":
+        model = CausalRefiner(dim=dim, vocab_size=m, num_heads=heads,
+                              num_encoder_layers=enc, max_depth=K,
+                              max_seq_len=2 * K, rngs=nnx.Rngs(seed))
+    else:
+        model = ScratchpadNet(dim=dim, vocab=m, num_slots=K, num_heads=heads,
+                              num_encoder_layers=enc, max_seq_len=2 * K,
+                              serial=(arm == "serial"), rngs=nnx.Rngs(seed))
+    opt = nnx.Optimizer(model, optax.adamw(lr, weight_decay=wd), wrt=nnx.Param)
+
+    def losses(mdl, tok, sub):
+        final = sub[:, -1]
+        if arm == "depthonly":
+            logits = mdl(tok, depth=K)[:, -1]                    # answer at last position
+            ce_final = optax.softmax_cross_entropy_with_integer_labels(logits, final).mean()
+            return ce_final, (logits, None)
+        answer_logits, slot_logits = mdl(tok)
+        ce_final = optax.softmax_cross_entropy_with_integer_labels(answer_logits, final).mean()
+        # The grade: λ fixed at 1.0 (pre-registered — see the design doc).
+        ce_slots = optax.softmax_cross_entropy_with_integer_labels(slot_logits, sub).mean()
+        return ce_final + slot_lambda * ce_slots, (answer_logits, slot_logits)
+
+    @nnx.jit
+    def step(mdl, op, k):
+        idx = jax.random.randint(k, (batch,), 0, tr_tok.shape[0])
+        def loss_fn(mm):
+            loss, _ = losses(mm, tr_tok[idx], tr_sub[idx])
+            return loss
+        loss, grads = nnx.value_and_grad(loss_fn)(mdl)
+        op.update(mdl, grads)
+        return loss
+
+    @nnx.jit
+    def eval_all(mdl):
+        _, (answer_logits, slot_logits) = losses(mdl, te_tok, te_sub)
+        final_acc = jnp.mean(answer_logits.argmax(-1) == te_sub[:, -1])
+        slot_acc = (jnp.mean(slot_logits.argmax(-1) == te_sub, axis=0)
+                    if slot_logits is not None else jnp.zeros(K))
+        return final_acc, slot_acc
+
+    for _ in range(steps):
+        key, k = jax.random.split(key)
+        step(model, opt, k)
+
+    final_acc, slot_acc = eval_all(model)
+    return float(final_acc), [float(x) for x in slot_acc], n_params(model)
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--arms", default="serial,parallel,depthonly")
+    ap.add_argument("--seeds", default="0,1,2")
+    ap.add_argument("--K", type=int, default=4, help="number of chained sub-steps = number of slots")
+    ap.add_argument("--m", type=int, default=7, help="modulus (prime); vocab and chance level 1/m")
+    ap.add_argument("--steps", type=int, default=2500)
+    ap.add_argument("--dim", type=int, default=64)
+    args = ap.parse_args()
+
+    print(f"== serial-scratchpad proof (#38): K={args.K} m={args.m} dim={args.dim} "
+          f"steps={args.steps} (chance={1/args.m:.3f}) ==")
+    print(f"{'arm':>10} {'seed':>5} {'params':>9} {'final_acc':>10} {'sec':>7}  slot_accs")
+    for arm in args.arms.split(","):
+        for seed in [int(s) for s in args.seeds.split(",")]:
+            t0 = time.time()
+            acc, slot_acc, params = train_one_arm(arm, K=args.K, m=args.m,
+                                                  dim=args.dim, steps=args.steps, seed=seed)
+            slots = " ".join(f"{a:.3f}" for a in slot_acc) if any(slot_acc) else "-"
+            print(f"{arm:>10} {seed:>5} {params/1e6:>8.2f}M {acc:>10.4f} {time.time()-t0:>7.1f}  [{slots}]",
+                  flush=True)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_scratchpad_harness.py
+++ b/tests/test_scratchpad_harness.py
@@ -43,25 +43,31 @@ def test_slot_order_flow_is_the_one_variable():
     grade logits."""
     tokens, _ = affine_chain_task(K, M)(jax.random.PRNGKey(1), 4)
 
-    def slot1_sum_wrt_slot0_embed(serial):
+    def slot_grad(serial, of_slot, wrt_row):
+        """grad of sum(slot_logits[:, of_slot]) w.r.t. slot_index embedding row."""
         model = ScratchpadNet(dim=DIM, vocab=M, num_slots=K, max_seq_len=2 * K,
                               serial=serial, rngs=nnx.Rngs(0))
         graph, state = nnx.split(model)
 
-        def f(emb_row0):
+        def f(emb_row):
             st = jax.tree_util.tree_map(lambda x: x, state)  # shallow copy
             emb = st["slot_index"]["embedding"][...]
-            st["slot_index"]["embedding"][...] = emb.at[0].set(emb_row0)
+            st["slot_index"]["embedding"][...] = emb.at[wrt_row].set(emb_row)
             _, slot_logits = nnx.merge(graph, st)(tokens)
-            return jnp.sum(slot_logits[:, 1])
+            return jnp.sum(slot_logits[:, of_slot])
 
-        emb0 = nnx.state(model)["slot_index"]["embedding"][...][0]
-        return jax.grad(f)(emb0)
+        row = nnx.state(model)["slot_index"]["embedding"][...][wrt_row]
+        return float(jnp.abs(jax.grad(f)(row)).max())
 
-    g_serial = slot1_sum_wrt_slot0_embed(serial=True)
-    g_parallel = slot1_sum_wrt_slot0_embed(serial=False)
-    assert float(jnp.abs(g_serial).max()) > 0.0, "serial: slot 1 must depend on slot 0"
-    assert float(jnp.abs(g_parallel).max()) == 0.0, "parallel: slots must be independent"
+    assert slot_grad(serial=True, of_slot=1, wrt_row=0) > 0.0, \
+        "serial: slot 1 must depend on slot 0"
+    assert slot_grad(serial=False, of_slot=1, wrt_row=0) == 0.0, \
+        "parallel: slots must be independent"
+    # The reverse direction must NEVER flow, in either mode — an earlier slot
+    # depending on a later one would be a future-slot leak (guards refactors of
+    # the write loop; currently impossible by construction).
+    assert slot_grad(serial=True, of_slot=0, wrt_row=1) == 0.0, \
+        "serial: slot 0 must not depend on slot 1"
 
 
 def test_all_arms_train_and_beat_nothing_burns():

--- a/tests/test_scratchpad_harness.py
+++ b/tests/test_scratchpad_harness.py
@@ -1,0 +1,76 @@
+"""Wiring guards for the serial-scratchpad proof harness (#38).
+
+These pin the properties the ablation's interpretation rests on: the task's
+recurrence is what the design doc says, serial and parallel arms differ by
+exactly one variable (data flow, not parameters), and the slot grades are a
+live gradient path — not a bonus the optimizer can ignore."""
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+from flax import nnx
+
+from scratchpad_harness import ScratchpadNet, affine_chain_task, n_params, train_one_arm
+
+K, M, DIM = 3, 7, 32
+
+
+def test_affine_chain_matches_reference():
+    tokens, subs = affine_chain_task(K, M)(jax.random.PRNGKey(0), 16)
+    a, b = np.asarray(tokens[:, 0::2]), np.asarray(tokens[:, 1::2])
+    r = np.zeros(16, dtype=np.int64)
+    for k in range(K):
+        r = (r * a[:, k] + b[:, k]) % M
+        np.testing.assert_array_equal(np.asarray(subs[:, k]), r)
+    assert (a >= 1).all(), "a tokens must be nonzero (invertible affine maps)"
+
+
+def test_serial_and_parallel_share_one_param_tree():
+    serial = ScratchpadNet(dim=DIM, vocab=M, num_slots=K, max_seq_len=2 * K,
+                           serial=True, rngs=nnx.Rngs(0))
+    parallel = ScratchpadNet(dim=DIM, vocab=M, num_slots=K, max_seq_len=2 * K,
+                             serial=False, rngs=nnx.Rngs(0))
+    assert n_params(serial) == n_params(parallel)
+    s_leaves = jax.tree_util.tree_leaves(nnx.state(serial, nnx.Param))
+    p_leaves = jax.tree_util.tree_leaves(nnx.state(parallel, nnx.Param))
+    for sl, pl in zip(s_leaves, p_leaves):
+        np.testing.assert_array_equal(np.asarray(sl), np.asarray(pl))
+
+
+def test_slot_order_flow_is_the_one_variable():
+    """Slot k+1 must read slot k in the serial arm and must NOT in the parallel
+    arm — measured as gradient flow from slot 0's index embedding into slot 1's
+    grade logits."""
+    tokens, _ = affine_chain_task(K, M)(jax.random.PRNGKey(1), 4)
+
+    def slot1_sum_wrt_slot0_embed(serial):
+        model = ScratchpadNet(dim=DIM, vocab=M, num_slots=K, max_seq_len=2 * K,
+                              serial=serial, rngs=nnx.Rngs(0))
+        graph, state = nnx.split(model)
+
+        def f(emb_row0):
+            st = jax.tree_util.tree_map(lambda x: x, state)  # shallow copy
+            emb = st["slot_index"]["embedding"][...]
+            st["slot_index"]["embedding"][...] = emb.at[0].set(emb_row0)
+            _, slot_logits = nnx.merge(graph, st)(tokens)
+            return jnp.sum(slot_logits[:, 1])
+
+        emb0 = nnx.state(model)["slot_index"]["embedding"][...][0]
+        return jax.grad(f)(emb0)
+
+    g_serial = slot1_sum_wrt_slot0_embed(serial=True)
+    g_parallel = slot1_sum_wrt_slot0_embed(serial=False)
+    assert float(jnp.abs(g_serial).max()) > 0.0, "serial: slot 1 must depend on slot 0"
+    assert float(jnp.abs(g_parallel).max()) == 0.0, "parallel: slots must be independent"
+
+
+def test_all_arms_train_and_beat_nothing_burns():
+    """Full train/eval path runs for every arm at toy size, losses finite, and
+    the graded arms report per-slot accuracies (the collapse detector)."""
+    for arm in ("serial", "parallel", "depthonly"):
+        acc, slot_acc, params = train_one_arm(arm, K=K, m=M, dim=DIM, steps=40,
+                                              batch=64, n_pool=512, n_test=128, seed=0)
+        assert np.isfinite(acc) and 0.0 <= acc <= 1.0, f"{arm}: bad final acc {acc}"
+        assert params > 0
+        if arm != "depthonly":
+            assert len(slot_acc) == K and all(np.isfinite(a) for a in slot_acc)


### PR DESCRIPTION
## Summary
The #38 bet survives its pre-registered toy gate: with an **identical parameter tree**, giving the K graded slots serial order takes held-out accuracy on chained affine maps from 0.19 (parallel control) to **0.99** — ~36× the pooled seed σ against a 2σ bar — while the depth-only control sits at chance. Design doc, harness, wiring tests, and findings entry included. Closes #38.

## What & why
Per the issue's test ladder: `docs/design/serial-scratchpad.md` pins the wiring first (K once-written slots, shared cross-attn write block, per-slot CE grades at fixed λ=1, slot k reads tokens + slots < k); `scratchpad_harness.py` implements the task and three arms; the win/kill criteria were pre-registered in the issue/design before any run.

Task note: the issue's example ("chained modular arithmetic") was upgraded to **affine-map composition** `r_k = (r_{k-1}·a_k + b_k) mod 7` — a running sum is commutative and would have an order-free shortcut, certifying nothing.

| arm | params | final acc (seeds 0/1/2) | mean ± σ | per-slot accs |
|---|---|---|---|---|
| **serial** | 0.22M | .999 / .979 / .999 | **0.992 ± 0.011** | 1.00 1.00 1.00 0.99 |
| parallel (identical tree) | 0.22M | .219 / .185 / .160 | 0.188 ± 0.030 | 1.00 1.00 0.29 0.15 |
| depthonly (CausalRefiner d4) | 0.17M | .148 / .129 / .142 | 0.140 ± 0.010 (chance=0.143) | — |

The per-slot pattern is the mechanism made visible: parallel slots solve the shallow token functions (r₁, r₂) then collapse exactly where composing a prior latent result becomes unavoidable. No kill criterion fired — serial's grades kept every link at ≈1.0 (no write-path collapse, the failure that killed both prior slot designs). This also unblocks #39.

## Validation / smoke-test performed
- [x] `JAX_PLATFORMS=cpu pytest tests/ -q` passes locally (4 new wiring tests: task-vs-numpy reference, param-tree identity between arms, gradient-flow one-variable guard incl. reverse-direction leak guard, all arms train)
- Other checks run:
  - **Independent reproduction:** the code-reviewer agent re-ran the full pre-registered command from scratch and every number in the findings table matched exactly.
  - **Reviewer verdict: `comment`** (non-blocking). All five findings applied in the follow-up commit: depth-only control's two-variable conflation now stated explicitly (dense-supervision-no-slots arm named as follow-up), design-doc shortcut claim weakened to order-free-only, "unlearnable" softened, findings `Commit:` pinned to the SHA the runs used, reverse-flow assert added.

## Risk
New standalone files only — nothing in the training path, models, or data pipeline is modified (`plan_a_model.Block`/`CausalRefiner` are imported, not touched). Toy-scale claim only; the findings doc states what the result does and does not license.

## Checklist
- [x] Did not weaken or delete any test (no skips/xfails/loosened asserts to make it pass)
- [x] Smoke-tested; no multi-hour run was launched without sign-off
- [x] Pinned deps unchanged, or the bump is justified above
- [x] Findings/claims backed by evidence in the PR or a linked finding issue

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HjZBFh2K2krkZJmFaxh6V2

---
_Generated by [Claude Code](https://claude.ai/code/session_01HjZBFh2K2krkZJmFaxh6V2)_