### PR TITLE
refactor(trainer): split validation + optimizers, extract SFT-switch clutter, dedupe weights

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -190,7 +190,7 @@ experiment (the arch behind the flag):
 | **Config (single source of truth)** | `config.py` — every architecture/training constant, the dtype policy, the arch selector |
 | **Model — live** | `plan_a_model.py` (CausalRefiner), `layers.py` |
 | **Model — control/graveyard** | `model.py` (UniversalReasoner) |
-| **Training loop** | `trainer.py` (+ `plan_a_trainer.py` adapter), `start_training.py` (entry), `grad_step.py`, `schedules.py` |
+| **Training loop** | `trainer.py` (loop + data pipeline; + `plan_a_trainer.py` adapter), `start_training.py` (entry), `grad_step.py`, `optimizers.py`, `schedules.py`, `validation.py` (held-out probe) |
 | **Data** | `prefill.py` (tokenize corpus → `runs/data/`), `data_loaders.py`, `tools/data_curation/` |
 | **Persistence & run state** | `checkpoint_utils.py`, `run_tracker.py`, `metrics_logger.py`, `monitor.py` |
 | **Proof instrument** | `ablation_harness.py` — tiny toy-task depth ablations (parity / cumsum / state-tracking) at the *exact* arch we'd ship |

--- a/monitor.py
+++ b/monitor.py
@@ -14,7 +14,24 @@ class LossMonitor:
         # Step at which the SFT phase began; None while still pretraining.
         self.sft_start_step = None
 
+    def reset_for_new_phase(self, step):
+        """Forget the previous phase's plateau state so the new phase gets a
+        fresh patience window and fresh bests. The attribute set must stay
+        stable — checkpoint_utils serializes these fields by name."""
+        self.ce_history = []
+        self.best_ce = float("inf")
+        self.best_loss = float("inf")
+        self.best_avg_ce = float("inf")
+        self.last_improvement_step = step
+
     def push(self, step, ce_loss, total_loss):
+        """Record one logging-window observation.
+
+        Returns True when the windowed CE average has not improved for
+        `patience` steps — the plateau signal the trainer acts on (switch to
+        SFT, or halt if already there). Side effect: sets `is_new_best`, which
+        the trainer reads for best-CE checkpointing.
+        """
         self.ce_history.append(ce_loss)
         if len(self.ce_history) > self.window:
             self.ce_history.pop(0)

--- a/optimizers.py
+++ b/optimizers.py
@@ -45,9 +45,12 @@ optimizer_chain = _make_chain(learning_schedule)
 
 
 def create_sft_optimizer(model, old_state=None):
-    """The SFT-phase optimizer: same chain at 10% LR. Pass `old_state` (moments
-    pulled to HOST first — see the #30 OOM note at the call sites) to preserve
-    momentum across the swap."""
+    """The SFT-phase optimizer: same chain at 10% LR. Pass `old_state` to
+    preserve momentum across the swap. VRAM note (#30): the mid-training call
+    site (trainer.train_loop) must stage the moments to HOST before calling —
+    building this optimizer allocates fresh full-size mu/nu on the GPU. The
+    startup resume path (start_training) may pass device state: nothing else
+    holds VRAM yet, so the transient double-state is harmless there."""
     print("📉 Recreating optimizer with LR reduced to 10% for SFT phase...")
 
     def sft_lr_schedule(step):

