### PR TITLE
Ablation: slots-only readout — the serial scratchpad's compression is real (#62)

### DIFF
--- a/docs/findings/2026-07-04-slots-only-readout-compression-real.md
+++ b/docs/findings/2026-07-04-slots-only-readout-compression-real.md
@@ -1,0 +1,54 @@
+# The serial scratchpad's compression is real: a readout blinded to the tokens stays within noise of the full readout
+
+Status: toy-proof (the #62 gate; strengthens the #38 interpretation)
+Date: 2026-07-04
+Commit: c664951  Run: tiny-config ablation (synthetic, no runs/ id)  Measured with: `JAX_PLATFORMS=cpu FORCE_F32_COMPUTE=1 python scratchpad_harness.py --arms serial,slotsonly --seeds 0,1,2 --K 4 --m 7 --steps 2500`
+
+## Setup
+
+The #38 win left one door open: the answer readout attended to `tokens + slots`,
+so the slots could have been decorative while the readout secretly re-derived
+the answer from the problem tokens. #62 closes it with one data-flow change and
+an identical parameter tree: the `slotsonly` arm removes the token states from
+the readout's context — if the slots carry the computation, blinding the
+readout should cost nothing.
+
+Same protocol as the #38 gate: affine chain K=4, m=7, dim 64, 2500 steps,
+held-out 4096, seeds {0,1,2}, matched pairs (same seed ⇒ same pools). A wiring
+guard (tests/test_scratchpad_harness.py) proves the blind readout has exactly
+zero gradient from token states, and that the control's token path is live.
+Pre-registered: slots-only within 2σ_pooled of tokens+slots → compression real;
+collapse toward the parallel/chance regime (≈0.19 / 0.14) → slots decorative
+and #38 needs a caveat.
+
+## Evidence
+
+Held-out final-answer accuracy:
+
+| arm | seed 0 | seed 1 | seed 2 | mean | σ |
+|---|---|---|---|---|---|
+| serial (tokens+slots) | 0.9988 | 0.9790 | 0.9988 | 0.9922 | 0.011 |
+| slots-only | 0.9370 | 0.8767 | 0.9983 | **0.9373** | 0.061 |
+
+The serial control reproduces the #38 numbers exactly (the readout refactor
+changed nothing). Delta = 0.055 < 2σ_pooled = 0.088 → **within noise:
+compression is real**. And categorically: 0.94 is nowhere near the 0.19
+decorative regime — the answer is being read out of the slots.
+
+Where the small gap lives, made visible by the per-slot grades: in both arms
+final accuracy ≈ slot-4 accuracy (blind: 0.939/0.872/0.999 slot-4 vs
+0.937/0.877/0.998 final). The blinded readout converts its last slot
+essentially losslessly; what varies is how well the *write chain* forms
+r₄ under different seeds. So the deficit, such as it is, sits in chain
+formation during training — not in the readout re-reading the problem.
+
+## Limitations
+
+- 3 seeds; the blind arm's seed spread (σ=0.061) is ~5× the control's. The
+  5.5pp mean gap is sub-threshold by the pre-registered bar but not obviously
+  zero — more seeds would resolve whether blinding carries a real few-point
+  training-dynamics cost (plausible: with tokens removed, all answer-loss
+  gradient pressure lands on the slot chain).
+- Toy scale, K=4, one task family — same license boundary as #38: this
+  strengthens the mechanism's interpretation, it does not upgrade the claim to
+  LM scale.

--- a/scratchpad_harness.py
+++ b/scratchpad_harness.py
@@ -10,6 +10,11 @@ Three arms on the chained-affine-maps task (docs/design/serial-scratchpad.md):
               matched control: exactly one variable removed.
   depthonly — CausalRefiner at depth K, final-answer supervision only. The
               is-it-just-depth control.
+  slotsonly — serial arm, but the answer readout sees ONLY the slots (tokens
+              removed from its context; identical parameters again). The #62
+              compression probe: if the slots really carry the computation, a
+              readout blinded to the tokens costs nothing; if accuracy
+              collapses, the readout was secretly re-reading the problem.
 
 Task: r_0 = 0; r_k = (r_{k-1} * a_k + b_k) mod m from tokens [a_1 b_1 ... a_K b_K].
 Affine composition mod m is non-commutative — no order-free shortcut — and
@@ -91,14 +96,17 @@ class ScratchpadNet(nnx.Module):
     serial=True:  slot k's write context is tokens + slots 1..k-1 (order by
                   construction; each slot written exactly once, then frozen).
     serial=False: all K slots written in ONE call, context is tokens only.
