### PR TITLE
Truncated backprop through refinement depth (--grad-last): pre-registered kill (#64)

### DIFF
--- a/ablation_harness.py
+++ b/ablation_harness.py
@@ -140,8 +140,8 @@ VOCAB = {"parity": 2, "cumsum5": 5, "statetrack": 5}
 
 
 def train_one(task_fn, vocab, depth, *, arch="refiner", dim=96, heads=4, enc=2, steps=2500,
-              batch=256, lr=2e-3, wd=0.01, seed=0, gate_bias=0.0, n_pool=32768, n_test=4096,
-              eval_batch=256, train_seq=SEQ, test_seq=None):
+              batch=256, lr=2e-3, wd=0.01, seed=0, gate_bias=0.0, grad_last=None,
+              n_pool=32768, n_test=4096, eval_batch=256, train_seq=SEQ, test_seq=None):
     # When test_seq > train_seq this is a length-generalization probe: the model
     # trains on length train_seq and is evaluated on longer sequences, so it must
     # use RoPE positions it never saw in training. test_seq=None -> same length.
@@ -168,12 +168,18 @@ def train_one(task_fn, vocab, depth, *, arch="refiner", dim=96, heads=4, enc=2, 
     n_params = sum(int(x.size) for x in jax.tree_util.tree_leaves(nnx.state(model, nnx.Param)))
     opt = nnx.Optimizer(model, optax.adamw(lr, weight_decay=wd), wrt=nnx.Param)
 
+    # Truncated backprop (#64): grad_last=j backprops through only the last j
+    # refinement iterations (refiner arm only — vanilla has no recurrence to cut).
+    # Training-only; eval has no backward pass, so it is untouched. grad_last is
+    # closed over, so it is static at trace time like `depth`.
+    model_kwargs = {} if arch == "vanilla" else {"grad_last": grad_last}
+
     @nnx.jit(static_argnames=["depth"])
     def step(model, opt, key, inp_all, tgt_all, mask_all, depth):
         idx = jax.random.randint(key, (batch,), 0, inp_all.shape[0])
         inp, tgt, mask = inp_all[idx], tgt_all[idx], mask_all[idx]
         def loss_fn(m):
-            logits = m(inp, depth=depth)
+            logits = m(inp, depth=depth, **model_kwargs)
             ce = optax.softmax_cross_entropy_with_integer_labels(logits=logits, labels=tgt)
             return jnp.sum(ce * mask) / jnp.sum(mask)
         loss, grads = nnx.value_and_grad(loss_fn)(model)
@@ -218,6 +224,8 @@ def main():
     ap.add_argument("--seed", type=int, default=0)
     ap.add_argument("--gate-bias", type=float, default=0.0,
                     help="init bias of the update gate; negative = retention-biased (stabilizes deep recurrence). refiner-only.")
+    ap.add_argument("--grad-last", type=int, default=None,
+                    help="backprop through only the last J refinement iterations (truncated backprop, #64); default = full backprop. refiner-only.")
     ap.add_argument("--lr", type=float, default=2e-3)
     ap.add_argument("--train-seq", type=int, default=SEQ)
     ap.add_argument("--test-seq", type=int, default=None,
@@ -235,14 +243,15 @@ def main():
     depths = [int(d) for d in args.depths.split(",")]
     test_seq = args.train_seq if args.test_seq is None else args.test_seq
 
-    print(f"== depth ablation: arch={args.arch} dim={args.dim} task={task_desc} (train_seq={args.train_seq}, test_seq={test_seq}, vocab={vocab}) steps={args.steps} seed={args.seed} gate_bias={args.gate_bias} lr={args.lr} ==")
+    print(f"== depth ablation: arch={args.arch} dim={args.dim} task={task_desc} (train_seq={args.train_seq}, test_seq={test_seq}, vocab={vocab}) steps={args.steps} seed={args.seed} gate_bias={args.gate_bias} grad_last={args.grad_last} lr={args.lr} ==")
     print(f"{'depth':>6} {'params':>9} {'val_acc':>9} {'val_ce':>9} {'sec':>7}")
     results = {}
     for d in depths:
         t0 = time.time()
         acc, ce, n_params = train_one(task_fn, vocab, d, arch=args.arch, dim=args.dim,
                                       steps=args.steps, seed=args.seed, gate_bias=args.gate_bias,
-                                      lr=args.lr, train_seq=args.train_seq, test_seq=test_seq)
+                                      grad_last=args.grad_last, lr=args.lr,
+                                      train_seq=args.train_seq, test_seq=test_seq)
         results[d] = (acc, ce)
         print(f"{d:>6} {n_params / 1e6:>8.2f}M {acc:>9.4f} {ce:>9.4f} {time.time() - t0:>7.1f}")
 

--- a/docs/findings/2026-07-05-truncated-backprop-depth-kill.md
+++ b/docs/findings/2026-07-05-truncated-backprop-depth-kill.md
@@ -1,0 +1,71 @@
+# Truncated backprop through refinement depth collapses state-tracking to near-chance — the trajectory gradient is load-bearing, idea killed
+
+Status: confirmed (negative result; pre-registered kill criterion met, ~26–32σ past the bar)
+Date: 2026-07-05
+Commit: cc9ee7a  Run: tiny-config ablation (synthetic, no runs/ id)  Measured with: `python ablation_harness.py --task statetrack --depths 8 --steps 2500 --seed {0,1,2} [--grad-last {1,2}]` (CPU, f32)
+
+## Setup
+
+The #64 hypothesis: gradient through only the last j refinement iterations is
+enough — earlier iterations would learn indirectly, because the state they hand
+forward must make the graded final step(s) succeed ("learn the destination,
+forget the path"). If true, deep refinement trains at ~O(1) activation memory in
+depth instead of O(depth). Mechanism: `grad_last=j` on the CausalRefiner detaches
+the loop state at iteration depth−j (deviation from the encoder output only, so
+the encoder keeps an identity gradient path).
+
+Protocol pre-registered on the issue before any run: statetrack, refiner arm,
+depth 8, dim 96, 2500 steps, matched pairs (same seed ⇒ same init, pools, and
+minibatch order; only `grad_last` varies), seeds {0,1,2}. Keep if j=1 or j=2 is
+within 2σ_pooled of full backprop; kill if the loss exceeds 2σ even at j=2.
+
+## Evidence
+
+Held-out accuracy, mean ± σ over seeds {0,1,2} (chance = 0.20):
+
+| arm | acc (seeds 0/1/2) | mean ± σ | val CE | Δ vs full | 2σ_pooled |
+|---|---|---|---|---|---|
+| full backprop | .958 / .981 / .977 | 0.972 ± 0.012 | 0.081 ± 0.034 | — | — |
+| j=2 | .306 / .290 / .253 | 0.283 ± 0.028 | 1.508 ± 0.051 | **−0.689 (32σ)** | 0.043 |
+| j=1 | .318 / .339 / .272 | 0.310 ± 0.034 | 1.450 ± 0.051 | **−0.662 (26σ)** | 0.051 |
+
+The kill criterion is met without ambiguity: both truncated arms sit ~0.7
+accuracy points below full backprop against a noise floor of ~0.02, and j=2 buys
+nothing over j=1 — the failure is not marginal, so no intermediate j was probed.
+
+**Truncation is worse than shallowness.** The instructive comparison: a depth-1
+refiner with full backprop scores ~0.82 on statetrack
+(2026-06-16-plan-a-depth-ablation.md), yet the depth-8 truncated arms score
+~0.28–0.31 — far below "just use the graded suffix as a shallow model." The
+mechanism is weight sharing: the refine block's weights are trained only for
+their role as the final graded step(s), but the same weights run the 7 ungraded
+prefix iterations. Every update blindly changes what the prefix does to the
+state, the graded suffix chases a moving, never-corrected input distribution,
+and the composition scrambles rather than refines. The prefix isn't a frozen
+no-op; it's an untrained transformation applied 7 times.
+
+**Why this diverges from the literature.** Geiping et al. (Huginn) train a
+recurrent-depth model successfully with truncated backprop — but their
+recurrence re-injects the input embedding at every iteration (anchoring the
+prefix trajectory) and backprops through k=8 steps of a much longer recurrence.
+Our refiner feeds the encoder state in once at step 0 and was cut to j∈{1,2}.
+The negative result is about *this* gate/no-reinjection architecture at tiny
+scale, not about truncated backprop in general.
+
+**The compute win was real — it just costs the task.** Truncated runs took ~2×
+less wall-clock per run under equal core allocation (j=2: ~1050s vs full:
+~2080s, uncontended CPU), confirming the backward pass through the prefix is
+genuinely skipped. The memory/compute mechanism works; the model it trains
+doesn't.
+
+## Limitations
+
+Toy scale, one task, one depth (8), j ∈ {1, 2} only, 3 seeds. Two follow-ups
+could revive the *goal* (O(1)-memory deep refinement) without contradicting this
+kill: (a) Huginn-style input re-injection at every iteration, which changes the
+architecture (a separate `idea`, not a re-run of this one); (b) gradient
+checkpointing (`jax.checkpoint` per iteration), which buys O(√depth) or O(1)
+activation memory for a ~33% FLOPs surcharge with *exact* gradients — the
+boring, guaranteed-correct alternative for the dim960/#16 and batching/#24
+memory pressure this idea was chasing. The claim as stated in #64 is dead:
+last-step-only gradient does not hold accuracy on the gated CausalRefiner.

--- a/plan_a_model.py
+++ b/plan_a_model.py
@@ -133,7 +133,8 @@ class CausalRefiner(nnx.Module):
             # and diverge (the depth-8 collapse, ablation_results.md run 2).
             self.gate = nnx.Linear(2 * dim, dim, bias_init=jax.nn.initializers.constant(gate_bias), rngs=rngs, dtype=dtype)
 
-    def __call__(self, tokens, depth=None, pad_mask=None, return_hidden=False):
+    def __call__(self, tokens, depth=None, pad_mask=None, return_hidden=False,
+                 grad_last=None):
         depth = self.max_depth if depth is None else depth
 
         pad_bias = None
@@ -145,7 +146,20 @@ class CausalRefiner(nnx.Module):
         for blk in self.encoder:
             z = blk(z, pad_bias)
 
+        # Truncated backprop through the refinement depth (#64): with grad_last=j,
+        # gradient flows through only the last j refinement iterations — the
+        # trajectory before the cut runs forward-only, so its activations need not
+        # be kept for the backward (~O(1) activation memory in depth instead of
+        # O(depth)). The cut detaches only the loop state's *deviation* from the
+        # encoder output; the encoder itself keeps an identity gradient path, since
+        # a full detach would leave it with no training signal at all.
+        assert grad_last is None or grad_last >= 1, "grad_last must be >= 1 (or None for full backprop)"
+        z_enc = z
+        cut = None if grad_last is None else depth - grad_last
+
         for step in range(depth):
+            if cut is not None and step == cut and cut > 0:
+                z = z_enc + jax.lax.stop_gradient(z - z_enc)
             t_signal = self.time_embed(jnp.asarray(step))
             z_in = self.time_norm(z) + self.time_signal_norm(t_signal)[None, None, :]
             z_new = self.refine_block(z_in, pad_bias)

--- a/tests/test_plan_a.py
+++ b/tests/test_plan_a.py
@@ -71,6 +71,40 @@ def test_overfit_single_batch():
     assert last < 0.15 * first, f"failed to overfit: {first:.3f} -> {last:.3f}"
 
 
+@pytest.mark.parametrize("grad_last", [1, 2])
+def test_truncated_backprop_gradient_routing(grad_last):
+    """Truncated backprop through depth (#64): grad_last=j must (a) leave the
+    forward pass numerically unchanged — the cut computes z_enc + (z - z_enc),
+    which only re-associates float addition, so equal up to ~1e-6, not bit-exact —
+    (b) zero the gradient of every time-embedding row used before the cut (those
+    steps live inside the detached prefix), (c) keep a nonzero gradient on the
+    last j rows and on the encoder (the identity bypass)."""
+    depth = 8
+    m = _tiny()
+    tok = jax.random.randint(jax.random.PRNGKey(3), (2, 16), 0, 37)
+    tgt = jax.random.randint(jax.random.PRNGKey(4), (2, 16), 0, 37)
+
+    def loss(mm, gl):
+        lg = mm(tok, depth=depth, grad_last=gl)
+        return jnp.mean(optax.softmax_cross_entropy_with_integer_labels(logits=lg, labels=tgt))
+
+    full = np.asarray(m(tok, depth=depth))
+    trunc = np.asarray(m(tok, depth=depth, grad_last=grad_last))
+    np.testing.assert_allclose(trunc, full, atol=1e-5, rtol=0,
+                               err_msg="stop_gradient changed the forward pass")
+
+    grads = nnx.grad(loss)(m, grad_last)
+    t_grad = np.asarray(grads["time_embed"]["embedding"][...])
+    cut = depth - grad_last
+    pre_norm = np.abs(t_grad[:cut]).max()
+    post_norm = np.abs(t_grad[cut:depth]).max()
+    assert pre_norm == 0.0, f"time-embed rows before the cut got gradient ({pre_norm})"
+    assert post_norm > 0.0, "time-embed rows after the cut got no gradient"
+
+    enc_norm = max(float(jnp.abs(x).max()) for x in jax.tree_util.tree_leaves(grads["encoder"]))
+    assert enc_norm > 0.0, "encoder lost its gradient path under truncated backprop"
+
+
 def test_depth_is_static_and_varies_output():
     """Different depths produce different logits (the loop actually does something)."""
     m = _tiny()


### PR DESCRIPTION
## Summary
Implements the `grad_last` truncated-backprop knob on the CausalRefiner, runs the #64 pre-registered ablation, and records the result: **kill**. Gradient through only the last 1–2 refinement steps collapses statetrack from 0.97 to ~0.3 (chance 0.20) — ~26–32σ past the 2σ kill bar.

Closes #64.

## What & why
- `plan_a_model.py`: `CausalRefiner.__call__` grows `grad_last=j` — the loop state is detached at iteration depth−j, but only its *deviation from the encoder output*, so the encoder keeps an identity gradient path (a full detach would leave it with zero training signal). Forward pass unchanged up to float re-association.
- `ablation_harness.py`: `--grad-last` flag (refiner arm only; training step only — eval has no backward).
- `tests/test_plan_a.py`: gradient-routing test — time-embed rows before the cut get exactly zero gradient, rows after and the encoder stay live; forward matches full backprop to 1e-5.
- `docs/findings/2026-07-05-truncated-backprop-depth-kill.md`: full evidence, matched pairs (same seed ⇒ same init/pools/data order), seeds {0,1,2}, means ± σ, both pre-registered criteria evaluated.

Headline numbers (statetrack, depth 8, dim 96, 2500 steps):

| arm | acc mean ± σ |
|---|---|
| full backprop | 0.972 ± 0.012 |
| j=2 | 0.283 ± 0.028 |
| j=1 | 0.310 ± 0.034 |

Truncation is *worse than shallowness* (depth-1 full backprop scores ~0.82): the shared block's weights train only for the graded suffix, yet the same weights run the 7 ungraded prefix iterations, so the prefix becomes a moving untrained transformation. The finding records why this diverges from Huginn (input re-injection every step there, none here) and names the boring exact-gradient alternative for the original memory goal: `jax.checkpoint` per iteration.

## Validation / smoke-test performed
- [x] `JAX_PLATFORMS=cpu pytest tests/ -q` passes locally (70 tests, all green)
- Other checks run: `ruff check` clean on all changed files; 9 × 2500-step CPU ablation runs (~4 h background, CPU lane, per the issue's budget); forward-pass equivalence pinned by the new test.

## Risk
Behavior-neutral unless `grad_last` is passed: the default (`None`) leaves the training path byte-identical, and nothing in the trainer passes it. No config, checkpoint-format, data-path, or pinned-dep changes. The knob stays available for a future re-injection-style idea, but per the finding it must not be used as-is expecting held accuracy.

## Checklist
- [x] Did not weaken or delete any test (no skips/xfails/loosened asserts to make it pass)
- [x] Smoke-tested; no multi-hour run was launched without sign-off (the ~4 h CPU sweep is the issue's own pre-approved budget: "9 CPU runs ≈ 2h background")
- [x] Pinned deps unchanged, or the bump is justified above
- [x] Findings/claims backed by evidence in the PR or a linked finding issue

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0197gv8bdynUDPSuzG8882xS

---
_Generated by [Claude Code](https://claude.ai/code/session_0197gv8bdynUDPSuzG8882xS)_