--- a/optimizers.py
+++ b/optimizers.py
@@ -1,0 +1,61 @@
+"""The training optimizers: the base pretrain chain and the reduced-LR SFT
+variant it hands over to at the phase switch. Both share the same structure
+(clip -> AdamW with masked weight decay, bf16 first moment, MultiSteps
+accumulation) so the SFT swap changes exactly one thing: the LR schedule.
+"""
+
+import gc
+
+import jax
+import jax.numpy as jnp
+import optax
+from flax import nnx
+
+from config import ACCUMULATION_STEPS
+from schedules import learning_schedule, weight_decay_schedule
+
+
+def weight_decay_mask(params):
+    return jax.tree_util.tree_map(lambda x: x.ndim >= 2, params)
+
+
+def _make_chain(learning_rate):
+    return optax.MultiSteps(
+        optax.chain(
+            optax.clip_by_global_norm(1.0),
+            optax.adamw(
+                learning_rate=learning_rate,
+                weight_decay=weight_decay_schedule,
+                mask=weight_decay_mask,
+                # Store Adam's first moment in bf16 (upcast to f32 for the update math).
+                # Storage-only, Turing-safe — tensor cores never see bf16. Frees ~2 bytes/
+                # param (~0.23GB at dim960), which is exactly what lets the dim960 / 138.7M
+                # model fit the 6GB card — it OOMs with f32 moments. The variance estimate
+                # (nu) stays f32: bf16 is too coarse near zero there. Verified sound by
+                # tools/bf16_mu_smoke.py (tracks an f32-mu run to 0.06% of loss).
+                mu_dtype=jnp.bfloat16,
+            ),
+        ),
+        every_k_schedule=ACCUMULATION_STEPS,
+        use_grad_mean=True,
+    )
+
+
+optimizer_chain = _make_chain(learning_schedule)
+
+
+def create_sft_optimizer(model, old_state=None):
+    """The SFT-phase optimizer: same chain at 10% LR. Pass `old_state` (moments
+    pulled to HOST first — see the #30 OOM note at the call sites) to preserve
+    momentum across the swap."""
+    print("📉 Recreating optimizer with LR reduced to 10% for SFT phase...")
+
+    def sft_lr_schedule(step):
+        return learning_schedule(step) * 0.1
+
+    new_opt = nnx.Optimizer(model, _make_chain(sft_lr_schedule), wrt=nnx.Param)
+    if old_state is not None:
+        nnx.update(new_opt, old_state)
+
+    gc.collect()
+    return new_opt

--- a/schedules.py
+++ b/schedules.py
@@ -41,6 +41,9 @@ CURRICULUM_STEPS = 10000.0
 # Endpoints over the (web, code, math) sources, in DataMixer source order.
 CURRICULUM_START_WEIGHTS = [0.85, 0.10, 0.05]
 CURRICULUM_END_WEIGHTS = [0.35, 0.40, 0.25]
+# SFT-phase mixture over (chat, web, code, math) — chat-led with pretrain replay.
+# Single source of truth: the trainer builds its mixer AND prints from this list.
+SFT_MIX_WEIGHTS = [0.70, 0.15, 0.10, 0.05]
 
 def get_curriculum_weights(loader_step):
     step = float(loader_step)

--- a/start_training.py
+++ b/start_training.py
@@ -14,9 +14,9 @@ import multiprocessing as mp
 
 from flax import nnx
 
+from optimizers import create_sft_optimizer
 from trainer import (
     init_model_and_optimizer,
-    create_sft_optimizer,
     setup_data_pipeline,
     train_loop,
 )

--- a/tests/test_validation_probe.py
+++ b/tests/test_validation_probe.py
@@ -1,7 +1,7 @@
 """The in-loop validation probe: scores held-out data without touching training.
 
-Also serves as the import canary for trainer.py — a syntax or wiring error
-there would otherwise only surface at the next training launch.
+Also serves as the import canary for trainer.py and its split-out modules — a
+syntax or wiring error there would otherwise only surface at the next launch.
 """
 
 import jax.numpy as jnp
@@ -11,16 +11,19 @@ import pytest
 
 def test_trainer_imports():
     import trainer  # noqa: F401
+    import optimizers  # noqa: F401
+    import validation  # noqa: F401
 
 
 def test_validation_probe_scores_and_preserves_training_state(tiny_model, monkeypatch):
     import trainer
+    import validation
 
     if not trainer.DATA_ROOT:
         pytest.skip("DATA_ROOT not set")
