### PR TITLE
Milestone diagnostics report (#20) + final-only supervision ablation: decomposition is taught (#67)

### DIFF
--- a/docs/findings/2026-07-04-final-only-supervision-decomposition-is-taught.md
+++ b/docs/findings/2026-07-04-final-only-supervision-decomposition-is-taught.md
@@ -1,0 +1,77 @@
+# Final-answer-only supervision collapses the serial scratchpad to chance — the decomposition is taught by the grade, not induced by structure
+
+Status: toy-proof (the #67 gate; bounds the #38 interpretation)
+Date: 2026-07-04
+Commit: 452b2a5  Run: tiny-config ablation (synthetic, no runs/ id)  Measured with: `JAX_PLATFORMS=cpu FORCE_F32_COMPUTE=1 python scratchpad_harness.py --arms serial,finalonly --seeds 0,1,2 --K 4 --m 7 --steps 2500`
+
+## Setup
+
+The missing cell in the #38 design matrix: serial (#38) had order + per-slot
+grade and won; parallel had the grade but no order and failed; depthonly had
+neither and sat at chance. #67 asks whether the grade or the structure carries
+the win — the `finalonly` arm keeps the serial wiring and parameters exactly
+(ordered write-once slots, slot k reads tokens + slots < k) but detaches the
+slot grade behind a stop-gradient, so final-answer CE is the model's only
+teacher. The slot readout still trains — on stop-gradiented slots — so it acts
+as a pure linear probe of what each slot carries without being able to teach
+the slots (wiring guard: tests/test_scratchpad_harness.py proves the slot CE
+has exactly zero gradient into everything upstream of the readout head).
+
+Same protocol as the #38 gate: affine chain K=4, m=7, dim 64, 2500 steps,
+held-out 4096, seeds {0,1,2}, matched pairs (same seed ⇒ same pools; serial
+control re-run on the same machine and reproducing the #38 numbers exactly).
+Pre-registered on the issue: within 2σ_pooled of the graded serial (~0.99) →
+**emergent**; collapse toward the depthonly/chance regime (~0.14) → **taught**;
+clearly between → partial, report where the slot chain breaks.
+
+## Evidence
+
+Held-out final-answer accuracy:
+
+| arm | seed 0 | seed 1 | seed 2 | mean | σ |
+|---|---|---|---|---|---|
+| serial (graded, #38 control) | 0.9988 | 0.9790 | 0.9988 | 0.9922 | 0.011 |
+| finalonly | 0.1299 | 0.1372 | 0.1353 | **0.1341** | 0.004 |
+
+Chance = 1/7 ≈ 0.143; the #38 depthonly control was 0.1397 ± 0.010. The verdict
+is not close: finalonly sits 0.858 below the graded serial (~101× σ_pooled =
+0.0085, bar was 2σ) and *inside* the depthonly/chance regime (0.7σ below its
+mean). **Taught**, at the pre-registered extreme.
+
+The probe readout shows where the chain never forms:
+
+| arm | slot 1 (r₁) | slot 2 | slot 3 | slot 4 |
+|---|---|---|---|---|
+| serial (graded) | 1.000 | 0.999 | 0.997 | 0.991 |
+| finalonly (probe) | 0.31–0.43 | 0.14 | 0.14 | 0.14 |
+
+Slot 1 is weakly decodable above chance (r₁ = b₁, a shallow copy the write
+block picks up incidentally); slots 2–4 carry nothing a linear probe can find.
+Without the grade the model doesn't build a partial chain that a final-only
+loss then fails to extend — it builds *no* chain, and the final answer never
+leaves chance. Structure (order + write-once + capacity) supplied the road;
+nothing drove on it.
+
+## What this bounds
+
+- The #38 win decomposes as: structure is *necessary* (parallel failed with the
+  grade) but not *sufficient* (finalonly fails with the structure). The
+  per-slot grade is load-bearing — it is what pulls the model onto the serial
+  decomposition, and the slots then genuinely carry it (#62).
+- For the LM-scale version this is the expensive branch: natural compression
+  will not self-organize just from giving the model ordered write-once slots;
+  it needs per-step targets (synthetic intermediate supervision or an
+  equivalent curriculum). That cost is now a known input to the bet, before
+  anything was built at scale.
+
+## Limitations
+
+- Toy scale, one task family, K=4, 2500 steps — a longer budget or an
+  annealed grade (start supervised, decay λ) might still find the chain; this
+  result kills "it emerges for free", not "it can never be induced".
+- The probe is linear and trained online; a stronger nonlinear probe could in
+  principle find structure a linear one misses, but the final answer sitting
+  at chance says there was nothing usable to find.
+- The optimization story (final-only gradient signal through 4 chained
+  cross-attention writes is weak/noisy) is a plausible mechanism but untested
+  here; it does not change the practical bound.

--- a/docs/findings/README.md
+++ b/docs/findings/README.md
@@ -7,6 +7,21 @@ Everything here must be reproducible from what the entry records: the commit has
 the run id, and the measurement command. If a claim can't be traced to those three
 things, it doesn't go in this folder.
 
+## Entries
+
+- `2026-06-11-slot-future-leak.md` — latent-scratchpad memory slots leaked future tokens into past predictions
+- `2026-06-13-cross-window-hunch-inert.md` — the cross-window "hunch" gives no next-window benefit (graveyard)
+- `2026-06-13-plan-a-depth-recurrence-works.md` — Plan A depth recurrence earns its compute on state-tracking (#16)
+- `2026-06-14-plan-a-integrated-into-trainer.md` — CausalRefiner integrated into the production trainer
+- `2026-06-16-plan-a-depth-ablation.md` — Plan A depth ablation on the toy tasks
+- `2026-06-18-plan-a-depth-transfer.md` — Plan A depth survives LM pretraining, exploited better than from scratch
+- `2026-06-19-plan-a-depth-dense-sweep.md` — dense sweep corrects the d8 read: depth plateaus by ~d6
+- `2026-07-03-serial-scratchpad-beats-controls.md` — #38: graded serial slots beat both controls, order is the variable
+- `2026-07-03-weight-tying-memorization-null.md` — weight-tying memorization/generalization trade: null both ways
+- `2026-07-04-gpt2-yardstick-calibrated.md` — the GPT-2-small yardstick reproduces the reference reading (#48)
+- `2026-07-04-slots-only-readout-compression-real.md` — #62: a readout blinded to tokens stays within noise; compression real
+- `2026-07-04-final-only-supervision-decomposition-is-taught.md` — #67: without the per-slot grade the scratchpad sits at chance; the decomposition is taught, not emergent
+
 ## Entry template
 
 ```markdown

--- a/scratchpad_harness.py
+++ b/scratchpad_harness.py
@@ -1,6 +1,6 @@
-"""Toy proof harness for the supervised serial latent scratchpad (#38).
+"""Toy proof harness for the supervised serial latent scratchpad (#38, #62, #67).
 
-Three arms on the chained-affine-maps task (docs/design/serial-scratchpad.md):
+Five arms on the chained-affine-maps task (docs/design/serial-scratchpad.md):
 
   serial    — K ordered sub-slots, each written ONCE by a shared cross-attention
               write block reading tokens + EARLIER slots only, each graded
@@ -15,6 +15,10 @@ Three arms on the chained-affine-maps task (docs/design/serial-scratchpad.md):
               compression probe: if the slots really carry the computation, a
               readout blinded to the tokens costs nothing; if accuracy
               collapses, the readout was secretly re-reading the problem.
+  finalonly — serial wiring and parameters, but the slot grade is detached
+              (stop-gradient probe): the model is taught by final-answer CE
+              only, while the readout head still measures what each slot
+              carries. The does-the-decomposition-emerge ablation (#67).
 
 Task: r_0 = 0; r_k = (r_{k-1} * a_k + b_k) mod m from tokens [a_1 b_1 ... a_K b_K].
 Affine composition mod m is non-commutative — no order-free shortcut — and
@@ -98,15 +102,23 @@ class ScratchpadNet(nnx.Module):
     serial=False: all K slots written in ONE call, context is tokens only.
     read_tokens=False: the answer readout's context is the slots alone — token
                   states never reach it (#62).
+    probe_only=True: the slot grade becomes a diagnostic-only linear probe —
+                  the slots are stop-gradiented before the readout, so the
+                  slot CE can fit the readout head but can never teach the
+                  slots. Final-answer CE becomes the model's only supervision
+                  (#67), with the slot-by-slot readout kept as the instrument
+                  that shows whether the decomposition emerged anyway.
     All modes share the identical parameter tree — the flags only change the
     data flow, which is what makes each comparison a one-variable ablation.
     """
 
     def __init__(self, *, dim, vocab, num_slots, num_heads=4, num_encoder_layers=2,
-                 max_seq_len=64, serial=True, read_tokens=True, rngs, dtype=jnp.float32):
+                 max_seq_len=64, serial=True, read_tokens=True, probe_only=False,
+                 rngs, dtype=jnp.float32):
         self.num_slots = num_slots
         self.serial = serial
         self.read_tokens = read_tokens
+        self.probe_only = probe_only
         self.embed = nnx.Embed(vocab, dim, rngs=rngs, dtype=dtype)
         self.encoder = nnx.List([
             Block(dim, num_heads, max_seq_len, rngs, dtype) for _ in range(num_encoder_layers)
@@ -136,7 +148,8 @@ class ScratchpadNet(nnx.Module):
         else:
             slots = self.write_block(queries, h)                            # one step, tokens only
 
-        slot_logits = self.slot_readout(slots)                              # [B, K, m]
+        graded = jax.lax.stop_gradient(slots) if self.probe_only else slots
+        slot_logits = self.slot_readout(graded)                             # [B, K, m]
         return self.readout(h, slots), slot_logits
 
     def readout(self, h, slots):
@@ -168,8 +181,9 @@ def train_one_arm(arm, *, K=4, m=7, dim=64, heads=4, enc=2, steps=2500, batch=25
     else:
         model = ScratchpadNet(dim=dim, vocab=m, num_slots=K, num_heads=heads,
                               num_encoder_layers=enc, max_seq_len=2 * K,
-                              serial=(arm in ("serial", "slotsonly")),
-                              read_tokens=(arm != "slotsonly"), rngs=nnx.Rngs(seed))
+                              serial=(arm != "parallel"),
+                              read_tokens=(arm != "slotsonly"),
+                              probe_only=(arm == "finalonly"), rngs=nnx.Rngs(seed))
     opt = nnx.Optimizer(model, optax.adamw(lr, weight_decay=wd), wrt=nnx.Param)
 
     def losses(mdl, tok, sub):
@@ -180,7 +194,10 @@ def train_one_arm(arm, *, K=4, m=7, dim=64, heads=4, enc=2, steps=2500, batch=25
             return ce_final, (logits, None)
         answer_logits, slot_logits = mdl(tok)
         ce_final = optax.softmax_cross_entropy_with_integer_labels(answer_logits, final).mean()
-        # The grade: λ fixed at 1.0 (pre-registered — see the design doc).
+        # The grade: λ fixed at 1.0 (pre-registered — see the design doc). In
+        # the finalonly arm the slots are stop-gradiented inside the model, so
+        # this same term only fits the diagnostic probe head — the model's
+        # sole teacher there is ce_final (#67).
         ce_slots = optax.softmax_cross_entropy_with_integer_labels(slot_logits, sub).mean()
         return ce_final + slot_lambda * ce_slots, (answer_logits, slot_logits)
 
@@ -213,7 +230,7 @@ def train_one_arm(arm, *, K=4, m=7, dim=64, heads=4, enc=2, steps=2500, batch=25
 def main():
     ap = argparse.ArgumentParser()
     ap.add_argument("--arms", default="serial,parallel,depthonly",
-                    help="any of serial,parallel,depthonly,slotsonly (#62)")
+                    help="any of serial,parallel,depthonly,slotsonly (#62),finalonly (#67)")
     ap.add_argument("--seeds", default="0,1,2")
     ap.add_argument("--K", type=int, default=4, help="number of chained sub-steps = number of slots")
     ap.add_argument("--m", type=int, default=7, help="modulus (prime); vocab and chance level 1/m")

--- a/tests/test_milestone_report.py
+++ b/tests/test_milestone_report.py
@@ -1,0 +1,45 @@
+"""Milestone report wrapper: cheap CPU checks, no checkpoint or GPU needed.
+
+The wrapper must tolerate a failing diagnostic (report it, keep going) and
+degrade gracefully when there is nothing to report on.
+"""
+
+import os
+import subprocess
+import sys
+
+REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+SCRIPT = os.path.join(REPO_ROOT, "tools", "milestone_report.py")
+
+
+def test_section_failure_is_tolerated_and_labeled():
+    from tools.milestone_report import run_section
+
+    failed = run_section("boom", lambda: 1 / 0)
+    assert failed["status"] == "FAILED"
+    assert "ZeroDivisionError" in failed["body"]
+
+    ok = run_section("fine", lambda: "all good")
+    assert ok["status"] == "ok"
+    assert ok["body"] == "all good"
+
+
+def _run(args, cwd):
+    env = dict(os.environ, PYTHONPATH=REPO_ROOT, JAX_PLATFORMS="cpu", FORCE_F32_COMPUTE="1")
+    return subprocess.run([sys.executable, SCRIPT, *args], cwd=cwd,
+                          env=env, capture_output=True, text=True, timeout=300)
+
+
+def test_help_is_fast_and_clean(tmp_path):
+    proc = _run(["--help"], cwd=tmp_path)
+    assert proc.returncode == 0, proc.stderr
+    assert "--ckpt" in proc.stdout
+
+
+def test_no_checkpoint_degrades_gracefully(tmp_path):
+    # Empty cwd: no runs/ at all. Must exit nonzero with a clear message,
+    # not a traceback.
+    proc = _run([], cwd=tmp_path)
+    assert proc.returncode != 0
+    assert "No checkpoint found" in proc.stderr + proc.stdout
+    assert "Traceback" not in proc.stderr

--- a/tests/test_scratchpad_harness.py
+++ b/tests/test_scratchpad_harness.py
@@ -8,6 +8,7 @@ live gradient path — not a bonus the optimizer can ignore."""
 import jax
 import jax.numpy as jnp
 import numpy as np
+import optax
 from flax import nnx
 
 from scratchpad_harness import ScratchpadNet, affine_chain_task, n_params, train_one_arm
@@ -110,10 +111,38 @@ def test_slotsonly_shares_the_serial_param_tree():
         np.testing.assert_array_equal(np.asarray(sl), np.asarray(bl))
 
 
+def test_finalonly_grade_is_a_detached_probe():
+    """finalonly (#67): the slot CE must reach ONLY the readout head — every
+    parameter upstream of the slots (write block, encoder, slot indices) gets
+    zero gradient from the grade, so final-answer CE is the model's sole
+    teacher. The graded serial arm must keep the grade live, unchanged."""
+    tokens, subs = affine_chain_task(K, M)(jax.random.PRNGKey(2), 8)
+
+    def slot_ce_grads(probe_only):
+        model = ScratchpadNet(dim=DIM, vocab=M, num_slots=K, max_seq_len=2 * K,
+                              serial=True, probe_only=probe_only, rngs=nnx.Rngs(0))
+
+        def slot_ce(mdl):
+            _, slot_logits = mdl(tokens)
+            return optax.softmax_cross_entropy_with_integer_labels(slot_logits, subs).mean()
+
+        return nnx.to_flat_state(nnx.grad(slot_ce)(model))
+
+    for path, leaf in slot_ce_grads(probe_only=True):
+        mx = float(jnp.abs(leaf[...]).max())
+        if path[0] == "slot_readout":
+            assert mx > 0.0, "probe head itself must still train"
+        else:
+            assert mx == 0.0, f"grade leaked upstream into {'/'.join(map(str, path))}"
+    assert any(path[0] == "write_block" and float(jnp.abs(leaf[...]).max()) > 0.0
+               for path, leaf in slot_ce_grads(probe_only=False)), \
+        "graded arm: slot CE must still teach the write block"
+
+
 def test_all_arms_train_and_beat_nothing_burns():
     """Full train/eval path runs for every arm at toy size, losses finite, and
     the graded arms report per-slot accuracies (the collapse detector)."""
-    for arm in ("serial", "parallel", "depthonly", "slotsonly"):
+    for arm in ("serial", "parallel", "depthonly", "slotsonly", "finalonly"):
         acc, slot_acc, params = train_one_arm(arm, K=K, m=M, dim=DIM, steps=40,
                                               batch=64, n_pool=512, n_test=128, seed=0)
         assert np.isfinite(acc) and 0.0 <= acc <= 1.0, f"{arm}: bad final acc {acc}"

--- a/tools/common.py
+++ b/tools/common.py
@@ -9,10 +9,20 @@ import os
 from flax import nnx
 import orbax.checkpoint as ocp
 
-from config import LATENT_DIM, BATCH_SIZE, resolve_root
+from config import LATENT_DIM, BATCH_SIZE, MODEL_ARCH, resolve_root
 from model import UniversalReasoner
 from data_loaders import TextDataGenerator
 from checkpoint_utils import discover_latest_checkpoint_run
+
+
+def build_model():
+    """Fresh model matching MODEL_ARCH. The two arches have different param
+    trees, so a restore must build the same arch the checkpoint was trained as
+    (select it at launch, e.g. MODEL_ARCH=refiner)."""
+    if MODEL_ARCH == "refiner":
+        from plan_a_trainer import RefinerForTraining
+        return RefinerForTraining(LATENT_DIM, nnx.Rngs(42))
+    return UniversalReasoner(LATENT_DIM, nnx.Rngs(42))
 
 
 def restore_model(checkpoint_path=None):
@@ -24,7 +34,7 @@ def restore_model(checkpoint_path=None):
         print(f"🔎 Using latest checkpointed run: {run_id}")
     checkpoint_path = os.path.abspath(checkpoint_path)
 
-    model = UniversalReasoner(LATENT_DIM, nnx.Rngs(42))
+    model = build_model()
     mngr = ocp.CheckpointManager(
         checkpoint_path,
         item_names=("model", "optimizer", "monitor_state", "step"),

--- a/tools/common.py
+++ b/tools/common.py
@@ -9,7 +9,7 @@ import os
 from flax import nnx
 import orbax.checkpoint as ocp
 
-from config import LATENT_DIM, BATCH_SIZE, resolve_root
+from config import LATENT_DIM, BATCH_SIZE, MODEL_ARCH, resolve_root
 from model import UniversalReasoner
 from data_loaders import TextDataGenerator
 from checkpoint_utils import discover_latest_checkpoint_run
@@ -40,8 +40,25 @@ def _restore_into(model, checkpoint_path):
     return model, latest
 
 
+def build_model():
+    """Fresh skeleton matching MODEL_ARCH. The two arches have different param
+    trees, so a restore must build the same arch the checkpoint was trained as
+    (select it at launch, e.g. MODEL_ARCH=refiner)."""
+    if MODEL_ARCH == "refiner":
+        from plan_a_trainer import RefinerForTraining
+        return RefinerForTraining(LATENT_DIM, nnx.Rngs(42))
+    return UniversalReasoner(LATENT_DIM, nnx.Rngs(42))
+
+
 def restore_model(checkpoint_path=None):
-    """Model-only restore from a checkpoint dir, defaulting to the latest run's."""
+    """Model-only restore from a checkpoint dir, defaulting to the latest run's.
+    Builds the skeleton per MODEL_ARCH; use restore_reasoner/restore_refiner to
+    pin an arch explicitly (e.g. eval_yardstick's --arch override)."""
+    return _restore_into(build_model(), checkpoint_path)
+
+
+def restore_reasoner(checkpoint_path=None):
+    """Reasoner restore regardless of MODEL_ARCH, for explicit --arch overrides."""
     return _restore_into(UniversalReasoner(LATENT_DIM, nnx.Rngs(42)), checkpoint_path)
 
 

--- a/tools/eval_depth_curve.py
+++ b/tools/eval_depth_curve.py
@@ -26,7 +26,7 @@ import optax
 from flax import nnx
 from dotenv import load_dotenv
 
-from config import MAX_SEQ_LEN, MAX_STEPS_LIMIT, PAD_TOKEN_ID
+from config import MAX_SEQ_LEN, MAX_STEPS_LIMIT, MODEL_ARCH, PAD_TOKEN_ID
 
 load_dotenv()
 
@@ -58,6 +58,12 @@ def main():
     parser.add_argument("--skip", type=int, default=3_000_000, help="samples to skip so eval data is past the trained range")
     parser.add_argument("--source", type=str, default="pretrain/fineweb-edu", help="data subdirectory under DATA_ROOT")
     args = parser.parse_args()
+
+    if MODEL_ARCH == "refiner":
+        raise SystemExit(
+            "eval_depth_curve probes the reasoner's cross-window hunch; the refiner has none "
+            "(its hunch_cache is a vestigial zero buffer). Use tools/eval_refiner_depth_transfer.py instead."
+        )
 
     model, ckpt_step = restore_model(args.checkpoint_path)
     batches = load_eval_batches(args.source, args.batches, args.skip)

--- a/tools/eval_yardstick.py
+++ b/tools/eval_yardstick.py
@@ -36,7 +36,7 @@ from flax import nnx
 from dotenv import load_dotenv
 
 from config import BATCH_SIZE, MAX_SEQ_LEN, PAD_TOKEN_ID, TOKENIZER_NAME, MODEL_ARCH
-from tools.common import restore_model, restore_refiner
+from tools.common import restore_reasoner, restore_refiner
 from tools.yardstick import (
     GPT2_SMALL_REFERENCE,
     LAMBADA_SHA256,
@@ -111,7 +111,7 @@ def main():
         # BATCH_SIZE; its forward asserts on any other leading dim.
         print(f"⚠️ reasoner arch: clamping --batch {args.batch} -> {BATCH_SIZE}.")
         args.batch = BATCH_SIZE
-    restore = {"reasoner": restore_model, "refiner": restore_refiner}[args.arch]
+    restore = {"reasoner": restore_reasoner, "refiner": restore_refiner}[args.arch]
     model, step = restore(args.checkpoint_path)
 
     path = args.data_path or fetch_lambada()

--- a/tools/milestone_report.py
+++ b/tools/milestone_report.py
@@ -1,0 +1,193 @@
+"""One milestone report per checkpoint — every offline diagnostic, one document.
+
+Convenience layer over the tools we already have; it adds no new instrumentation.
+Against the latest (or a given) checkpoint it runs, in order:
+
+  1. Depth curve — arch-aware, because the two arches ask different depth questions:
+       reasoner: tools/eval_depth_curve.py (window-2 CE vs window-1 hunch depth;
+                 its "fresh" baseline IS the carried-vs-fresh hunch comparison —
+                 that diagnostic was folded into this tool, and the hunch is proven
+                 inert: docs/findings/2026-06-13-cross-window-hunch-inert.md)
+       refiner:  tools/eval_refiner_depth_transfer.py (depth-swept held-out CE by domain)
+  2. Fixed-prompt transcripts — tools/dump_transcripts.py (the systematized vibes eval)
+  3. Held-out validation CE — trainer.ValidationProbe, the same fixed batches and
+     depth the training loop scores, so the number is comparable to the run's curve.
+
+Sections 1–2 run as subprocesses (each tool is CLI-shaped, and isolation means one
+crash costs one section, not the report); section 3 runs in-process, last, so this
+process holds no accelerator memory while the children run. A failed section is
+reported as FAILED with its error and the rest keep going.
+
+The consolidated report prints to stdout and is saved under the run dir
+(runs/<run>/milestone_report_step_<n>.md — gitignored with the rest of runs/).
+
+Run when a checkpoint is worth a look (GPU free, or on CPU while training):
+    PYTHONPATH=. python tools/milestone_report.py [--ckpt DIR] [--quick]
+On CPU prepend FORCE_F32_COMPUTE=1 JAX_PLATFORMS=cpu (see config.py).
+"""
+
+import os
+
+os.environ.setdefault("XLA_PYTHON_CLIENT_MEM_FRACTION", "0.5")
+
+import argparse
+import datetime
+import subprocess
+import sys
+import time
+import traceback
+
+REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+CKPT_ITEMS = ("model", "optimizer", "monitor_state", "step")
+
+
+def run_tool(script, extra_args=(), timeout=None):
+    """Run a tools/ CLI as a subprocess and return its stdout, raising on failure."""
+    cmd = [sys.executable, os.path.join("tools", script), *extra_args]
+    env = dict(os.environ, PYTHONPATH=REPO_ROOT + os.pathsep + os.environ.get("PYTHONPATH", ""))
+    proc = subprocess.run(cmd, cwd=REPO_ROOT, env=env, capture_output=True, text=True, timeout=timeout)
+    if proc.returncode != 0:
+        stderr_tail = "\n".join(proc.stderr.strip().splitlines()[-15:])
+        raise RuntimeError(
+            f"{script} exited {proc.returncode}\n"
+            f"--- stdout ---\n{proc.stdout.strip()}\n--- stderr (tail) ---\n{stderr_tail}"
+        )
+    return proc.stdout.strip()
+
+
+def run_section(title, fn):
+    """Run one diagnostic and tolerate its failure: capture the error, keep going."""
+    print(f"\n=== {title} ===")
+    start = time.time()
+    try:
+        body, status = fn(), "ok"
+    except Exception:
+        body, status = traceback.format_exc(), "FAILED"
+    return {"title": title, "status": status, "elapsed": time.time() - start, "body": body}
+
+
+def section_depth_curve(arch, fwd_args, batches, timeout):
+    batch_args = [] if batches is None else ["--batches", str(batches)]
+    if arch == "refiner":
+        note = ("eval_depth_curve (carried-vs-fresh hunch) skipped: it probes the reasoner's "
+                "cross-window hunch, which the refiner does not have. Depth-swept held-out CE "
+                "by domain stands in as the depth diagnostic.")
+        out = run_tool("eval_refiner_depth_transfer.py", [*fwd_args, *batch_args], timeout)
+    else:
+        note = ("carried-vs-fresh hunch is the 'fresh' baseline inside this curve; the hunch is "
+                "proven inert (docs/findings/2026-06-13-cross-window-hunch-inert.md), so expect flat.")
+        out = run_tool("eval_depth_curve.py", [*fwd_args, *batch_args], timeout)
+    return f"{note}\n\n{out}"
+
+
+def section_transcripts(fwd_args, quick_args, timeout):
+    out = run_tool("dump_transcripts.py", [*fwd_args, *quick_args], timeout)
+    # Inline the transcript file it saved — cleaner than the streamed stdout.
+    for line in out.splitlines():
+        if "Saved " in line:
+            path = os.path.join(REPO_ROOT, line.split("Saved ", 1)[1].strip())
+            if os.path.exists(path):
+                with open(path) as f:
+                    return f"(from {path})\n\n{f.read().strip()}"
+    return out
+
+
+def section_val_ce(checkpoint_path):
+    from tools.common import restore_model
+    import trainer
+
+    if not trainer.DATA_ROOT:
+        return "skipped: DATA_ROOT is not set — no held-out data to score"
+    model, _ = restore_model(checkpoint_path)
+    val_ce = trainer.ValidationProbe().run(model)
+    if val_ce is None:
+        return "no held-out validation data available (is DATA_ROOT set?)"
+    return (f"validation CE: {val_ce:.4f} nats "
+            f"(fixed depth {trainer.VAL_FIXED_DEPTH}, {trainer.VAL_BATCHES} batches, "
+            f"skip {trainer.VAL_SKIP_SAMPLES:,} — same probe the training loop logs)")
+
+
+def git_commit():
+    try:
+        return subprocess.run(["git", "rev-parse", "--short", "HEAD"], cwd=REPO_ROOT,
+                              capture_output=True, text=True).stdout.strip() or "unknown"
+    except OSError:
+        return "unknown"
+
+
+def main():
+    parser = argparse.ArgumentParser(description="run all diagnostics against a checkpoint, emit one report")
+    parser.add_argument("--ckpt", "--checkpoint-path", dest="checkpoint_path", default=None,
+                        help="Orbax checkpoint dir (default: the latest run's)")
+    parser.add_argument("--out", default=None,
+                        help="report path (default: <run dir>/milestone_report_step_<n>.md)")
+    parser.add_argument("--quick", action="store_true",
+                        help="tiny settings (2 batches, 2 prompts, 32 new tokens) for a fast smoke pass")
+    parser.add_argument("--section-timeout", type=float, default=None,
+                        help="seconds before a diagnostic subprocess is killed (default: none)")
+    args = parser.parse_args()
+
+    # Heavy imports after arg parsing so --help stays instant.
+    from config import MODEL_ARCH
+    from checkpoint_utils import discover_latest_checkpoint_run
+    import orbax.checkpoint as ocp
+
+    if args.checkpoint_path:
+        checkpoint_path = os.path.abspath(args.checkpoint_path)
+        report_dir = os.path.dirname(checkpoint_path)
+        source = checkpoint_path
+    else:
+        checkpoint_path, run_id = discover_latest_checkpoint_run()
+        if checkpoint_path is None:
+            raise SystemExit("No checkpoint found: no run under runs/ has a readable checkpoint "
+                             "(train first, or point at one with --ckpt).")
+        checkpoint_path = os.path.abspath(checkpoint_path)
+        report_dir = os.path.join("runs", run_id)
+        source = f"latest run {run_id}"
+        print(f"🔎 Using latest checkpointed run: {run_id}")
+
+    step = ocp.CheckpointManager(checkpoint_path, item_names=CKPT_ITEMS).latest_step()
+    if step is None:
+        raise SystemExit(f"No checkpoint found under {checkpoint_path}.")
+    print(f"📋 Milestone report: {source}, step {step}, arch '{MODEL_ARCH}'")
+
+    # Forward the checkpoint only when the user overrode it; otherwise each tool
+    # self-discovers the same latest run (and keeps its own output placement).
+    fwd_args = ["--checkpoint-path", checkpoint_path] if args.checkpoint_path else []
+    batches = 2 if args.quick else None
+    transcript_args = ["--prompts", "2", "--max-new-tokens", "32"] if args.quick else []
+
+    sections = [
+        run_section("Depth curve", lambda: section_depth_curve(
+            MODEL_ARCH, fwd_args, batches, args.section_timeout)),
+        run_section("Fixed-prompt transcripts", lambda: section_transcripts(
+            fwd_args, transcript_args, args.section_timeout)),
+        run_section("Held-out validation CE", lambda: section_val_ce(checkpoint_path)),
+    ]
+
+    lines = [
+        f"# Milestone report — checkpoint step {step}",
+        "",
+        f"- generated: {datetime.datetime.now().astimezone().isoformat()}",
+        f"- arch: {MODEL_ARCH}",
+        f"- checkpoint: {checkpoint_path}",
+        f"- commit: {git_commit()}",
+        "",
+    ]
+    for s in sections:
+        lines += [f"## {s['title']} — {s['status']} ({s['elapsed']:.0f}s)", "", "```", s["body"], "```", ""]
+    report = "\n".join(lines)
+
+    print("\n" + report)
+    out_path = args.out or os.path.join(report_dir, f"milestone_report_step_{step}.md")
+    os.makedirs(os.path.dirname(out_path) or ".", exist_ok=True)
+    with open(out_path, "w") as f:
+        f.write(report + "\n")
+    print(f"✨ Saved {out_path}")
+
+    if all(s["status"] == "FAILED" for s in sections):
+        raise SystemExit("Every section failed — see the report above.")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
Two independent items developed in parallel: the #20 milestone diagnostics report script, and the #67 final-answer-only supervision ablation — which returned the pre-registered **"taught"** verdict: the scratchpad decomposition does not emerge from structure alone; the per-slot grade is load-bearing.

Closes #20
Closes #67

## What & why

**#20 — `tools/milestone_report.py`.** One command runs all existing diagnostics against the latest checkpoint (or `--ckpt`) and emits a single consolidated report: depth curve (arch-aware — reasoner → `eval_depth_curve.py`, refiner → `eval_refiner_depth_transfer.py`), fixed-prompt transcripts (inlined), and the held-out validation CE probe (same `ValidationProbe` the training loop logs). Sections are failure-isolated: a broken diagnostic reports its error and the rest keep going; report saved next to the checkpoint (gitignored). Along the way, fixed a latent bug in `tools/common.py`: `restore_model()` hardcoded `UniversalReasoner`, so any restore under `MODEL_ARCH=refiner` would fail on the mismatched param tree — it now builds its skeleton per `MODEL_ARCH` via `build_model()`, with explicit `restore_reasoner`/`restore_refiner` kept for `eval_yardstick`'s `--arch` override. `eval_depth_curve.py` now exits with a clear message under `MODEL_ARCH=refiner` instead of silently probing the refiner's vestigial zero hunch buffer.

**#67 — the missing cell in the #38/#62/#63 design matrix.** New `finalonly` arm in `scratchpad_harness.py`: identical serial structure (ordered write-once slots, slot k reads tokens + slots &lt; k), but the per-slot grade is stop-gradiented into a pure linear probe — final-answer CE is the model's only teacher, while the slot readout stays trainable as a diagnostic. Matched pairs, seeds {0,1,2}, `affine_chain`, K=4, m=7, 2500 steps, held-out 4096:

| arm | held-out final acc (3 seeds) |
|---|---|
| serial control (per-slot grade) | **0.9922 ± 0.011** (0.9988 / 0.9790 / 0.9988 — reproduces #38) |
| finalonly | **0.1341 ± 0.004** (0.1299 / 0.1372 / 0.1353) |

Gap ≈ 101× σ_pooled (pre-registered emergent bar: within 2σ); finalonly sits inside the depthonly/chance regime (0.1397 ± 0.010 / 0.143). Probe readout: slot 1 weakly decodable (0.31–0.43; r₁ is a shallow copy), slots 2–4 flat at chance — no chain forms at all. Finding: `docs/findings/2026-07-04-final-only-supervision-decomposition-is-taught.md` (limitations recorded: 2500-step budget kills "emerges for free," not "can never be induced" — grade-annealing untested). Also adds a chronological Entries index to `docs/findings/README.md`.

## Validation / smoke-test performed
- [x] `JAX_PLATFORMS=cpu pytest tests/ -q` passes locally (full suite green on the merged branch, `FORCE_F32_COMPUTE=1`; GPU-marked tests skipped as designed)
- Other checks run:
  - New wiring-guard test proves the finalonly grade has exactly zero gradient upstream of the probe head, and stays live in the graded arm
  - One finalonly seed re-run on the merged code reproduced bit-for-bit (0.1299, identical probe accuracies)
  - `milestone_report.py` exercised end-to-end against a real (untrained) CPU checkpoint: report generated, transcripts section ok, data-dependent sections failed softly with captured errors (no `DATA_ROOT` in sandbox), graceful no-checkpoint exit, instant `--help`

## Risk
- CPU-only toy harness + tooling; no training-loop, checkpoint-format, or VRAM impact. Pinned deps unchanged.
- `restore_model()` now dispatches on `MODEL_ARCH` — behavior is identical for every existing reasoner workflow; under `MODEL_ARCH=refiner` it goes from guaranteed-crash to correct restore. `eval_yardstick`'s explicit `--arch` semantics preserved via `restore_reasoner`.
- Depth-curve and val-CE report sections couldn't be exercised against real data in the sandbox (no corpus); their code paths are the existing tools', unchanged.

## Checklist
- [x] Did not weaken or delete any test (no skips/xfails/loosened asserts to make it pass)
- [x] Smoke-tested; no multi-hour run was launched without sign-off (6 CPU runs, ~4 min each)
- [x] Pinned deps unchanged, or the bump is justified above
- [x] Findings/claims backed by evidence in the PR or a linked finding issue

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014J8vXqpGmGgALecEAcn71x

---
_Generated by [Claude Code](https://claude.ai/code/session_014J8vXqpGmGgALecEAcn71x)_