### PR TITLE
perf(attn): blockwise memory-lean attention for the refiner, opt-in (#66)

### DIFF
--- a/attention.py
+++ b/attention.py
@@ -8,8 +8,11 @@ probabilities for the backward; at seq 512 / depth 8 those transients dominate
 the compiled grad step (the 1.9 GiB peak mem_profile names, and what OOM'd the
 dim960 fit-test). Here one query block's [heads, block_q, s] scores exist at a
 time, and the backward saves NO probabilities — it recomputes each block from
-(q, k, v), flash-attention's memory story in pure XLA (no Ampere kernels, so it
-runs on the Turing card and the CPU test lane alike).
+(q, k, v). Memory-wise this is flash-attention's story in pure XLA (no Ampere
+kernels, so it runs on the Turing card and the CPU test lane alike); mechanically
+it is simpler: blocking is over QUERIES only, each block softmaxes over the full
+key axis in one shot, so there is no online-softmax / running log-sum-exp state
+to maintain — don't go hunting for it.
 
 Numerics match the stock path: scores accumulate in f32 (``preferred_element_
 type``), softmax runs in f32, the causal mask and additive pad bias apply to

--- a/attention.py
+++ b/attention.py
@@ -1,0 +1,118 @@
+"""Memory-lean causal attention (#66).
+
+Blockwise attention via a custom VJP whose forward AND backward are ``lax.scan``
+loops over query blocks — the same construction that fixed the vocab-wide CE
+peak in losses.py (#19), applied to the other quadratic tensor. Stock
+``jax.nn.dot_product_attention`` materializes [heads, s, s] scores and saves the
+probabilities for the backward; at seq 512 / depth 8 those transients dominate
+the compiled grad step (the 1.9 GiB peak mem_profile names, and what OOM'd the
+dim960 fit-test). Here one query block's [heads, block_q, s] scores exist at a
+time, and the backward saves NO probabilities — it recomputes each block from
+(q, k, v), flash-attention's memory story in pure XLA (no Ampere kernels, so it
+runs on the Turing card and the CPU test lane alike).
+
+Numerics match the stock path: scores accumulate in f32 (``preferred_element_
+type``), softmax runs in f32, the causal mask and additive pad bias apply to
+scaled scores. Only the block loop reorders float ops, so parity is allclose,
+not bit-exact — pinned by tests/test_chunked_attention.py in value and grads.
+"""
+
+from functools import partial
+
+import jax
+import jax.numpy as jnp
+
+# Queries scored per scan step. 128 keeps the live block at [h, 128, s] —
+# a single bounded transient instead of one [h, s, s] per attention call.
+DEFAULT_BLOCK_Q = 128
+
+
+def _block_scores(q_blk, k, row_start, pad_cols):
+    """Scaled f32 scores for one query block, causal + pad bias applied.
+    q_blk [b, Bq, h, d]; k [b, s, h, d]; pad_cols [b, s] additive f32."""
+    d = q_blk.shape[-1]
+    s = k.shape[1]
+    scores = jnp.einsum('bqhd,bkhd->bhqk', q_blk, k,
+                        preferred_element_type=jnp.float32) / jnp.sqrt(d).astype(jnp.float32)
+    rows = row_start + jnp.arange(q_blk.shape[1])
+    causal = rows[:, None] >= jnp.arange(s)[None, :]                # True = allowed
+    bias = jnp.where(causal, 0.0, -1e9)[None, None, :, :] + pad_cols[:, None, None, :]
+    return scores + bias
+
+
+def _pad_to_blocks(q, block_q):
+    """Pad the query axis up to a whole number of blocks and reshape to
+    [n_blocks, b, Bq, h, d] for lax.scan. Padded rows are discarded by the
+    caller's final slice; their all-masked softmax is uniform, not NaN."""
+    b, s, h, d = q.shape
+    n_pad = (-s) % block_q
+    if n_pad:
+        q = jnp.pad(q, ((0, 0), (0, n_pad), (0, 0), (0, 0)))
+    n_blocks = (s + n_pad) // block_q
+    return q.reshape(b, n_blocks, block_q, h, d).swapaxes(0, 1), n_blocks
+
+
+def _forward(q, k, v, pad_cols, block_q):
+    b, s, h, d = q.shape
+    q_steps, n_blocks = _pad_to_blocks(q, block_q)
+    starts = jnp.arange(n_blocks) * block_q
+
+    def step(_, xs):
+        q_blk, row_start = xs
+        probs = jax.nn.softmax(_block_scores(q_blk, k, row_start, pad_cols), axis=-1)
+        out_blk = jnp.einsum('bhqk,bkhd->bqhd', probs.astype(v.dtype), v)
+        return None, out_blk
+
+    _, out_steps = jax.lax.scan(step, None, (q_steps, starts))
+    return out_steps.swapaxes(0, 1).reshape(b, n_blocks * block_q, h, d)[:, :s]
+
+
+@partial(jax.custom_vjp, nondiff_argnums=(4,))
+def chunked_causal_attention(q, k, v, pad_cols, block_q=DEFAULT_BLOCK_Q):
+    """Causal multi-head attention over [b, s, h, d] inputs, scored one query
+    block at a time. ``pad_cols`` is the additive key-padding bias [b, s]
+    (0 = attend, -1e9 = masked); it takes no gradient (it comes from a token
+    comparison upstream). Drop-in for the stock
+    ``jax.nn.dot_product_attention(q, k, v, bias=causal+pad)`` up to float
+    summation order."""
+    return _forward(q, k, v, pad_cols, block_q)
+
+
+def _cca_fwd(q, k, v, pad_cols, block_q):
+    # Residuals are just the inputs — no [s, s] probabilities are saved; the
+    # backward recomputes each block. This is the entire memory win.
+    return _forward(q, k, v, pad_cols, block_q), (q, k, v, pad_cols)
+
+
+def _cca_bwd(block_q, residuals, g):
+    q, k, v, pad_cols = residuals
+    b, s, h, d = q.shape
+    scale = jnp.sqrt(d).astype(jnp.float32)
+
+    q_steps, n_blocks = _pad_to_blocks(q, block_q)
+    g_steps, _ = _pad_to_blocks(g, block_q)
+    starts = jnp.arange(n_blocks) * block_q
+
+    def step(carry, xs):
+        dk_acc, dv_acc = carry
+        q_blk, g_blk, row_start = xs
+        probs = jax.nn.softmax(_block_scores(q_blk, k, row_start, pad_cols), axis=-1)  # [b,h,Bq,s] f32
+
+        g32 = g_blk.astype(jnp.float32)
+        # dV += P^T dO ; dP = dO V^T ; softmax bwd: dS = P * (dP - sum(dP*P))
+        dv_blk = jnp.einsum('bhqk,bqhd->bkhd', probs, g32)
+        dp = jnp.einsum('bqhd,bkhd->bhqk', g32, v.astype(jnp.float32))
+        ds = probs * (dp - jnp.sum(dp * probs, axis=-1, keepdims=True))
+        dq_blk = jnp.einsum('bhqk,bkhd->bqhd', ds, k.astype(jnp.float32)) / scale
+        dk_blk = jnp.einsum('bhqk,bqhd->bkhd', ds, q_blk.astype(jnp.float32)) / scale
+        return (dk_acc + dk_blk, dv_acc + dv_blk), dq_blk
+
+    zeros = jnp.zeros((b, s, h, d), jnp.float32)
+    (dk, dv), dq_steps = jax.lax.scan(step, (zeros, zeros), (q_steps, g_steps, starts))
+    dq = dq_steps.swapaxes(0, 1).reshape(b, n_blocks * block_q, h, d)[:, :s]
+
+    return (dq.astype(q.dtype), dk.astype(k.dtype), dv.astype(v.dtype),
+            jnp.zeros_like(pad_cols))
+
+
+chunked_causal_attention.defvjp(_cca_fwd, _cca_bwd)

