### PR TITLE
Fix sampler: apply temperature before top-k/top-p truncation

### DIFF
--- a/infer_local.py
+++ b/infer_local.py
@@ -34,29 +34,36 @@ def run_model_inference(
     )
     return out.logits
 
-@partial(nnx.jit, static_argnames=['refresh', 'top_k', 'top_p'])
-def get_logits_for_token(model, padded_tks, token_idx, refresh, top_k, top_p):
-    all_logits = run_model_inference(model, padded_tks, max_steps=MAX_STEPS_LIMIT, should_refresh=refresh)
-    logits = all_logits[0, token_idx, :]
-    
+def _temperature_truncate(logits, temperature, top_k, top_p):
+    """Scale by temperature first, then truncate — top-p's cutoff must be
+    computed on the distribution actually being sampled (HF/nanoGPT/llama.cpp
+    convention), not on the untempered one."""
+    logits = logits / temperature
+
     if top_k > 0:
         top_vals, _ = jax.lax.top_k(logits, top_k)
         k_threshold = top_vals[-1]
         logits = jnp.where(logits < k_threshold, -jnp.inf, logits)
-    
+
     if top_p < 1.0:
         sorted_indices = jnp.argsort(logits)[::-1]
         sorted_logits = logits[sorted_indices]
         probs = jax.nn.softmax(sorted_logits)
         cum_probs = jnp.cumsum(probs)
-        
+
         cum_probs_shifted = jnp.roll(cum_probs, 1).at[0].set(0.0)
         cutoff_mask = cum_probs_shifted < top_p
-        
+
         p_threshold = jnp.min(jnp.where(cutoff_mask, sorted_logits, jnp.inf))
         logits = jnp.where(logits < p_threshold, -jnp.inf, logits)
-        
+
     return logits
+
+@partial(nnx.jit, static_argnames=['refresh', 'top_k', 'top_p'])
+def get_logits_for_token(model, padded_tks, token_idx, refresh, top_k, top_p, temperature):
+    all_logits = run_model_inference(model, padded_tks, max_steps=MAX_STEPS_LIMIT, should_refresh=refresh)
+    logits = all_logits[0, token_idx, :]
+    return _temperature_truncate(logits, temperature, top_k, top_p)
 
 def generate_text(model, enc, prompt, max_new_tokens=256, temperature=0.5, top_k=50, top_p=0.9):
     seed = int(time.time() * 1000) % (2**31)
