### PR TITLE
Underflow instrument: per-group exactly-zero gradient fraction (#82)

### DIFF
--- a/grad_step.py
+++ b/grad_step.py
@@ -13,6 +13,28 @@ from schedules import (
 )
 from losses import chunked_cross_entropy
 
+def zero_fraction_by_group(grad_tree):
+    """Fraction of exactly-zero entries in `grad_tree`, one value per top-level
+    param group (the model's top-level attributes: 'embed', 'encoder_stack',
+    'reasoning_stack', ...).
+
+    Instrument for #82: f16 gradient underflow rounds entries to exactly zero
+    without ever going non-finite, so it's invisible to the NaN-streak abort
+    and to the global grad norm. Reported per group, not as one number,
+    because the embedding's zero-fraction is legitimately huge (only tokens
+    present in the micro-batch get a gradient row) — the signal to watch
+    lives in the dense-kernel groups (attention projections, MLP, norms),
+    which should read ~0 in healthy f16 training.
+    """
+    zero_counts = {}
+    sizes = {}
+    for path, leaf in jax.tree_util.tree_flatten_with_path(grad_tree)[0]:
+        group = str(getattr(path[0], 'key', path[0]))
+        zero_counts[group] = zero_counts.get(group, 0) + jnp.sum(leaf == 0)
+        sizes[group] = sizes.get(group, 0) + leaf.size
+    return {group: zero_counts[group] / sizes[group] for group in zero_counts}
+
+
 def compute_total_loss(ce1, ce2, out1, out2, f_lambda, d_lambda):
     """Assembles the full training loss from both segments' outputs.
 
@@ -87,7 +109,12 @@ def compute_grad_step(model, batch_tokens, step, max_steps, doc_boundary=False):
 
     sq_norms = jax.tree_util.tree_map(lambda x: jnp.sum(jnp.square(x)), grads)
     grad_norm = jnp.sqrt(sum(jax.tree_util.tree_leaves(sq_norms)))
-    
+
+    # Carried on the aux (not the return tuple) so this instrument doesn't
+    # force every one of the ~15 call sites that unpack this function's
+    # 4-tuple to change.
+    out = out.replace(diag={**out.diag, 'grad_zero_frac': zero_fraction_by_group(grads)})
+
     return loss, out, grads, grad_norm
 
 

--- a/tests/test_grad_zero_fraction.py
+++ b/tests/test_grad_zero_fraction.py
@@ -1,0 +1,51 @@
+"""Underflow instrument (#82): f16 gradient underflow rounds entries to
+exactly zero without ever going non-finite, so it's invisible to the
+NaN-streak abort and to the global grad norm. `zero_fraction_by_group` is the
+guard — a hand-built grad tree with known zero counts per top-level group, so
+the fraction math is pinned independent of any real model."""
+
+import os
+os.environ.setdefault("JAX_PLATFORMS", "cpu")
+
+import jax.numpy as jnp
+
+from grad_step import zero_fraction_by_group
+
+
+def test_zero_fraction_per_group_matches_hand_count():
+    grads = {
+        # 3 of 4 entries zero.
+        "embed": {"embedding": jnp.array([0.0, 0.0, 0.0, 1.0])},
+        # 1 of 4 entries zero, split across two leaves in the same group.
+        "encoder_stack": {
+            "w": jnp.array([[1.0, 2.0], [0.0, 3.0]]),
+        },
+    }
+
+    fractions = zero_fraction_by_group(grads)
+
+    assert set(fractions.keys()) == {"embed", "encoder_stack"}
+    assert float(fractions["embed"]) == 0.75
+    assert float(fractions["encoder_stack"]) == 0.25
+
+
+def test_zero_fraction_sums_leaves_within_a_group():
+    # Two leaves in the same top-level group must pool into one fraction,
+    # not report per-leaf independently.
+    grads = {
+        "block": {
+            "attn": {"q": jnp.zeros((4,))},
+            "mlp": {"up": jnp.ones((4,))},
+        },
+    }
+
+    fractions = zero_fraction_by_group(grads)
+
+    assert set(fractions.keys()) == {"block"}
+    assert float(fractions["block"]) == 0.5
+
+
+def test_all_nonzero_group_reads_zero():
+    grads = {"norm": {"scale": jnp.array([1.0, 2.0, 3.0])}}
+    fractions = zero_fraction_by_group(grads)
+    assert float(fractions["norm"]) == 0.0

--- a/trainer.py
+++ b/trainer.py
@@ -247,6 +247,15 @@ def train_loop(model, optimizer, data_queue, mngr, best_mngr, monitor, start_ste
                 # Logged once; clear so it isn't re-attributed to later opt-steps.
                 latest_val_ce = None
 
+                # Underflow instrument (#82): per-group exactly-zero gradient
+                # fraction from the last micro-step in this window. The
+                # embedding group reads high by design (see grad_step.py);
+                # watch the dense-kernel groups for a rising trend instead.
+                zero_frac = out.diag.get('grad_zero_frac', {})
+                if zero_frac:
+                    frac_str = " | ".join(f"{g}: {float(f):.4f}" for g, f in sorted(zero_frac.items()))
+                    print(f"🧊 [Grad Zero-Frac] Opt Step: {opt_step} | {frac_str}")
+
                 if not sft_phase_event.is_set():
                     curr_weights = get_curriculum_weights(opt_step)
                     print(


### PR DESCRIPTION
## Summary
Adds the per-top-level-param-group exactly-zero gradient fraction instrument from #82.

## What & why
`config.py`'s dtype policy is pure f16 compute, with optax loss scaling named as the fix *if* underflow shows up — but f16 gradient underflow is silent: entries round to exactly zero without ever going non-finite, so it's invisible to the NaN-streak abort and to the global grad norm.

- `grad_step.py`: new `zero_fraction_by_group(grad_tree)` walks the same grad pytree `compute_grad_step` already reduces for the norm, grouping by top-level attribute name (`embed`, `encoder_stack`, `reasoning_stack`, ...) via `tree_flatten_with_path` (same grouping technique `plot_history.py` already uses for param-count stats). Per-group, not one aggregate number, because the embedding's zero-fraction is legitimately huge (only tokens present in the micro-batch get a gradient row) — the signal to watch is the dense-kernel groups (attention projections, MLP, norms).
- The result is carried on `out.diag['grad_zero_frac']` rather than added to `compute_grad_step`'s return tuple, so none of the ~13 existing call sites that unpack `(loss, out, grads, grad_norm)` need to change.
- `trainer.py` prints it at the existing per-opt-step logging cadence (no new cadence constant needed).

Closes #82

## Validation / smoke-test performed
- [x] `JAX_PLATFORMS=cpu pytest tests/ -q` passes locally (full suite, including new `tests/test_grad_zero_fraction.py`)
- Other checks run:
  - `JAX_PLATFORMS=cpu RUN_GOLDEN=1 pytest tests/test_golden_run.py tests/test_attention_numerics.py tests/test_step_determinism.py -q` (golden-run CI job equivalent)
  - `JAX_PLATFORMS=cpu FORCE_F32_COMPUTE=1 python tools/overfit_smoke.py --synthetic --dim 64 --blocks 2 --steps 80` (overfit-smoke CI job equivalent)
  - Manually wired a real `UniversalReasoner` grad step and confirmed `out.diag['grad_zero_frac']` returns one float per top-level group
  - `ruff check` on the changed files

## Risk
Purely additive: one new pure function, one new dict key merged into an existing diag dict, one new print statement gated on that key being present. No change to the loss, the optimizer, gradients themselves, or the checkpoint/param tree shape. No new call-site signature changes.

Note: this PR wires and unit-tests the instrument (the acceptance criteria in #82); it does not yet render the "policy vindicated / elevated" verdict from #82, since that requires reading the instrument on a real f16 GPU run (`tools/smoke_refiner_gpu.py` + the early base run), which isn't available in this environment.

## Checklist
- [x] Did not weaken or delete any test (no skips/xfails/loosened asserts to make it pass)
- [x] Smoke-tested; no multi-hour run was launched without sign-off
- [x] Pinned deps unchanged
- [x] Findings/claims backed by evidence in the PR (see Validation section above)


---
_Generated by [Claude Code](https://claude.ai/code/session_01P4QTdofqd2SCTgkepXn9qb)_