--- a/config.py
+++ b/config.py
@@ -47,6 +47,11 @@ NUM_GROUPS = NUM_HEADS // 4
 # A refiner run has a different param tree, so it must start fresh (--new-run);
 # it cannot resume a reasoner checkpoint.
 MODEL_ARCH = os.environ.get("MODEL_ARCH", "reasoner")
+# Blockwise memory-lean attention for the refiner (#66): removes the O(seq²)
+# score/probability transients that dominate the grad-step peak (mem_profile).
+# Opt-in until the dim960 GPU fit-test + wall-clock bench pass on the box;
+# same math as stock attention up to float summation order.
+CHUNKED_ATTENTION = os.environ.get("CHUNKED_ATTENTION", "0") == "1"
 # Plan A: number of causal encoder layers beneath the single shared refine block
 # (which is looped up to MAX_STEPS_LIMIT times). Tuned to land the param count
 # near the reasoner baseline; init prints the actual count for both arches.

--- a/plan_a_model.py
+++ b/plan_a_model.py
@@ -15,15 +15,22 @@ import jax
 import jax.numpy as jnp
 from flax import nnx
 
+from attention import chunked_causal_attention
 from rope import rope_tables, apply_rope
 
 
 class CausalAttention(nnx.Module):
-    """Multi-head self-attention, RoPE, causal mask folded into an additive bias."""
+    """Multi-head self-attention, RoPE, causal mask folded into an additive bias.
 
-    def __init__(self, dim, num_heads, max_pos, rngs, dtype=jnp.float32):
+    chunked=True swaps the stock dot_product_attention for the blockwise
+    memory-lean path (attention.py, #66): same math up to float summation
+    order, but no [s, s] score/probability tensor is ever materialized or
+    saved for the backward — the O(seq²) activation wall goes away."""
+
+    def __init__(self, dim, num_heads, max_pos, rngs, dtype=jnp.float32, chunked=False):
         assert dim % num_heads == 0, "dim must divide num_heads"
         self.num_heads = num_heads