@@ -81,16 +88,19 @@ def generate_text(model, enc, prompt, max_new_tokens=256, temperature=0.5, top_k
 
         should_refresh = (i % HUNCH_REFRESH_EVERY == 0)
 
+        # temperature=0 means greedy argmax below; pass 1.0 so the jitted
+        # truncation step is a no-op scale rather than a division by zero.
+        effective_temperature = temperature if temperature > 0.0 else 1.0
         logits = get_logits_for_token(
-            model, input_ids, valid_len - 1, 
-            refresh=should_refresh, top_k=top_k, top_p=top_p
+            model, input_ids, valid_len - 1,
+            refresh=should_refresh, top_k=top_k, top_p=top_p,
+            temperature=effective_temperature,
         )
 
         rng, subkey = jax.random.split(rng)
 
         if temperature > 0.0:
-            scaled_logits = logits / temperature
-            next_token = int(jax.random.categorical(subkey, scaled_logits))
+            next_token = int(jax.random.categorical(subkey, logits))
         else:
             next_token = int(jnp.argmax(logits))
 

--- a/tests/test_sampler.py
+++ b/tests/test_sampler.py
@@ -1,0 +1,78 @@
+"""Regression tests for issue #81: temperature must be applied to logits
+before top-k/top-p truncation, not after — the nucleus/top-k cutoff has to
+be computed on the distribution actually being sampled.
+"""
+
+import math
+
+import jax.numpy as jnp
+import numpy as np
+
+from infer_local import _temperature_truncate
+
+LOGITS = [2.0, 1.9, 1.8, 0.0, -1.0]
+
+
+def _reference_nucleus_kept_indices(logits, temperature, top_p):
+    """Independent (pure-Python) reference: temperature -> sort -> cumsum -> cutoff."""
+    scaled = [logit / temperature for logit in logits]
+    order = sorted(range(len(scaled)), key=lambda i: scaled[i], reverse=True)
+    sorted_vals = [scaled[i] for i in order]
+    m = max(sorted_vals)
+    exps = [math.exp(v - m) for v in sorted_vals]
+    total = sum(exps)
+    probs = [e / total for e in exps]
+
+    cum = 0.0
+    kept = []
+    for idx, p in zip(order, probs):
+        if cum < top_p:
+            kept.append(idx)
+        cum += p
+    return set(kept)
+
+
+def _kept_indices(masked_logits):
+    return {i for i, v in enumerate(np.asarray(masked_logits)) if np.isfinite(v)}
+
+
+def test_temperature_one_matches_unscaled_nucleus():
+    """At T=1 the kept token set must be unchanged vs the untempered nucleus."""
+    logits = jnp.array(LOGITS)
+    top_p = 0.7
+
+    masked = _temperature_truncate(logits, temperature=1.0, top_k=0, top_p=top_p)
+    kept = _kept_indices(masked)
+
+    assert kept == _reference_nucleus_kept_indices(LOGITS, 1.0, top_p)
+
+
+def test_temperature_scaling_changes_nucleus_and_matches_reference():
+    """At T!=1 the kept set must match temperature-first truncation, and must
+    differ from the untempered (pre-fix) nucleus on a vector built so the two
+    orderings visibly disagree."""
+    top_p = 0.7
+    temperature = 0.3
+
+    masked = _temperature_truncate(jnp.array(LOGITS), temperature=temperature, top_k=0, top_p=top_p)
+    kept = _kept_indices(masked)
+
+    reference = _reference_nucleus_kept_indices(LOGITS, temperature, top_p)
+    assert kept == reference
+
+    # Sharpening the distribution before truncation keeps a strictly smaller
+    # nucleus than truncating on the raw (untempered) logits — this is the
+    # case the pre-fix code (mask first, divide by T after) got wrong.
+    untempered_kept = _reference_nucleus_kept_indices(LOGITS, 1.0, top_p)
+    assert kept < untempered_kept
+
+
+def test_top_k_selection_is_temperature_invariant():
+    """top-k is order-preserving under any positive scale, so temperature
+    should not change which tokens survive a top-k-only truncation."""
+    logits = jnp.array(LOGITS)
+
+    kept_t1 = _kept_indices(_temperature_truncate(logits, temperature=1.0, top_k=3, top_p=1.0))
+    kept_t_sharp = _kept_indices(_temperature_truncate(logits, temperature=0.3, top_k=3, top_p=1.0))
+
+    assert kept_t1 == kept_t_sharp == {0, 1, 2}


### PR DESCRIPTION
## Summary
Sampling in `infer_local.py` truncated (top-k/top-p) the untempered logits, then divided by temperature afterward — the nucleus/top-k cutoff was computed on the wrong distribution.

## What & why
`get_logits_for_token` applied top-k/top-p to raw logits; `generate_text` then divided the surviving logits by `temperature`. Convention (HF `generate`, nanoGPT, llama.cpp) is temperature first, then truncation, since top-p's cutoff is defined on the distribution actually being sampled. At the defaults (T=0.5, top_p=0.9) this kept a larger token set than "top_p=0.9" means everywhere else, skewing `tools/dump_transcripts.py` readings.

Fixed by extracting the truncation logic into `_temperature_truncate(logits, temperature, top_k, top_p)`, which now divides by temperature *before* applying the top-k/top-p masks. `get_logits_for_token` takes `temperature` as an argument and returns already-tempered logits; `generate_text` samples directly from them instead of dividing again. The T=0 (greedy argmax) path is unaffected — `effective_temperature=1.0` is passed through as a no-op scale so `get_logits_for_token` never divides by zero.

Closes #81

## Validation / smoke-test performed
- [x] `JAX_PLATFORMS=cpu pytest tests/ -q` passes locally
- Other checks run: added `tests/test_sampler.py` — (1) T=1 kept token set unchanged vs the untempered nucleus, (2) at T≠1 the kept set matches an independent temperature→sort→cumsum→cutoff reference implementation on a hand-built logit vector where the two orderings visibly disagree, (3) top-k selection is temperature-invariant (order-preserving under positive scale). Also ran `ruff check` on changed files.

## Risk
Inference-only path (`infer_local.py` / `tools/dump_transcripts.py`); no effect on training, checkpoints, or model numerics. Changes generated-token distributions at nominally identical CLI settings (by design — this is the fix), so old transcripts are not directly comparable to new ones.

## Checklist
- [x] Did not weaken or delete any test (no skips/xfails/loosened asserts to make it pass)
- [x] Smoke-tested; no multi-hour run was launched without sign-off
- [x] Pinned deps unchanged, or the bump is justified above
- [x] Findings/claims backed by evidence in the PR or a linked finding issue


---
_Generated by [Claude Code](https://claude.ai/code/session_01PiTf3f7hNSXLEtx43G3X5h)_