### PR TITLE
Per-pass deep supervision + gradient islands: islands killed, stabilizer effect recorded (#75)

### DIFF
--- a/ablation_harness.py
+++ b/ablation_harness.py
@@ -141,6 +141,7 @@ VOCAB = {"parity": 2, "cumsum5": 5, "statetrack": 5}
 
 def train_one(task_fn, vocab, depth, *, arch="refiner", dim=96, heads=4, enc=2, steps=2500,
               batch=256, lr=2e-3, wd=0.01, seed=0, gate_bias=0.0, grad_last=None,
+              per_pass_loss=False, islands=False, readouts=False,
               n_pool=32768, n_test=4096, eval_batch=256, train_seq=SEQ, test_seq=None):
     # When test_seq > train_seq this is a length-generalization probe: the model
     # trains on length train_seq and is evaluated on longer sequences, so it must
@@ -168,17 +169,25 @@ def train_one(task_fn, vocab, depth, *, arch="refiner", dim=96, heads=4, enc=2, 
     n_params = sum(int(x.size) for x in jax.tree_util.tree_leaves(nnx.state(model, nnx.Param)))
     opt = nnx.Optimizer(model, optax.adamw(lr, weight_decay=wd), wrt=nnx.Param)
 
-    # Truncated backprop (#64): grad_last=j backprops through only the last j
-    # refinement iterations (refiner arm only — vanilla has no recurrence to cut).
-    # Training-only; eval has no backward pass, so it is untouched. grad_last is
-    # closed over, so it is static at trace time like `depth`.
-    model_kwargs = {} if arch == "vanilla" else {"grad_last": grad_last}
+    # Truncated backprop (#64) / gradient islands + per-pass supervision (#75):
+    # refiner-arm knobs only — vanilla has no recurrence to cut or grade.
+    # Training-only; eval has no backward pass, so its final-pass metric is the
+    # same instrument for every arm. All are closed over, so static at trace time.
+    model_kwargs = {} if arch == "vanilla" else {"grad_last": grad_last, "islands": islands}
 
     @nnx.jit(static_argnames=["depth"])
     def step(model, opt, key, inp_all, tgt_all, mask_all, depth):
         idx = jax.random.randint(key, (batch,), 0, inp_all.shape[0])
         inp, tgt, mask = inp_all[idx], tgt_all[idx], mask_all[idx]
         def loss_fn(m):
+            if per_pass_loss:
+                # Deep supervision (#75): grade EVERY pass's draft against the
+                # target, uniform mean over passes. Broadcast targets/mask over
+                # the leading pass axis of [depth, b, s, vocab] logits.
+                logits_all, _ = m(inp, depth=depth, return_all_iters=True, **model_kwargs)
+                ce = optax.softmax_cross_entropy_with_integer_labels(
+                    logits=logits_all, labels=jnp.broadcast_to(tgt, (depth,) + tgt.shape))
+                return jnp.sum(ce * mask) / (jnp.sum(mask) * depth)
             logits = m(inp, depth=depth, **model_kwargs)
             ce = optax.softmax_cross_entropy_with_integer_labels(logits=logits, labels=tgt)
             return jnp.sum(ce * mask) / jnp.sum(mask)
@@ -207,7 +216,34 @@ def train_one(task_fn, vocab, depth, *, arch="refiner", dim=96, heads=4, enc=2, 
         s = slice(i, i + eval_batch)
         a, c, m = eval_chunk_sums(model, te_inp[s], te_tgt[s], te_mask[s], depth)
         acc_sum, ce_sum, count = acc_sum + float(a), ce_sum + float(c), count + float(m)
-    return acc_sum / count, ce_sum / count, n_params
+
+    if not readouts:
+        return acc_sum / count, ce_sum / count, n_params
+
+    # #75 readouts (refiner only) — how each part of the model reacts:
+    #   per-pass accuracy: is every pass improving the draft, or does the work
+    #     happen late? gate openness: do early passes make real updates?
+    #   depth transfer: trained at `depth`, evaled at 1..12 — past max_depth the
+    #     time embedding saturates (jnp.take clips the row index), so passes
+    #     beyond training depth reuse the last time signal.
+    @nnx.jit(static_argnames=["depth"])
+    def eval_passes(model, inp, tgt, mask, depth):
+        logits_all, gates = model(inp, depth=depth, return_all_iters=True)
+        hit = (logits_all.argmax(-1) == tgt[None]) * mask[None]
+        return jnp.sum(hit, axis=(1, 2)) / jnp.sum(mask), gates
+
+    sub = slice(0, min(1024, te_inp.shape[0]))
+    pass_acc, gate_open = eval_passes(model, te_inp[sub], te_tgt[sub], te_mask[sub], depth)
+    transfer = {}
+    for d in range(1, 13):
+        a, _, m = eval_chunk_sums(model, te_inp[sub], te_tgt[sub], te_mask[sub], d)
+        transfer[d] = float(a) / float(m)
+    extras = {
+        "pass_acc": [float(x) for x in pass_acc],
+        "gate_open": None if gate_open is None else [float(x) for x in gate_open],
+        "transfer": transfer,
+    }
+    return acc_sum / count, ce_sum / count, n_params, extras
 
 
 def main():
@@ -226,6 +262,12 @@ def main():
                     help="init bias of the update gate; negative = retention-biased (stabilizes deep recurrence). refiner-only.")
     ap.add_argument("--grad-last", type=int, default=None,
                     help="backprop through only the last J refinement iterations (truncated backprop, #64); default = full backprop. refiner-only.")
+    ap.add_argument("--per-pass-loss", action="store_true",
+                    help="deep supervision (#75): grade every refinement pass against the target (uniform mean over passes). refiner-only.")
+    ap.add_argument("--islands", action="store_true",
+                    help="cut the gradient chain at every pass boundary (#75) — pair with --per-pass-loss. refiner-only.")
+    ap.add_argument("--readouts", action="store_true",
+                    help="print #75 readouts: per-pass accuracy, gate openness per pass, depth-transfer curve (eval at depths 1..12). refiner-only.")
     ap.add_argument("--lr", type=float, default=2e-3)
     ap.add_argument("--train-seq", type=int, default=SEQ)
     ap.add_argument("--test-seq", type=int, default=None,
@@ -243,17 +285,25 @@ def main():
     depths = [int(d) for d in args.depths.split(",")]
     test_seq = args.train_seq if args.test_seq is None else args.test_seq
 
-    print(f"== depth ablation: arch={args.arch} dim={args.dim} task={task_desc} (train_seq={args.train_seq}, test_seq={test_seq}, vocab={vocab}) steps={args.steps} seed={args.seed} gate_bias={args.gate_bias} grad_last={args.grad_last} lr={args.lr} ==")
+    print(f"== depth ablation: arch={args.arch} dim={args.dim} task={task_desc} (train_seq={args.train_seq}, test_seq={test_seq}, vocab={vocab}) steps={args.steps} seed={args.seed} gate_bias={args.gate_bias} grad_last={args.grad_last} per_pass={args.per_pass_loss} islands={args.islands} lr={args.lr} ==")
     print(f"{'depth':>6} {'params':>9} {'val_acc':>9} {'val_ce':>9} {'sec':>7}")
     results = {}
     for d in depths:
         t0 = time.time()
-        acc, ce, n_params = train_one(task_fn, vocab, d, arch=args.arch, dim=args.dim,
-                                      steps=args.steps, seed=args.seed, gate_bias=args.gate_bias,
-                                      grad_last=args.grad_last, lr=args.lr,
-                                      train_seq=args.train_seq, test_seq=test_seq)
+        out = train_one(task_fn, vocab, d, arch=args.arch, dim=args.dim,
+                        steps=args.steps, seed=args.seed, gate_bias=args.gate_bias,
+                        grad_last=args.grad_last, per_pass_loss=args.per_pass_loss,
+                        islands=args.islands, readouts=args.readouts, lr=args.lr,
+                        train_seq=args.train_seq, test_seq=test_seq)
+        acc, ce, n_params = out[:3]
         results[d] = (acc, ce)
         print(f"{d:>6} {n_params / 1e6:>8.2f}M {acc:>9.4f} {ce:>9.4f} {time.time() - t0:>7.1f}")
+        if args.readouts:
+            extras = out[3]
+            print("  pass_acc: " + " ".join(f"{a:.4f}" for a in extras["pass_acc"]))
+            if extras["gate_open"] is not None:
+                print("  gate_open: " + " ".join(f"{g:.4f}" for g in extras["gate_open"]))
+            print("  transfer: " + " ".join(f"d{k}={v:.4f}" for k, v in extras["transfer"].items()))
 
     base_acc = results[depths[0]][0]
     best_d = max(results, key=lambda d: results[d][0])

--- a/docs/findings/2026-07-05-per-pass-supervision-islands.md
+++ b/docs/findings/2026-07-05-per-pass-supervision-islands.md
@@ -1,0 +1,75 @@
+# Per-pass supervision cannot replace the trajectory gradient (islands killed), but it stabilizes deep recurrence — parity's depth-8 collapse rescued at +6.5σ
+
+Status: confirmed for the pre-registered kills/nulls; preliminary for the stabilizer observation (emerged from readouts, needs its own confirmatory test)
+Date: 2026-07-05
+Commit: 3bfe1fd  Run: tiny-config ablation (synthetic, no runs/ id)  Measured with: `python ablation_harness.py --task {statetrack,cumsum5,parity} --depths 8 --steps 2500 --seed {0..5} [--per-pass-loss] [--islands] [--readouts]` (CPU, f32)
+
+## Setup
+
+The #75 hypothesis, built on #64's kill (`2026-07-05-truncated-backprop-depth-kill.md`):
+there, the ungraded prefix passes had no training signal and truncation collapsed to
+near-chance. Fix under test: grade EVERY pass against the target (deep supervision,
+uniform mean over passes); then cutting the gradient chain at every pass boundary
+("islands") might hold accuracy at ~O(1) activation memory in depth.
+
+Arms, pre-registered on the issue before any run — matched pairs (same seed ⇒ same
+init/pools/minibatch order), statetrack depth 8, dim 96, 2500 steps, seeds {0,1,2}:
+**(a)** control, final-pass loss + full chain (#64's control; seed-0 spot-check
+reproduced its 0.9580 exactly, validating reuse); **(b)** per-pass loss + islands;
+**(c)** per-pass loss, chain intact. Keep: (b) within 2σ_pooled of (a). Partial
+keep: (c) beats (a) by ≥2σ. Kill: neither. Secondary readouts (no keep/kill
+weight): cumsum5 + parity (a) vs (b); per-pass accuracy; gate openness; depth
+transfer 1..12. After (c) posted +1.54σ at 3 seeds, a seed extension {3,4,5} for
+(a)/(c) was pre-registered before running: keep (c) iff ≥2σ_pooled over 6 seeds.
+
+## Evidence
+
+**statetrack held-out accuracy (chance 0.20):**
+
+| arm | seeds 0..5 | mean ± σ |
+|---|---|---|
+| (a) control | .958 / .981 / .977 / **.352** / .972 / .984 | 0.871 ± 0.254 (bimodal) |
+| (b) islands | .712 / .724 / .485 | 0.640 ± 0.135 |
+| (c) supervised, chain intact | .986 / .989 / .982 / .988 / .983 / .988 | 0.986 ± 0.003 |
+
+- **(b) keep: NOT MET** — Δ = −0.332 vs the 3-seed control, −3.46σ. Killed. But
+  supervision moved truncated training from #64's 0.31 (near-chance) to 0.64–0.72
+  with monotonically-improving passes: local grading teaches passes to contribute;
+  it cannot replace cross-pass credit where the task needs composed sequential
+  work. Consistently: cumsum5 (no composition needed) is free (−0.18σ), and see
+  parity below.
+- **(c) partial keep: NOT MET, twice** — +1.54σ at 3 seeds; extension verdict
+  +0.64σ at 6 seeds (control seed 3 collapsed, inflating σ); even the
+  working-mode-only view (collapsed seed excluded) is +1.58σ. Per the
+  pre-registrations, no mean-accuracy claim is kept. Formally this lands the
+  kill branch of #75.
+
+**What the readouts recorded (not pre-registered criteria — observations):**
+
+1. **Parity depth-8 rescue, +6.5σ.** Control reproduces the documented parity
+   collapse (0.581 ± 0.048, chance 0.5); islands+per-pass scores 0.929 ± 0.059.
+   The one task where deep weight-shared recurrence was known unstable is fixed
+   by grading every pass.
+2. **Matched-pair collapse rescue.** Control seed 3 collapsed to 0.352; arm (c),
+   same seed, same everything but the per-pass loss: 0.988. One-variable
+   evidence (n=1 collapse event) that supervision removes the collapse mode;
+   (c) posted 0 collapses in 6 seeds, σ 0.003 vs the control's working-mode 0.010.
+3. **Passes converge early and start high.** (c)'s pass-1 draft scores 0.61–0.68
+   (control pass 1: 0.29) and the curve saturates by pass ~5 while the control is
+   still climbing at pass 8. Depth-9 transfer holds better (0.96–0.99 vs 0.88).
+4. **Gate behavior.** (c) settles near 0.48–0.52 openness (drafts reach a fixed
+   point and the gate stops rewriting them); control keeps gates wider (0.58–0.72)
+   and is still churning at pass 8.
+5. **Depth ≥10 is chance for every arm** — running past max_depth+1 clips the
+   time-embedding row (jnp.take) and the state degenerates. Harness property,
+   not an arm difference; relevant to any future depth-extrapolation probe.
+
+## Limitations
+
+Toy scale, depth 8 only, uniform per-pass loss weighting only, 3 seeds on the
+secondary tasks, and the stabilizer claim rests on one pre-specified but
+non-primary comparison (parity) plus one collapse event. The #75 claims die as
+registered; the stabilizer effect is filed as its own pre-registered hypothesis
+(follow-up issue) — if it replicates, per-pass supervision is a training-recipe
+knob (cost: per-pass head FLOPs at train time), not a memory knob. For the
+original O(1)-memory goal, `jax.checkpoint` remains the exact-gradient fallback.

--- a/plan_a_model.py
+++ b/plan_a_model.py
@@ -134,7 +134,7 @@ class CausalRefiner(nnx.Module):
             self.gate = nnx.Linear(2 * dim, dim, bias_init=jax.nn.initializers.constant(gate_bias), rngs=rngs, dtype=dtype)
 
     def __call__(self, tokens, depth=None, pad_mask=None, return_hidden=False,
-                 grad_last=None):
+                 grad_last=None, islands=False, return_all_iters=False):
         depth = self.max_depth if depth is None else depth
 
         pad_bias = None
@@ -154,11 +154,22 @@ class CausalRefiner(nnx.Module):
         # encoder output; the encoder itself keeps an identity gradient path, since
         # a full detach would leave it with no training signal at all.
         assert grad_last is None or grad_last >= 1, "grad_last must be >= 1 (or None for full backprop)"
+        assert not (islands and grad_last is not None), "islands and grad_last are different cuts — pick one"
         z_enc = z
         cut = None if grad_last is None else depth - grad_last
 
+        # islands (#75): cut the trajectory gradient at EVERY pass boundary, so
+        # each iteration is graded only by its own loss (pair with per-pass
+        # supervision — with a final-only loss this is just grad_last=1). Same
+        # deviation-only detach as grad_last: the encoder keeps its identity path.
+        # return_all_iters (#75): also return every pass's logits (toy scale only
+        # — [depth, b, s, vocab] is cheap here, unaffordable at real vocab) plus
+        # each pass's mean gate openness, for per-pass supervision and readouts.
+        all_z, gate_means = [], []
         for step in range(depth):
-            if cut is not None and step == cut and cut > 0:
+            if islands and step > 0:
+                z = z_enc + jax.lax.stop_gradient(z - z_enc)
+            elif cut is not None and step == cut and cut > 0:
                 z = z_enc + jax.lax.stop_gradient(z - z_enc)
             t_signal = self.time_embed(jnp.asarray(step))
             z_in = self.time_norm(z) + self.time_signal_norm(t_signal)[None, None, :]
@@ -166,8 +177,19 @@ class CausalRefiner(nnx.Module):
             if self.use_gate:
                 g = jax.nn.sigmoid(self.gate(jnp.concatenate([z_new, z], axis=-1)))
                 z = g * z_new + (1.0 - g) * z
+                gate_means.append(jnp.mean(g))
             else:
                 z = z_new
+            if return_all_iters:
+                all_z.append(z)
+
+        if return_all_iters:
+            z_all = self.out_norm(jnp.stack(all_z))  # [depth, b, s, dim]
+            embed_t = self.embed.embedding[...].astype(self.dtype).T
+            logits_all = jnp.matmul(z_all.astype(self.dtype), embed_t,
+                                    preferred_element_type=jnp.float32)
+            gates = jnp.stack(gate_means) if self.use_gate else None
+            return logits_all, gates
 
         z = self.out_norm(z)
         if return_hidden:

--- a/tests/test_plan_a.py
+++ b/tests/test_plan_a.py
@@ -105,6 +105,48 @@ def test_truncated_backprop_gradient_routing(grad_last):
     assert enc_norm > 0.0, "encoder lost its gradient path under truncated backprop"
 
 
+def test_return_all_iters_last_pass_matches_standard_forward():
+    """The per-pass logits path (#75) must be a pure readout: pass k's logits for
+    k = depth-1 equal the standard __call__ output, and gate means land in (0,1)."""
+    m = _tiny()
+    tok = jnp.arange(1, 17)[None, :]
+    logits_all, gates = m(tok, depth=4, return_all_iters=True)
+    std = m(tok, depth=4)
+    assert logits_all.shape == (4,) + std.shape
+    np.testing.assert_allclose(np.asarray(logits_all[-1]), np.asarray(std), atol=1e-5, rtol=0)
+    assert gates.shape == (4,) and float(gates.min()) > 0.0 and float(gates.max()) < 1.0
+
+
+def test_islands_gradient_routing():
+    """Gradient islands (#75): with per-pass supervision every pass's time-embed
+    row gets gradient (each island has its own test); with a final-only loss the
+    islands cut reduces to last-pass-only credit. Encoder stays live in both."""
+    depth = 8
+    m = _tiny()
+    tok = jax.random.randint(jax.random.PRNGKey(5), (2, 16), 0, 37)
+    tgt = jax.random.randint(jax.random.PRNGKey(6), (2, 16), 0, 37)
+
+    def per_pass_loss(mm):
+        lg, _ = mm(tok, depth=depth, islands=True, return_all_iters=True)
+        labels = jnp.broadcast_to(tgt, (depth,) + tgt.shape)
+        return jnp.mean(optax.softmax_cross_entropy_with_integer_labels(logits=lg, labels=labels))
+
+    def final_only_loss(mm):
+        lg, _ = mm(tok, depth=depth, islands=True, return_all_iters=True)
+        return jnp.mean(optax.softmax_cross_entropy_with_integer_labels(logits=lg[-1], labels=tgt))
+
+    g_pp = nnx.grad(per_pass_loss)(m)
+    rows = np.abs(np.asarray(g_pp["time_embed"]["embedding"][...])[:depth]).max(axis=1)
+    assert (rows > 0.0).all(), "per-pass supervision left some pass without gradient"
+    enc_norm = max(float(jnp.abs(x).max()) for x in jax.tree_util.tree_leaves(g_pp["encoder"]))
+    assert enc_norm > 0.0, "encoder lost its gradient path under islands"
+
+    g_fo = nnx.grad(final_only_loss)(m)
+    rows = np.abs(np.asarray(g_fo["time_embed"]["embedding"][...])[:depth]).max(axis=1)
+    assert (rows[:-1] == 0.0).all(), "islands + final-only loss leaked credit into earlier passes"
+    assert rows[-1] > 0.0
+
+
 def test_depth_is_static_and_varies_output():
     """Different depths produce different logits (the loop actually does something)."""
     m = _tiny()


### PR DESCRIPTION
## Summary
Implements per-pass deep supervision and gradient islands on the CausalRefiner, runs the #75 pre-registered sweep (25 CPU runs incl. a pre-registered seed extension), and records the verdict: **islands killed, no mean-accuracy claim kept for supervision-with-chain — but per-pass grading rescued parity's documented depth-8 collapse at +6.5σ**, spun out as #77.

Closes #75.

## What & why
- `plan_a_model.py`: `return_all_iters` returns every pass's logits + per-pass mean gate openness (toy scale only); `islands=True` cuts the trajectory gradient at every pass boundary using #64's deviation-only detach, so the encoder keeps its identity path.
- `ablation_harness.py`: `--per-pass-loss` (grade every pass, uniform mean), `--islands`, `--readouts` (per-pass accuracy curve, gate openness, depth-transfer eval 1..12).
- `tests/test_plan_a.py`: per-pass logits are a pure readout (last pass ≡ standard forward); islands route credit to every pass under per-pass loss and only the last under final-only loss; encoder never loses gradient.
- `docs/findings/2026-07-05-per-pass-supervision-islands.md`: full evidence.

Headline (statetrack, depth 8, matched pairs):

| arm | mean ± σ | verdict |
|---|---|---|
| control (6 seeds) | 0.871 ± 0.254 (bimodal — seed 3 collapsed to 0.352) | — |
| islands + per-pass (3 seeds) | 0.640 ± 0.135 | **killed, −3.46σ** (but rescued from #64's 0.31) |
| per-pass, chain intact (6 seeds) | 0.986 ± 0.003 | won every seed, yet +1.54σ/+0.64σ on the two pre-registered tests — inside noise, not kept |

Recorded observations (readouts, no keep/kill weight): parity depth-8 collapse fixed 0.581→0.929 (+6.5σ); control seed 3's collapse rescued by the matched per-pass run (0.352→0.988); pass-1 accuracy 0.66 vs 0.29 with convergence by pass ~5; cumsum5 neutral. The stabilizer hypothesis gets its own pre-registered issue: #77.

## Validation / smoke-test performed
- [x] `JAX_PLATFORMS=cpu pytest tests/ -q` passes locally (all green, incl. 2 new tests)
- Other checks run: `ruff check` clean on changed files; control seed-0 spot-check reproduced #64's 0.9580 exactly (pipeline determinism, validating control reuse); 25 × 2500-step CPU runs per the issue's pre-registered protocol + seed extension.

## Risk
Behavior-neutral unless the new flags are passed: defaults leave the model and training path unchanged, and nothing outside the harness passes them. `return_all_iters` materializes [depth, b, s, vocab] logits — toy scale only by design, noted in code. No config, checkpoint, data-path, or pinned-dep changes.

## Checklist
- [x] Did not weaken or delete any test (no skips/xfails/loosened asserts to make it pass)
- [x] Smoke-tested; no multi-hour run was launched without sign-off (the CPU sweep is #75's own pre-approved budget)
- [x] Pinned deps unchanged, or the bump is justified above
- [x] Findings/claims backed by evidence in the PR or a linked finding issue

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0197gv8bdynUDPSuzG8882xS

---
_Generated by [Claude Code](https://claude.ai/code/session_0197gv8bdynUDPSuzG8882xS)_