+        self.chunked = chunked
         self.head_dim = dim // num_heads
         assert self.head_dim % 2 == 0, "head_dim must be even for RoPE"
         self.q = nnx.Linear(dim, dim, rngs=rngs, dtype=dtype)
@@ -46,27 +53,34 @@ class CausalAttention(nnx.Module):
         q = apply_rope(q, cos, sin)
         k = apply_rope(k, cos, sin)
 
-        pos = jnp.arange(s)
-        causal = pos[:, None] >= pos[None, :]                       # [s, s], True = allowed
-        bias = jnp.where(causal, 0.0, -1e9)[None, None, :, :]       # [1, 1, s, s]
-        if pad_bias is not None:
-            bias = bias + pad_bias                                  # pad_bias [b, 1, 1, s]
-
         # q_norm/k_norm run in f32 for stability, so q/k come out f32 while v is in
         # the compute dtype. Cast q/k back so all three match (dot_product_attention
         # requires it) and attention takes the tensor-core path. No-op in f32 (CPU /
         # toy harness); the real-scale f16 run needs it.
         q = q.astype(x.dtype)
         k = k.astype(x.dtype)
-        out = jax.nn.dot_product_attention(q, k, v, bias=bias.astype(x.dtype))
+
+        if self.chunked:
+            # Blockwise path (#66): causal mask built per query block inside the
+            # scan; only the key-padding bias is passed, as additive [b, s].
+            pad_cols = (pad_bias[:, 0, 0, :] if pad_bias is not None
+                        else jnp.zeros((b, s), jnp.float32))
+            out = chunked_causal_attention(q, k, v, pad_cols)
+        else:
+            pos = jnp.arange(s)
+            causal = pos[:, None] >= pos[None, :]                   # [s, s], True = allowed
+            bias = jnp.where(causal, 0.0, -1e9)[None, None, :, :]   # [1, 1, s, s]
+            if pad_bias is not None:
+                bias = bias + pad_bias                              # pad_bias [b, 1, 1, s]
+            out = jax.nn.dot_product_attention(q, k, v, bias=bias.astype(x.dtype))
         return self.o(out.reshape(b, s, d))
 
 
 class Block(nnx.Module):
     """Pre-norm transformer block: causal attention + SwiGLU MLP, zero-init residual."""
 
