### PR TITLE
Apply the unused findings: depth-overrun guard, serving at the depth knee, refiner as default arch

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -179,8 +179,8 @@ have different param trees, so a run of one cannot resume the other's checkpoint
 - **`reasoner`** — `UniversalReasoner` in `model.py`: the original cross-window "hunch"
   design. The hunch is **proven inert** (`docs/findings/2026-06-13-cross-window-hunch-inert.md`),
   so this is effectively a vanilla random-depth transformer — kept as the control
-  baseline. It is the current `MODEL_ARCH` default; the base-run plan switches to
-  `refiner` (tracked in issues).
+  baseline, selected explicitly with `MODEL_ARCH=reasoner`. The default is `refiner`
+  (the live bet); resuming an old reasoner run now requires the env var.
 
 The reusable scaffold (stable across whatever idea we try next) vs the swappable
 experiment (the arch behind the flag):

--- a/ablation_harness.py
+++ b/ablation_harness.py
@@ -225,18 +225,26 @@ def train_one(task_fn, vocab, depth, *, arch="refiner", dim=96, heads=4, enc=2, 
     #     happen late? gate openness: do early passes make real updates?
     #   depth transfer: trained at `depth`, evaled at 1..12 — past max_depth the
     #     time embedding saturates (jnp.take clips the row index), so passes
-    #     beyond training depth reuse the last time signal.
+    #     beyond training depth reuse the last time signal. The model asserts on
+    #     depth overrun exactly because of that clamp; this probe is the one
+    #     deliberate exception, so it opts in.
     @nnx.jit(static_argnames=["depth"])
     def eval_passes(model, inp, tgt, mask, depth):
         logits_all, gates = model(inp, depth=depth, return_all_iters=True)
         hit = (logits_all.argmax(-1) == tgt[None]) * mask[None]
         return jnp.sum(hit, axis=(1, 2)) / jnp.sum(mask), gates
 
+    @nnx.jit(static_argnames=["depth"])
+    def eval_transfer_sums(model, inp, tgt, mask, depth):
+        logits = model(inp, depth=depth, allow_depth_overrun=True)
+        pred = logits.argmax(-1)
+        return jnp.sum((pred == tgt) * mask), jnp.sum(mask)
+
     sub = slice(0, min(1024, te_inp.shape[0]))
     pass_acc, gate_open = eval_passes(model, te_inp[sub], te_tgt[sub], te_mask[sub], depth)
     transfer = {}
     for d in range(1, 13):
-        a, _, m = eval_chunk_sums(model, te_inp[sub], te_tgt[sub], te_mask[sub], d)
+        a, m = eval_transfer_sums(model, te_inp[sub], te_tgt[sub], te_mask[sub], d)
         transfer[d] = float(a) / float(m)
     extras = {
         "pass_acc": [float(x) for x in pass_acc],

--- a/config.py
+++ b/config.py
@@ -39,14 +39,16 @@ NUM_GROUPS = NUM_HEADS // 4
 
 # Architecture selector (env-overridable so a run is chosen at launch, not by a
 # code edit):
-#   "reasoner" — UniversalReasoner, the cross-window-hunch baseline (default;
-#                the hunch is proven inert, so this is effectively a vanilla
-#                random-depth transformer and serves as the control).
-#   "refiner"  — Plan A CausalRefiner: causal within-window depth recurrence
-#                (docs/findings/2026-06-13-plan-a-depth-recurrence-works.md).
-# A refiner run has a different param tree, so it must start fresh (--new-run);
-# it cannot resume a reasoner checkpoint.
-MODEL_ARCH = os.environ.get("MODEL_ARCH", "reasoner")
+#   "refiner"  — Plan A CausalRefiner: causal within-window depth recurrence.
+#                The default: it is the live bet, proven on the toy gate and
+#                through pretraining (findings 2026-06-13 / 06-16 / 06-18).
+#   "reasoner" — UniversalReasoner, the cross-window-hunch baseline. The hunch
+#                is proven inert (finding 2026-06-13), so this is effectively a
+#                vanilla random-depth transformer, kept as the control —
+#                select it explicitly (MODEL_ARCH=reasoner) for control runs.
+# The two arches have different param trees, so a checkpoint from one cannot be
+# resumed by the other — resuming an old reasoner run now requires the env var.
+MODEL_ARCH = os.environ.get("MODEL_ARCH", "refiner")
 # Blockwise memory-lean attention for the refiner (#66): removes the O(seq²)
 # score/probability transients that dominate the grad-step peak (mem_profile).
 # Opt-in until the dim960 GPU fit-test + wall-clock bench pass on the box;

--- a/config.py
+++ b/config.py
@@ -57,6 +57,15 @@ CHUNKED_ATTENTION = os.environ.get("CHUNKED_ATTENTION", "0") == "1"
 # near the reasoner baseline; init prints the actual count for both arches.
 REFINER_ENCODER_LAYERS = int(os.environ.get("REFINER_ENCODER_LAYERS", "7"))
 
+# Refiner serving depth. The dense 1→8 sweep
+# (docs/findings/2026-06-19-plan-a-depth-dense-sweep.md) put the accuracy
+# plateau at ~d6 (peak d7; d6–d8 inside seed noise), and pretraining shifts the
+# curve LEFT — the same ceiling in fewer loops. Loops past the knee buy nothing
+# measurable and cost a full pass of the shared block each, so inference/eval
+# tooling defaults here. Training is a separate decision and still samples up to
+# MAX_STEPS_LIMIT (pre-registered with the sweep: "MAX_STEPS_LIMIT=8 stays").
+INFERENCE_DEPTH = int(os.environ.get("INFERENCE_DEPTH", "6"))
+
 # Training
 MAX_STEPS_LIMIT = 8
 BATCH_SIZE = 1

--- a/plan_a_model.py
+++ b/plan_a_model.py
@@ -134,8 +134,21 @@ class CausalRefiner(nnx.Module):
             self.gate = nnx.Linear(2 * dim, dim, bias_init=jax.nn.initializers.constant(gate_bias), rngs=rngs, dtype=dtype)
 
     def __call__(self, tokens, depth=None, pad_mask=None, return_hidden=False,
-                 grad_last=None, islands=False, return_all_iters=False):
+                 grad_last=None, islands=False, return_all_iters=False,
+                 allow_depth_overrun=False):
         depth = self.max_depth if depth is None else depth
+        # The time embedding has rows for steps 0..max_depth only. Past that,
+        # rows are untrained (training never samples above max_depth) and then
+        # jnp.take clamps the index, so extra passes silently reuse the last
+        # time signal and the state degenerates — flagged in the 2026-06-18
+        # depth-transfer caveats, then measured as chance at depth >= 10 in
+        # 2026-07-05-per-pass-supervision-islands.md (readout 5). Fail loud;
+        # a deliberate extrapolation probe must say so.
+        assert allow_depth_overrun or depth <= self.max_depth, (
+            f"depth={depth} > max_depth={self.max_depth}: no trained time-embedding "
+            f"rows exist past max_depth and the row index silently clamps. Pass "
+            f"allow_depth_overrun=True only for a deliberate depth-extrapolation probe."
+        )
 
         pad_bias = None
         if pad_mask is not None:

--- a/plan_a_trainer.py
+++ b/plan_a_trainer.py
@@ -27,6 +27,7 @@ from config import (
     NUM_HEADS,
     MAX_SEQ_LEN,
     MAX_STEPS_LIMIT,
+    INFERENCE_DEPTH,
     PAD_TOKEN_ID,
     COMPUTE_DTYPE,
     REFINER_ENCODER_LAYERS,
@@ -58,9 +59,13 @@ class RefinerForTraining(nnx.Module):
         # Kept tiny ([1, 1, dim]) since it carries no information.
         self.hunch_cache = nnx.Variable(jnp.zeros((1, 1, latent_dim)))
 
-    def __call__(self, tokens, max_steps=MAX_STEPS_LIMIT, training=False, should_refresh=True):
+    def __call__(self, tokens, max_steps=INFERENCE_DEPTH, training=False, should_refresh=True):
         # training / should_refresh are part of the baseline interface and have no
         # effect here (no dropout, no carried state) — accepted and ignored.
+        # The default depth is the serving knee (INFERENCE_DEPTH, the 2026-06-19
+        # dense-sweep plateau), NOT MAX_STEPS_LIMIT: callers that don't say a depth
+        # get the cheapest setting the evidence says is equivalent. Training always
+        # passes its sampled depth explicitly.
         pad_mask = tokens != self.pad_token_id
         zero = jnp.array(0.0)
         diag = {"temporal_drift": zero, "forget_density": zero, "tau": zero}

--- a/tests/test_plan_a.py
+++ b/tests/test_plan_a.py
@@ -154,3 +154,17 @@ def test_depth_is_static_and_varies_output():
     d1 = np.asarray(m(tok, depth=1))
     d8 = np.asarray(m(tok, depth=8))
     assert np.max(np.abs(d1 - d8)) > 1e-3, "depth had no effect on the output"
+
+
+def test_depth_overrun_fails_loud():
+    """Depth past max_depth has no trained time-embedding rows and the row index
+    silently clamps (findings 2026-06-18 caveats, 2026-07-05 readout 5) — the
+    model must refuse it unless the caller opts into a deliberate probe."""
+    m = _tiny()  # max_depth=8
+    tok = jnp.arange(1, 17)[None, :]
+    with pytest.raises(AssertionError, match="allow_depth_overrun"):
+        m(tok, depth=9)
+    # The opt-in must still run — degraded numbers are the probe's business
+    # (at random init deep overrun can even overflow, so only shape is checked).
+    out = np.asarray(m(tok, depth=12, allow_depth_overrun=True))
+    assert out.shape == (1, 16, 37)


### PR DESCRIPTION
## Summary
Three findings had documented conclusions that never fed back into the code. This PR applies them, one commit each. A fourth candidate (per-iteration `jax.checkpoint` on the refinement loop) was implemented, measured null, and dropped — the measurement is recorded below.

## What & why
One commit per finding:

1. **`fix(refiner): fail loud on depth past max_depth`** — the silent time-embedding clamp was flagged twice (2026-06-18 depth-transfer caveats; 2026-07-05 per-pass finding, readout 5: depth ≥ 10 reads as chance) and already cost one probe degenerate numbers. `CausalRefiner` now asserts, with `allow_depth_overrun=True` as the explicit opt-in used by the harness's deliberate 1..12 transfer probe.
2. **`feat(config): INFERENCE_DEPTH=6`** — the dense sweep (2026-06-19 finding) put the accuracy plateau at ~d6 (peak d7, d6–d8 inside seed noise) and showed pretraining shifts the curve left. The training side of that finding was applied when it landed (`MAX_STEPS_LIMIT=8` stays, pre-registered); the serving side never was — implicit-depth inference ran all 8 loops. The refiner's serving default is now the knee, env-overridable.
3. **`feat(config): default MODEL_ARCH to the refiner`** — the hunch was proven inert (2026-06-13) and Plan A earned live-bet status, yet a run launched without `MODEL_ARCH` set still trained the dead design. The README already described the refiner as the model; now the config agrees. Control runs select `MODEL_ARCH=reasoner` explicitly.

**Implemented, measured null, dropped — per-iteration loop remat** (the exact-gradient memory lever named by the #64 kill finding). The depth-axis memory term is real: static grad-step peak at dim960/seq512/chunked-attention/f32 grows 1.215 → 1.548 → 1.987 GiB at depth 1 → 4 → 8 (~110 MiB/pass). But a Python-unrolled `jax.checkpoint` around the iteration recovers none of it: the recompute appears in the compiled HLO (op counts rise ~30%) while the peak stays bit-identical, at dim512 and dim960 alike. This reproduces the `losses.py` lesson ("XLA fused the unrolled regions and raised the remat floor") a third time. The version that would actually work is the chunked-CE recipe — rolled `lax.scan` over iterations with a hand-written VJP — which interacts with the static-unroll depth design and is a real `optimization` issue, not a drive-by commit. Gradient-equivalence was verified before dropping (loss and all grads matched to 1e-6).

**Deliberately not done here:** stripping the inert hunch machinery out of `model.py` (invalidates goldens + old checkpoints for a control that's now non-default — cost exceeds benefit), and the gate-bias probe from the 06-16 caveat (that's a run, not code — cheapest home is one extra matched arm on #77, which is testing a different cure for the same collapse mode).

## Validation / smoke-test performed
- [x] `JAX_PLATFORMS=cpu pytest tests/ -q` passes locally (78 passed, 4 skipped = the GPU/opt-in gates)
- Other checks run:
  - `RUN_GOLDEN=1 pytest tests/test_golden_run.py` passes — the recorded trajectory is untouched (all changes are flag defaults + an assert; no math changed).
  - Two new tests: depth-overrun assert fires / opt-in path runs; harness suite green with the opted-in transfer probe.
  - `ruff check` clean on all touched files.
  - `tools/mem_profile.py` reproduces the #66 numbers exactly (1.946 / 1.094 GiB), validating the instrument used for the remat measurement above.

## Risk
- **`MODEL_ARCH` default flip**: resuming an old reasoner run now requires `MODEL_ARCH=reasoner`. A wrong arch fails loud at Orbax restore (different param trees), not silently. CI is unaffected (tests construct arches explicitly).
- **`INFERENCE_DEPTH`**: changes only *implicit*-depth serving calls; training, the validation probe (fixed depth 4), and the yardstick (explicit `--depth`) are untouched.
- **Depth guard**: any script that was silently over-running depth will now assert — that's the point; the harness's deliberate probe is opted in.
- No numerics, dtype, data-path, or checkpoint-format changes. Pinned deps unchanged.

## Checklist
- [x] Did not weaken or delete any test (no skips/xfails/loosened asserts to make it pass)
- [x] Smoke-tested; no multi-hour run was launched without sign-off
- [x] Pinned deps unchanged, or the bump is justified above
- [x] Findings/claims backed by evidence in the PR or a linked finding issue

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Y7feuWYidn9m4T9q7LSnDo

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y7feuWYidn9m4T9q7LSnDo)_