-    monkeypatch.setattr(trainer, "VAL_BATCHES", 1)
+    monkeypatch.setattr(validation, "VAL_BATCHES", 1)
 
-    probe = trainer.ValidationProbe()
+    probe = validation.ValidationProbe(trainer.DATA_ROOT)
     sentinel = jnp.ones_like(tiny_model.hunch_cache[...]) * 0.123
     tiny_model.hunch_cache[...] = sentinel
 

--- a/tools/eval_refiner_depth_transfer.py
+++ b/tools/eval_refiner_depth_transfer.py
@@ -94,7 +94,7 @@ def load_domain_batches(source, num_batches, skip):
 @nnx.jit(static_argnames=["depth"])
 def _ce_sums(model, batch, depth):
     """Masked next-token CE sum + token count over both windows at a fixed depth —
-    mirrors trainer._val_ce_sums, but depth is the swept argument here."""
+    mirrors validation._val_ce_sums, but depth is the swept argument here."""
     seq1_in, seq1_out = batch[:, :MAX_SEQ_LEN], batch[:, 1:MAX_SEQ_LEN + 1]
     seq2_in, seq2_out = batch[:, MAX_SEQ_LEN:2 * MAX_SEQ_LEN], batch[:, MAX_SEQ_LEN + 1:2 * MAX_SEQ_LEN + 1]
     out1 = model(seq1_in, max_steps=depth, training=False)

--- a/tools/smoke_refiner_gpu.py
+++ b/tools/smoke_refiner_gpu.py
@@ -25,7 +25,7 @@ from flax import nnx
 from config import LATENT_DIM, MAX_SEQ_LEN, MAX_STEPS_LIMIT, VOCAB_SIZE
 from grad_step import compute_grad_step, apply_grads
 from plan_a_trainer import RefinerForTraining
-from trainer import optimizer_chain
+from optimizers import optimizer_chain
 
 
 def main():

--- a/trainer.py
+++ b/trainer.py
@@ -1,3 +1,7 @@
+"""The training loop and its data pipeline. The pieces the loop *uses* live in
+their own modules: held-out scoring in validation.py, the optimizer chains in
+optimizers.py, schedules and mixture policies in schedules.py."""
+
 import os
 import gc
 import time
@@ -6,7 +10,6 @@ import queue
 
 import jax
 import jax.numpy as jnp
-import optax
 from flax import nnx
 from dotenv import load_dotenv
 
@@ -16,8 +19,6 @@ from config import (
     BATCH_SIZE,
     ACCUMULATION_STEPS,
     LATENT_DIM,
-    MAX_SEQ_LEN,
-    PAD_TOKEN_ID,
     MODEL_ARCH,
     REFINER_ENCODER_LAYERS,
     MAX_STEPS_LIMIT,
@@ -28,13 +29,15 @@ from config import (
 from model import UniversalReasoner
 from checkpoint_utils import save_checkpoint
 from grad_step import compute_grad_step, apply_grads
+from optimizers import optimizer_chain, create_sft_optimizer
 from schedules import (
-    learning_schedule,
-    weight_decay_schedule,
+    CURRICULUM_START_WEIGHTS,
+    SFT_MIX_WEIGHTS,
     get_curriculum_weights,
     get_average_curriculum_weights,
     sample_reasoning_depth,
 )
+from validation import ValidationProbe
 from metrics_logger import MetricsLogger
 from data_loaders import TextDataGenerator, DataMixer
 
@@ -46,21 +49,12 @@ PREFETCH_SIZE = 128
 # Abort training after this many consecutive non-finite micro-steps.
 MAX_NONFINITE_STREAK = 50
 
-# Held-out validation: the same fixed batches, scored the same deterministic way,
-# every VAL_EVERY_OPT_STEPS optimizer steps. Train CE cannot see overfitting or
-# data drift; this curve is the one decisions should read.
+# Cadences, in optimizer steps, both firing at the opt-step boundary — NOT
+# nested in the logging block (nesting would multiply the interval by
+# LOG_REAL_STEPS, the bug that hid the probe). The full-state checkpoint save
+# blocks the loop (wait_until_finished), so it must stay rare.
 VAL_EVERY_OPT_STEPS = 64
-VAL_BATCHES = 4
-VAL_FIXED_DEPTH = 4
-
-# Rolling-latest checkpoint cadence (optimizer steps). The full model+optimizer
-# save blocks the loop (wait_until_finished), so it fires far less often than
-# logging — at the opt-step boundary, NOT nested in the logging block (nesting
-# would multiply the interval by LOG_REAL_STEPS, the bug that hid the probe).
 CHECKPOINT_EVERY_OPT_STEPS = 64
-# Far past any plausible training consumption (an 8k-opt-step run consumes
-# under 1M fineweb samples; fineweb holds 4.3M) so the slice stays held out.
-VAL_SKIP_SAMPLES = 3_000_000
 
 DATA_ROOT = os.environ.get("DATA_ROOT", "")
 if DATA_ROOT:
@@ -68,84 +62,6 @@ if DATA_ROOT:
 else:
     print("⚠️ Warning: DATA_ROOT is not set. Data loading will fail unless provided via environment.")
 
-
-@nnx.jit
-def _val_ce_sums(model, batch):
-    """Masked CE sums over both windows, mirroring the training segment structure
-    (window 1 fresh, window 2 on the carried hunch) at a fixed depth."""
-    seq1_in, seq1_out = batch[:, :MAX_SEQ_LEN], batch[:, 1:MAX_SEQ_LEN + 1]
-    seq2_in, seq2_out = batch[:, MAX_SEQ_LEN:2 * MAX_SEQ_LEN], batch[:, MAX_SEQ_LEN + 1:2 * MAX_SEQ_LEN + 1]
-    out1 = model(seq1_in, max_steps=VAL_FIXED_DEPTH, training=False, should_refresh=True)
-    out2 = model(seq2_in, max_steps=VAL_FIXED_DEPTH, training=False, should_refresh=False)
-    total = jnp.array(0.0)
-    count = jnp.array(0)
-    for logits, targets in ((out1.logits, seq1_out), (out2.logits, seq2_out)):
-        mask = targets != PAD_TOKEN_ID
-        ce = optax.softmax_cross_entropy_with_integer_labels(logits=logits, labels=targets)
-        total += jnp.sum(ce * mask)
-        count += jnp.sum(mask)
-    return total, count
-
-
-class ValidationProbe:
-    """Loads VAL_BATCHES fixed held-out batches once, then scores them on demand.
-    Restores the training stream's carried hunch afterwards, so validating never
-    perturbs training."""
-
-    def __init__(self):
-        self._batches = None
-
-    def _load(self):
-        gen = TextDataGenerator(f"{DATA_ROOT}/pretrain/fineweb-edu")
-        gen.skip_count = VAL_SKIP_SAMPLES
-        batches = []
-        while len(batches) < VAL_BATCHES:
-            batch, _ = gen.get_batch(BATCH_SIZE)
-            if batch is None:
-                break
-            batches.append(batch)
-        if not batches:
-            print("⚠️ Validation disabled: no held-out data available past the skip range.")
-        return batches
-
-    def run(self, model):
-        if self._batches is None:
-            self._batches = self._load()
-        if not self._batches:
-            return None
-        saved_hunch = model.hunch_cache[...]
-        total, count = 0.0, 0
-        for batch in self._batches:
-            model.hunch_cache[...] = jnp.zeros_like(saved_hunch)
-            ce_sum, ce_count = _val_ce_sums(model, batch)
-            total += float(ce_sum)
-            count += int(ce_count)
-        model.hunch_cache[...] = saved_hunch
-        return total / max(count, 1)
-
-
-def weight_decay_mask(params):
-    return jax.tree_util.tree_map(lambda x: x.ndim >= 2, params)
-
-optimizer_chain = optax.MultiSteps(
-    optax.chain(
-        optax.clip_by_global_norm(1.0),
-        optax.adamw(
-            learning_rate=learning_schedule,
-            weight_decay=weight_decay_schedule,
-            mask=weight_decay_mask,
-            # Store Adam's first moment in bf16 (upcast to f32 for the update math).
-            # Storage-only, Turing-safe — tensor cores never see bf16. Frees ~2 bytes/
-            # param (~0.23GB at dim960), which is exactly what lets the dim960 / 138.7M
-            # model fit the 6GB card — it OOMs with f32 moments. The variance estimate
-            # (nu) stays f32: bf16 is too coarse near zero there. Verified sound by
-            # tools/bf16_mu_smoke.py (tracks an f32-mu run to 0.06% of loss).
-            mu_dtype=jnp.bfloat16,
-        ),
-    ),
-    every_k_schedule=ACCUMULATION_STEPS,
-    use_grad_mean=True
-)
 
 def _param_count(model):
     return sum(int(x.size) for x in jax.tree_util.tree_leaves(nnx.state(model, nnx.Param)))
@@ -168,33 +84,6 @@ def init_model_and_optimizer():
 
     return model, optimizer
 
-def create_sft_optimizer(model, old_state=None):
-    print("📉 Recreating optimizer with LR reduced to 10% for SFT phase...")
-
-    def sft_lr_schedule(step):
-        return learning_schedule(step) * 0.1
-
-    sft_chain = optax.MultiSteps(
-        optax.chain(
-            optax.clip_by_global_norm(1.0),
-            optax.adamw(
-                learning_rate=sft_lr_schedule,
-                weight_decay=weight_decay_schedule,
-                mask=weight_decay_mask,
-                mu_dtype=jnp.bfloat16,  # match the base optimizer (see init chain above)
-            ),
-        ),
-        every_k_schedule=ACCUMULATION_STEPS,
-        use_grad_mean=True
-    )
-
-    new_opt = nnx.Optimizer(model, sft_chain, wrt=nnx.Param)
-    if old_state is not None:
-        nnx.update(new_opt, old_state)
-
-    gc.collect()
-    return new_opt
-
 def setup_data_pipeline(start_step, sft_phase_event, sft_start_step=None):
     print("🚀 Initializing Dynamic Data Phases...")
     pretrain_sources = [
@@ -202,8 +91,7 @@ def setup_data_pipeline(start_step, sft_phase_event, sft_start_step=None):
         TextDataGenerator(f"{DATA_ROOT}/pretrain/codeparrot"),
         TextDataGenerator(f"{DATA_ROOT}/pretrain/finemath"),
     ]
-    pretrain_weights = [0.85, 0.10, 0.05]
-    pretrain_mixer = DataMixer(pretrain_sources, pretrain_weights)
+    pretrain_mixer = DataMixer(pretrain_sources, CURRICULUM_START_WEIGHTS)
 
     sft_sources = [
         TextDataGenerator(f"{DATA_ROOT}/chat/ultrachat"),
@@ -211,8 +99,7 @@ def setup_data_pipeline(start_step, sft_phase_event, sft_start_step=None):
         pretrain_sources[1],
         pretrain_sources[2],
     ]
-    sft_weights = [0.70, 0.15, 0.10, 0.05]
-    sft_mixer = DataMixer(sft_sources, sft_weights)
+    sft_mixer = DataMixer(sft_sources, SFT_MIX_WEIGHTS)
 
     if start_step > 1:
         start_opt_step = start_step // ACCUMULATION_STEPS
@@ -231,7 +118,7 @@ def setup_data_pipeline(start_step, sft_phase_event, sft_start_step=None):
 
             # 2. Add SFT usage for all blended sources (Chat + Replay)
             total_sft_seen = (start_step - sft_start_step)
-            for gen, weight in zip(sft_sources, sft_weights):
+            for gen, weight in zip(sft_sources, SFT_MIX_WEIGHTS):
                 gen.skip_count += int(total_sft_seen * weight)
 
     data_queue = queue.Queue(maxsize=PREFETCH_SIZE)
@@ -262,7 +149,7 @@ def train_loop(model, optimizer, data_queue, mngr, best_mngr, monitor, start_ste
     # (start_step == 1) appends to any existing CSV untouched.
     start_opt_step = start_step // ACCUMULATION_STEPS if start_step > 1 else None
     logger = MetricsLogger(history_file, start_opt_step=start_opt_step)
-    val_probe = ValidationProbe()
+    val_probe = ValidationProbe(DATA_ROOT)
     step = start_step
 
     accum_loss = 0.0
@@ -367,45 +254,39 @@ def train_loop(model, optimizer, data_queue, mngr, best_mngr, monitor, start_ste
                         f"Weights (Web/Code/Math): {curr_weights[0]:.3f} / {curr_weights[1]:.3f} / {curr_weights[2]:.3f}"
                     )
                 else:
-                    print(f"💬 [SFT Phase] Opt Step: {opt_step} | Avg Sampled Depth: {accum_depth:.2f} | Weights (Chat/Web/Code/Math): [0.70, 0.15, 0.10, 0.05]")
+                    sft_w = " / ".join(f"{w:.2f}" for w in SFT_MIX_WEIGHTS)
+                    print(f"💬 [SFT Phase] Opt Step: {opt_step} | Avg Sampled Depth: {accum_depth:.2f} | Weights (Chat/Web/Code/Math): {sft_w}")
 
                 # Periodically update session duration to capture active timings
                 run_tracker.update_session_duration()
 
-                if monitor.push(opt_step, float(accum_token_loss), float(accum_loss)):
-                    if not sft_phase_event.is_set():
-                        sft_phase_event.set()
-                        monitor.sft_start_step = step
-
-                        # Pull the optimizer moments to host BEFORE building the SFT
-                        # optimizer. nnx.Optimizer eagerly allocates a fresh full-size
-                        # mu/nu on the GPU, so without this the old (GPU) state and the
-                        # new (GPU) state coexist for an instant — a ~2x optimizer-state
-                        # spike that OOM'd the 6GB card at the phase switch (#30).
-                        # device_get copies the moments to RAM, so the old GPU buffers
-                        # free on the del below and only one full optimizer state is
-                        # resident at the peak. Momentum is preserved: create_sft_
-                        # optimizer copies these host values into the new optimizer.
-                        old_state = jax.device_get(nnx.state(optimizer))
-                        del optimizer
-                        gc.collect()
-
-                        optimizer = create_sft_optimizer(model, old_state)
-                        del old_state
-                        gc.collect()
-
-                        print("\n" + "🔄"*30)
-                        print("🔄 CE Plateau Detected! Triggering SFT Chat Phase and decaying Learning Rate!")
-                        print("🔄"*30 + "\n")
-
-                        monitor.ce_history = []
-                        monitor.best_ce = float("inf")
-                        monitor.best_loss = float("inf")
-                        monitor.best_avg_ce = float("inf")
-                        monitor.last_improvement_step = opt_step
-                    else:
+                plateaued = monitor.push(opt_step, float(accum_token_loss), float(accum_loss))
+                if plateaued:
+                    if sft_phase_event.is_set():
                         print("🛑 Training halted: No improvement in CE during SFT phase.")
                         break
+
+                    print("\n" + "🔄"*30)
+                    print("🔄 CE Plateau Detected! Triggering SFT Chat Phase and decaying Learning Rate!")
+                    print("🔄"*30 + "\n")
+                    sft_phase_event.set()
+                    monitor.sft_start_step = step
+
+                    # OOM-critical ordering (#30): pull the optimizer moments to
+                    # host, then free the old optimizer IN THIS SCOPE, before
+                    # nnx.Optimizer eagerly allocates the new full-size mu/nu on
+                    # the GPU — otherwise both states coexist for an instant, a
+                    # ~2x spike that OOM'd the 6GB card. (This block must stay
+                    # inline: a helper's `del` cannot release the loop's local
+                    # reference.) Momentum survives via the host copy.
+                    old_state = jax.device_get(nnx.state(optimizer))
+                    del optimizer
+                    gc.collect()
+                    optimizer = create_sft_optimizer(model, old_state)
+                    del old_state
+                    gc.collect()
+
+                    monitor.reset_for_new_phase(opt_step)
 
                 # Best-CE checkpoint: saved here where monitor.is_new_best is
                 # computed (over the windowed accumulators), in a sibling dir so

--- a/validation.py
+++ b/validation.py
@@ -1,0 +1,74 @@
+"""Held-out validation: the same fixed batches, scored the same deterministic
+way, on demand. Train CE cannot see overfitting or data drift; this curve is
+the one decisions should read. The trainer drives it on its own cadence
+(VAL_EVERY_OPT_STEPS there); everything about *what* a probe measures lives here.
+"""
+
+import jax.numpy as jnp
+import optax
+from flax import nnx
+
+from config import BATCH_SIZE, MAX_SEQ_LEN, PAD_TOKEN_ID
+from data_loaders import TextDataGenerator
+
+VAL_BATCHES = 4
+VAL_FIXED_DEPTH = 4
+# Far past any plausible training consumption (an 8k-opt-step run consumes
+# under 1M fineweb samples; fineweb holds 4.3M) so the slice stays held out.
+VAL_SKIP_SAMPLES = 3_000_000
+
+
+@nnx.jit
+def _val_ce_sums(model, batch):
+    """Masked CE sums over both windows, mirroring the training segment structure
+    (window 1 fresh, window 2 on the carried hunch) at a fixed depth."""
+    seq1_in, seq1_out = batch[:, :MAX_SEQ_LEN], batch[:, 1:MAX_SEQ_LEN + 1]
+    seq2_in, seq2_out = batch[:, MAX_SEQ_LEN:2 * MAX_SEQ_LEN], batch[:, MAX_SEQ_LEN + 1:2 * MAX_SEQ_LEN + 1]
+    out1 = model(seq1_in, max_steps=VAL_FIXED_DEPTH, training=False, should_refresh=True)
+    out2 = model(seq2_in, max_steps=VAL_FIXED_DEPTH, training=False, should_refresh=False)
+    total = jnp.array(0.0)
+    count = jnp.array(0)
+    for logits, targets in ((out1.logits, seq1_out), (out2.logits, seq2_out)):
+        mask = targets != PAD_TOKEN_ID
+        ce = optax.softmax_cross_entropy_with_integer_labels(logits=logits, labels=targets)
+        total += jnp.sum(ce * mask)
+        count += jnp.sum(mask)
+    return total, count
+
+
+class ValidationProbe:
+    """Loads VAL_BATCHES fixed held-out batches once, then scores them on demand.
+    Restores the training stream's carried hunch afterwards, so validating never
+    perturbs training."""
+
+    def __init__(self, data_root):
+        self.data_root = data_root
+        self._batches = None
+
+    def _load(self):
+        gen = TextDataGenerator(f"{self.data_root}/pretrain/fineweb-edu")
+        gen.skip_count = VAL_SKIP_SAMPLES
+        batches = []
+        while len(batches) < VAL_BATCHES:
+            batch, _ = gen.get_batch(BATCH_SIZE)
+            if batch is None:
+                break
+            batches.append(batch)
+        if not batches:
+            print("⚠️ Validation disabled: no held-out data available past the skip range.")
+        return batches
+
+    def run(self, model):
+        if self._batches is None:
+            self._batches = self._load()
+        if not self._batches:
+            return None
+        saved_hunch = model.hunch_cache[...]
+        total, count = 0.0, 0
+        for batch in self._batches:
+            model.hunch_cache[...] = jnp.zeros_like(saved_hunch)
+            ce_sum, ce_count = _val_ce_sums(model, batch)
+            total += float(ce_sum)
+            count += int(ce_count)
+        model.hunch_cache[...] = saved_hunch
+        return total / max(count, 1)


### PR DESCRIPTION
## Summary
The maintainability pass we scoped: trainer.py (425 → 309 lines) now holds only the loop and its data pipeline. Held-out scoring moved to `validation.py`, the optimizer chains to `optimizers.py`, the SFT phase-switch block reads top-to-bottom, mixture weights have one source of truth in `schedules.py`, and `LossMonitor` gained a documented plateau contract plus `reset_for_new_phase`. Move-only — no numeric or behavioral change. Issue-less per maintainer request.

## What & why
- **`validation.py`** — `_val_ce_sums` + `ValidationProbe` (+ its three constants). The probe takes `data_root` explicitly instead of reaching into trainer's global.
- **`optimizers.py`** — `weight_decay_mask`, the base `optimizer_chain`, `create_sft_optimizer`. Both chains now come from one `_make_chain(lr)`, so the SFT variant differs by exactly the LR schedule — the invariant the old inline comment claimed is now enforced by construction.
- **SFT switch in the loop** — early-exit halt, banner, flags, then the #30 OOM-critical host-staged swap (deliberately kept inline: a helper's `del` can't release the loop's local reference), then `monitor.reset_for_new_phase(...)` replacing the five-attribute grope.
- **Weight dedupe** — pretrain mixer uses `CURRICULUM_START_WEIGHTS`; SFT mixer *and* the SFT log line use new `SFT_MIX_WEIGHTS` (the log previously hardcoded a string copy of the list — a desync waiting to happen).
- **Monitor clarity** — `push()` documents its return (the plateau signal) and the `is_new_best` side channel; `reset_for_new_phase` keeps the checkpoint-serialized attribute set byte-stable.
- CLAUDE.md repo map updated; importers (`start_training`, `tools/smoke_refiner_gpu`, tests) rewired.

## Validation / smoke-test performed
- [x] `JAX_PLATFORMS=cpu pytest tests/ -q` passes locally (53 tests, incl. golden-run + determinism — numerics untouched)
- Other checks run:
  - End-to-end exercise of the exact refactored path on CPU: base chain → grad steps → forced plateau → `reset_for_new_phase` → host-staged swap via `create_sft_optimizer` → further finite grad steps.
  - **code-reviewer agent verdict: `comment`** — confirmed optimizer-chain byte-equivalence, #30 ordering preserved (only the banner print moved earlier; no state effect), checkpoint-serialized monitor attributes untouched, no missed importers, no import cycles, and that `DataMixer` copies its weight list so the shared constants can't be mutated. Its two low-severity residues (a stale `trainer._val_ce_sums` comment; an overstated docstring about host-staging on the resume path) are fixed in the follow-up commit.

## Risk
Structural only. Optimizer state trees are unchanged (checkpoints resume), monitor serialization is name-stable (old checkpoints restore), mixture values are identical to the old literals including the resume skip-count math. The one behavior-adjacent edit is the SFT banner printing before the swap instead of after — cosmetic ordering of stdout.

## Checklist
- [x] Did not weaken or delete any test (no skips/xfails/loosened asserts to make it pass)
- [x] Smoke-tested; no multi-hour run was launched without sign-off
- [x] Pinned deps unchanged, or the bump is justified above
- [x] Findings/claims backed by evidence in the PR or a linked finding issue

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HjZBFh2K2krkZJmFaxh6V2

---
_Generated by [Claude Code](https://claude.ai/code/session_01HjZBFh2K2krkZJmFaxh6V2)_