-    Both modes share the identical parameter tree — `serial` only changes the
-    data flow, which is what makes serial-vs-parallel a one-variable ablation.
+    read_tokens=False: the answer readout's context is the slots alone — token
+                  states never reach it (#62).
+    All modes share the identical parameter tree — the flags only change the
+    data flow, which is what makes each comparison a one-variable ablation.
     """
 
     def __init__(self, *, dim, vocab, num_slots, num_heads=4, num_encoder_layers=2,
-                 max_seq_len=64, serial=True, rngs, dtype=jnp.float32):
+                 max_seq_len=64, serial=True, read_tokens=True, rngs, dtype=jnp.float32):
         self.num_slots = num_slots
         self.serial = serial
+        self.read_tokens = read_tokens
         self.embed = nnx.Embed(vocab, dim, rngs=rngs, dtype=dtype)
         self.encoder = nnx.List([
             Block(dim, num_heads, max_seq_len, rngs, dtype) for _ in range(num_encoder_layers)
@@ -129,10 +137,16 @@ class ScratchpadNet(nnx.Module):
             slots = self.write_block(queries, h)                            # one step, tokens only
 
         slot_logits = self.slot_readout(slots)                              # [B, K, m]
+        return self.readout(h, slots), slot_logits
+
+    def readout(self, h, slots):
+        """Answer logits from the readout context. A separate method so the #62
+        wiring guard can probe it directly: with read_tokens=False the token
+        states must be unable to influence the answer except through slots."""
+        bsz = h.shape[0]
+        ctx = jnp.concatenate([h, slots], axis=1) if self.read_tokens else slots
         aq = jnp.broadcast_to(self.answer_query[...].astype(h.dtype), (bsz, 1, h.shape[-1]))
-        a = self.read_block(aq, jnp.concatenate([h, slots], axis=1))
-        answer_logits = self.answer_head(a)[:, 0]                           # [B, m]
-        return answer_logits, slot_logits
+        return self.answer_head(self.read_block(aq, ctx))[:, 0]            # [B, m]
 
 
 def n_params(model):
@@ -154,7 +168,8 @@ def train_one_arm(arm, *, K=4, m=7, dim=64, heads=4, enc=2, steps=2500, batch=25
     else:
         model = ScratchpadNet(dim=dim, vocab=m, num_slots=K, num_heads=heads,
                               num_encoder_layers=enc, max_seq_len=2 * K,
-                              serial=(arm == "serial"), rngs=nnx.Rngs(seed))
+                              serial=(arm in ("serial", "slotsonly")),
+                              read_tokens=(arm != "slotsonly"), rngs=nnx.Rngs(seed))
     opt = nnx.Optimizer(model, optax.adamw(lr, weight_decay=wd), wrt=nnx.Param)
 
     def losses(mdl, tok, sub):
@@ -197,7 +212,8 @@ def train_one_arm(arm, *, K=4, m=7, dim=64, heads=4, enc=2, steps=2500, batch=25
 
 def main():
     ap = argparse.ArgumentParser()
-    ap.add_argument("--arms", default="serial,parallel,depthonly")
+    ap.add_argument("--arms", default="serial,parallel,depthonly",
+                    help="any of serial,parallel,depthonly,slotsonly (#62)")
     ap.add_argument("--seeds", default="0,1,2")
     ap.add_argument("--K", type=int, default=4, help="number of chained sub-steps = number of slots")
     ap.add_argument("--m", type=int, default=7, help="modulus (prime); vocab and chance level 1/m")

--- a/tests/test_scratchpad_harness.py
+++ b/tests/test_scratchpad_harness.py
@@ -70,10 +70,50 @@ def test_slot_order_flow_is_the_one_variable():
         "serial: slot 0 must not depend on slot 1"
 
 
+def test_slotsonly_readout_cannot_see_token_states():
+    """#62 wiring guard, same style as the order-flow guard: the slots-only
+    readout must have exactly zero gradient from the token states it was
+    blinded to — otherwise the ablation isn't measuring what it claims —
+    while the tokens+slots readout must have a live token path."""
+    tokens, _ = affine_chain_task(K, M)(jax.random.PRNGKey(2), 4)
+
+    def token_grad_into_answer(read_tokens):
+        model = ScratchpadNet(dim=DIM, vocab=M, num_slots=K, max_seq_len=2 * K,
+                              serial=True, read_tokens=read_tokens, rngs=nnx.Rngs(0))
+        h = model.embed(tokens)
+        for blk in model.encoder:
+            h = blk(h)
+        queries = model.slot_index(jnp.arange(K))[None].repeat(4, axis=0)
+        slots = []
+        for k in range(K):
+            ctx = jnp.concatenate([h] + slots, axis=1) if slots else h
+            slots.append(model.write_block(queries[:, k:k + 1], ctx))
+        slots = jnp.concatenate(slots, axis=1)
+        # Differentiate the answer w.r.t. the token states AT THE READOUT ONLY
+        # (slots held fixed): any nonzero grad is a direct token->answer path.
+        g = jax.grad(lambda hh: jnp.sum(model.readout(hh, slots)))(h)
+        return float(jnp.abs(g).max())
+
+    assert token_grad_into_answer(read_tokens=False) == 0.0, \
+        "slotsonly: the readout must be blind to token states"
+    assert token_grad_into_answer(read_tokens=True) > 0.0, \
+        "serial: the tokens+slots readout must actually read the tokens"
+
+
+def test_slotsonly_shares_the_serial_param_tree():
+    serial = ScratchpadNet(dim=DIM, vocab=M, num_slots=K, max_seq_len=2 * K,
+                           serial=True, read_tokens=True, rngs=nnx.Rngs(0))
+    blind = ScratchpadNet(dim=DIM, vocab=M, num_slots=K, max_seq_len=2 * K,
+                          serial=True, read_tokens=False, rngs=nnx.Rngs(0))
+    for sl, bl in zip(jax.tree_util.tree_leaves(nnx.state(serial, nnx.Param)),
+                      jax.tree_util.tree_leaves(nnx.state(blind, nnx.Param))):
+        np.testing.assert_array_equal(np.asarray(sl), np.asarray(bl))
+
+
 def test_all_arms_train_and_beat_nothing_burns():
     """Full train/eval path runs for every arm at toy size, losses finite, and
     the graded arms report per-slot accuracies (the collapse detector)."""
-    for arm in ("serial", "parallel", "depthonly"):
+    for arm in ("serial", "parallel", "depthonly", "slotsonly"):
         acc, slot_acc, params = train_one_arm(arm, K=K, m=M, dim=DIM, steps=40,
                                               batch=64, n_pool=512, n_test=128, seed=0)
         assert np.isfinite(acc) and 0.0 <= acc <= 1.0, f"{arm}: bad final acc {acc}"


### PR DESCRIPTION
## Summary
The #62 compression probe: blind the answer readout to the token states (slots-only context, identical parameter tree) and see if the #38 win survives. It does — slots-only lands at 0.9373 vs the control's 0.9922, delta 0.055 < the pre-registered 2σ_pooled bar of 0.088, and nowhere near the decorative regime (≈0.19). The slots genuinely carry the computation.

Closes #62

## What & why
- `scratchpad_harness.py` — new `slotsonly` arm: `read_tokens=False` removes token states from the answer readout's context. One data-flow flag, zero parameter changes (mirrors the serial/parallel one-variable design). The readout moved into a `readout(h, slots)` method so the wiring guard can probe it directly.
- `tests/test_scratchpad_harness.py` — two new guards: the blind readout has *exactly zero* gradient from token states (and the control's token path is live), and the slotsonly/serial param trees are byte-identical. The train-path smoke now covers all four arms.
- `docs/findings/2026-07-04-slots-only-readout-compression-real.md` — the result, including the mechanism note: in both arms final accuracy ≈ slot-4 accuracy, so the small mean gap is chain-formation noise under training dynamics, not the readout re-reading the problem. Honest caveat recorded: the blind arm's seed spread is ~5× the control's at 3 seeds.

## Validation / smoke-test performed
- [x] `JAX_PLATFORMS=cpu pytest tests/ -q` passes locally (harness + yardstick files re-run at HEAD; full suite green earlier on this branch)
- Other checks run:
  - The experiment itself: `--arms serial,slotsonly --seeds 0,1,2 --K 4 --m 7 --steps 2500` (CPU, FORCE_F32_COMPUTE=1). The serial control reproduces the #38 numbers **exactly** (0.9988/0.9790/0.9988) — the readout refactor changed nothing.
  - `ruff check` clean on touched files.

## Risk
- Harness + tests + docs only; no production model, trainer, checkpoint, or data-path changes. The `ScratchpadNet.__call__` refactor is behavior-preserving for existing arms — proven by the control reproducing #38's accuracies to the fourth digit.

## Checklist
- [x] Did not weaken or delete any test (no skips/xfails/loosened asserts to make it pass)
- [x] Smoke-tested; no multi-hour run was launched without sign-off
- [x] Pinned deps unchanged, or the bump is justified above
- [x] Findings/claims backed by evidence in the PR or a linked finding issue

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011eT1nXf64hwcMKkNwA3eeh

---
_Generated by [Claude Code](https://claude.ai/code/session_011eT1nXf64hwcMKkNwA3eeh)_