-    def __init__(self, dim, num_heads, max_pos, rngs, dtype=jnp.float32):
-        self.attn = CausalAttention(dim, num_heads, max_pos, rngs, dtype)
+    def __init__(self, dim, num_heads, max_pos, rngs, dtype=jnp.float32, chunked_attention=False):
+        self.attn = CausalAttention(dim, num_heads, max_pos, rngs, dtype, chunked=chunked_attention)
         self.norm1 = nnx.RMSNorm(dim, epsilon=1e-6, rngs=rngs, dtype=dtype)
         self.norm2 = nnx.RMSNorm(dim, epsilon=1e-6, rngs=rngs, dtype=dtype)
         hidden = ((int(8 * dim / 3) + 63) // 64) * 64
@@ -90,7 +104,8 @@ class CausalRefiner(nnx.Module):
     """
 
     def __init__(self, *, dim, vocab_size, num_heads=4, num_encoder_layers=2,
-                 max_depth=8, max_seq_len=512, use_gate=True, gate_bias=0.0, rngs, dtype=jnp.float32):
+                 max_depth=8, max_seq_len=512, use_gate=True, gate_bias=0.0,
+                 chunked_attention=False, rngs, dtype=jnp.float32):
         self.dim = dim
         self.vocab_size = vocab_size
         self.max_depth = max_depth
@@ -101,9 +116,11 @@ class CausalRefiner(nnx.Module):
         self.time_embed = nnx.Embed(max_depth + 1, dim, rngs=rngs, dtype=dtype)
 
         self.encoder = nnx.List([
-            Block(dim, num_heads, max_seq_len, rngs, dtype) for _ in range(num_encoder_layers)
+            Block(dim, num_heads, max_seq_len, rngs, dtype, chunked_attention=chunked_attention)
+            for _ in range(num_encoder_layers)
         ])
-        self.refine_block = Block(dim, num_heads, max_seq_len, rngs, dtype)  # shared, looped
+        self.refine_block = Block(dim, num_heads, max_seq_len, rngs, dtype,
+                                  chunked_attention=chunked_attention)  # shared, looped
 
         self.time_norm = nnx.RMSNorm(dim, epsilon=1e-6, rngs=rngs, dtype=dtype)
         self.time_signal_norm = nnx.RMSNorm(dim, epsilon=1e-6, rngs=rngs, dtype=dtype)

--- a/plan_a_trainer.py
+++ b/plan_a_trainer.py
@@ -30,6 +30,7 @@ from config import (
     PAD_TOKEN_ID,
     COMPUTE_DTYPE,
     REFINER_ENCODER_LAYERS,
+    CHUNKED_ATTENTION,
 )
 from layers import ReasonerOutput
 from plan_a_model import CausalRefiner
@@ -44,12 +45,14 @@ class RefinerForTraining(nnx.Module):
 
     def __init__(self, latent_dim, rngs, *, vocab_size=VOCAB_SIZE, num_heads=NUM_HEADS,
                  encoder_layers=REFINER_ENCODER_LAYERS, max_depth=MAX_STEPS_LIMIT,
-                 max_seq_len=MAX_SEQ_LEN, pad_token_id=PAD_TOKEN_ID, dtype=COMPUTE_DTYPE):
+                 max_seq_len=MAX_SEQ_LEN, pad_token_id=PAD_TOKEN_ID, dtype=COMPUTE_DTYPE,
+                 chunked_attention=CHUNKED_ATTENTION):
         self.pad_token_id = pad_token_id
         self.refiner = CausalRefiner(
             dim=latent_dim, vocab_size=vocab_size, num_heads=num_heads,
             num_encoder_layers=encoder_layers, max_depth=max_depth,
             max_seq_len=max_seq_len, dtype=dtype, rngs=rngs,
+            chunked_attention=chunked_attention,
         )
         # Vestigial: written by the trainer's hunch bookkeeping, never read here.
         # Kept tiny ([1, 1, dim]) since it carries no information.

--- a/tests/test_chunked_attention.py
+++ b/tests/test_chunked_attention.py
@@ -6,6 +6,7 @@ CausalRefiner must preserve the no-future-leak invariant."""
 import jax
 import jax.numpy as jnp
 import numpy as np
+import pytest
 from flax import nnx
 
 from attention import chunked_causal_attention
@@ -69,6 +70,50 @@ def test_chunked_refiner_matches_stock_refiner():
     gc = jax.tree_util.tree_leaves(nnx.grad(loss)(chunked))
     for a, b in zip(gc, gs):
         np.testing.assert_allclose(np.asarray(a), np.asarray(b), rtol=1e-3, atol=1e-6)
+
+
+def test_chunked_refiner_multiblock_with_padding():
+    """Model-level parity where the chunked path actually crosses a block
+    boundary (seq 160 > DEFAULT_BLOCK_Q=128) AND threads a real pad mask —
+    the two conditions the small model tests above never exercise together."""
+    kw = dict(dim=32, vocab_size=17, num_heads=4, num_encoder_layers=1,
+              max_depth=2, max_seq_len=160)
+    stock = CausalRefiner(**kw, chunked_attention=False, rngs=nnx.Rngs(3))
+    chunked = CausalRefiner(**kw, chunked_attention=True, rngs=nnx.Rngs(3))
+
+    rng = np.random.default_rng(11)
+    tokens = jnp.asarray(rng.integers(0, 17, size=(2, 160)), jnp.int32)
+    pad_mask = jnp.asarray(np.arange(160) < 149)[None, :]          # last 11 padded
+    pad_mask = jnp.broadcast_to(pad_mask, (2, 160))
+
+    out_s = stock(tokens, depth=2, pad_mask=pad_mask)
+    out_c = chunked(tokens, depth=2, pad_mask=pad_mask)
+    np.testing.assert_allclose(np.asarray(out_c), np.asarray(out_s), rtol=1e-4, atol=1e-5)
+
+    def loss(m):
+        return jnp.mean(m(tokens, depth=2, pad_mask=pad_mask) ** 2)
+
+    for a, b in zip(jax.tree_util.tree_leaves(nnx.grad(loss)(chunked)),
+                    jax.tree_util.tree_leaves(nnx.grad(loss)(stock))):
+        np.testing.assert_allclose(np.asarray(a), np.asarray(b), rtol=1e-3, atol=1e-6)
+
+
+@pytest.mark.gpu
+def test_chunked_attention_f16_parity_gpu():
+    """Pin the PRODUCTION dtype path: on the GPU lane (RUN_TESTS_ON_GPU=1,
+    f16 compute) chunked and stock attention must agree within f16 headroom.
+    CPU CI skips this — the CPU lane forces f32 (see conftest)."""
+    s, block_q = 160, 128
+    rng = np.random.default_rng(23)
+    mk = lambda: jnp.asarray(rng.normal(size=(B, s, H, D)), jnp.float16)
+    q, k, v = mk(), mk(), mk()
+    pad_cols = jnp.broadcast_to(
+        jnp.where(jnp.arange(s) < s - 5, 0.0, -1e9)[None, :].astype(jnp.float32), (B, s))
+
+    out_c = chunked_causal_attention(q, k, v, pad_cols, block_q)
+    out_s = _stock(q, k, v, pad_cols)
+    assert np.isfinite(np.asarray(out_c)).all()
+    np.testing.assert_allclose(np.asarray(out_c), np.asarray(out_s), rtol=2e-2, atol=2e-3)
 
 
 def test_chunked_path_has_no_future_leak():

--- a/tests/test_chunked_attention.py
+++ b/tests/test_chunked_attention.py
@@ -1,0 +1,90 @@
+"""Chunked attention (#66) parity guards: the blockwise path must equal stock
+dot_product_attention in VALUE and GRADIENTS — including causal masking, key
+padding, and query lengths that don't divide the block size — and the chunked
+CausalRefiner must preserve the no-future-leak invariant."""
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+from flax import nnx
+
+from attention import chunked_causal_attention
+from plan_a_model import CausalRefiner
+
+B, H, D = 1, 4, 8
+
+
+def _stock(q, k, v, pad_cols):
+    s = q.shape[1]
+    pos = jnp.arange(s)
+    causal = pos[:, None] >= pos[None, :]
+    bias = jnp.where(causal, 0.0, -1e9)[None, None, :, :] + pad_cols[:, None, None, :]
+    return jax.nn.dot_product_attention(q, k, v, bias=bias)
+
+
+def _rand_qkv(seed, s):
+    rng = np.random.default_rng(seed)
+    mk = lambda: jnp.asarray(rng.normal(size=(B, s, H, D)), jnp.float32)
+    q, k, v = mk(), mk(), mk()
+    pad_cols = jnp.where(jnp.arange(s) < s - 3, 0.0, -1e9)[None, :].astype(jnp.float32)
+    pad_cols = jnp.broadcast_to(pad_cols, (B, s))
+    return q, k, v, pad_cols
+
+
+def test_value_and_grad_parity_dividing_and_ragged():
+    for s, block_q in ((32, 16), (24, 16)):  # dividing and non-dividing
+        q, k, v, pad_cols = _rand_qkv(s, s)
+
+        out_c = chunked_causal_attention(q, k, v, pad_cols, block_q)
+        out_s = _stock(q, k, v, pad_cols)
+        np.testing.assert_allclose(np.asarray(out_c), np.asarray(out_s), rtol=1e-5, atol=1e-6)
+
+        # Gradient parity through a scalar loss that weights every element.
+        w = jnp.asarray(np.random.default_rng(7).normal(size=out_s.shape), jnp.float32)
+        g_c = jax.grad(lambda q, k, v: jnp.sum(chunked_causal_attention(q, k, v, pad_cols, block_q) * w),
+                       argnums=(0, 1, 2))(q, k, v)
+        g_s = jax.grad(lambda q, k, v: jnp.sum(_stock(q, k, v, pad_cols) * w),
+                       argnums=(0, 1, 2))(q, k, v)
+        for gc, gs, name in zip(g_c, g_s, "qkv"):
+            np.testing.assert_allclose(np.asarray(gc), np.asarray(gs), rtol=1e-4, atol=1e-6,
+                                       err_msg=f"grad w.r.t. {name} drifted (s={s})")
+
+
+def test_chunked_refiner_matches_stock_refiner():
+    """Full-model parity: same weights, flag on vs off — logits and a training
+    gradient must agree."""
+    kw = dict(dim=32, vocab_size=17, num_heads=4, num_encoder_layers=2,
+              max_depth=3, max_seq_len=40)
+    stock = CausalRefiner(**kw, chunked_attention=False, rngs=nnx.Rngs(0))
+    chunked = CausalRefiner(**kw, chunked_attention=True, rngs=nnx.Rngs(0))
+
+    tokens = jnp.asarray(np.random.default_rng(1).integers(0, 17, size=(2, 40)), jnp.int32)
+    np.testing.assert_allclose(np.asarray(chunked(tokens, depth=3)),
+                               np.asarray(stock(tokens, depth=3)), rtol=1e-4, atol=1e-5)
+
+    def loss(m):
+        return jnp.mean(m(tokens, depth=3) ** 2)
+
+    gs = jax.tree_util.tree_leaves(nnx.grad(loss)(stock))
+    gc = jax.tree_util.tree_leaves(nnx.grad(loss)(chunked))
+    for a, b in zip(gc, gs):
+        np.testing.assert_allclose(np.asarray(a), np.asarray(b), rtol=1e-3, atol=1e-6)
+
+
+def test_chunked_path_has_no_future_leak():
+    """Perturbing position j must leave logits at positions < j unchanged at
+    every depth — the same causality bar the stock refiner passes."""
+    model = CausalRefiner(dim=32, vocab_size=17, num_heads=4, num_encoder_layers=2,
+                          max_depth=4, max_seq_len=24, chunked_attention=True,
+                          rngs=nnx.Rngs(2))
+    rng = np.random.default_rng(5)
+    tokens = jnp.asarray(rng.integers(0, 17, size=(1, 24)), jnp.int32)
+    j = 15
+    perturbed = tokens.at[0, j].set((int(tokens[0, j]) + 1) % 17)
+    for depth in (1, 2, 4):
+        base = model(tokens, depth=depth)
+        pert = model(perturbed, depth=depth)
+        np.testing.assert_array_equal(
+            np.asarray(base[:, :j]), np.asarray(pert[:, :j]),
+            err_msg=f"future-token leak through the chunked path at depth {depth}",
+        )


### PR DESCRIPTION
## Summary
Kills the O(seq²) attention transient on the refiner: blockwise attention (query-block `lax.scan` inside a `custom_vjp` whose backward recomputes per block, saving no probabilities) — the same construction chunked CE (#19) proved, applied to the other quadratic tensor. **Measured: grad-step peak transient 1.946 → 1.094 GiB (−44%) at dim512/depth8; the `[·,16,512,512]` shapes leave the compiled HLO entirely.** Opt-in via `CHUNKED_ATTENTION=1`, default OFF. Relates #66 — the flag flip + GPU numbers close it from the box.

## What & why
`tools/mem_profile` (#51) names the refiner's biggest transient class: s² f32 attention scores/probabilities (~27 GiB total across the HLO, 1.9 GiB peak at the default config — the tensor class that OOM'd the dim960 fit-test). `attention.py` scores one 128-query block at a time (each block softmaxes over the full key axis — deliberately *not* online-softmax; nothing to get wrong there), f32 accumulation matching stock, causal mask + pad bias identical. Flag threads config → `RefinerForTraining` → `CausalRefiner` (which stays config-free); flag-off is the stock path byte-for-byte, and the reasoner/golden is untouched.

Pre-registered gates for flipping the default (in #66): dim960 GPU fit-test shows the headroom, wall-clock within +10% of stock, f16 GPU-lane tests green. Until then this is dormant code behind a default-off flag.

## Validation / smoke-test performed
- [x] `JAX_PLATFORMS=cpu pytest tests/ -q` passes locally (58 tests; golden + determinism untouched)
- Other checks run:
  - Parity tests: value + all three gradients vs stock autodiff (dividing + ragged blocks, key padding); full-model flag-on-vs-off parity in logits and training gradients; **multi-block + padded model-level test (seq 160 > block 128)**; no-future-leak invariant on the chunked path at every depth; f16 parity test pinned to the GPU lane for when the box is back.
  - `tools/mem_profile --arch refiner --depth 8` before/after: peak temp 1.946 → 1.094 GiB; footprint 2.528 → 1.677 GiB; no [512,512] buffer in the chunked HLO (forward or backward).
  - **code-reviewer agent verdict: `comment`** — independently re-derived the softmax-attention gradient and matched the implementation term by term; probed batched ragged padding (≤7e-7 drift), fully-masked rows (no NaN), f16 (matches stock's own f32 drift); confirmed flag-off is a no-op and the checkpoint tree is unchanged. Its three low findings (multi-block model test, f16 lane, docstring wording) are applied in the follow-up commit.

## Risk
Default-off: merging changes nothing about any run until `CHUNKED_ATTENTION=1`. When flipped: numerics are allclose-not-bit-exact to stock (block loop reorders float sums — same class of intentional change as #19), so the golden story is unaffected (goldens cover the reasoner). Known cost: backward recomputes each block's scores (~one extra partial forward of attention when ON) — the wall-clock gate on the box decides whether that trade is paid.

## Checklist
- [x] Did not weaken or delete any test (no skips/xfails/loosened asserts to make it pass)
- [x] Smoke-tested; no multi-hour run was launched without sign-off
- [x] Pinned deps unchanged, or the bump is justified above
- [x] Findings/claims backed by evidence in the PR or a linked finding issue

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HjZBFh2K2krkZJmFaxh6V2

---
_Generated by [Claude Code](https://claude.ai/code/session_01HjZBFh2K2krkZJmFaxh6V2)_