### PR TITLE
Logit-scale thermometer: output entropy, mean log Z, max |logit| in the training diag (#80)

### DIFF
--- a/grad_step.py
+++ b/grad_step.py
@@ -50,10 +50,10 @@ def compute_grad_step(model, batch_tokens, step, max_steps, doc_boundary=False):
         seq2_in, seq2_out = batch_tokens[:, MAX_SEQ_LEN:2*MAX_SEQ_LEN], batch_tokens[:, MAX_SEQ_LEN+1:2*MAX_SEQ_LEN+1]
 
         out1 = model(seq1_in, max_steps=max_steps, training=True, should_refresh=should_refresh)
-        ce1 = ce_of(out1, seq1_out)
+        ce1, _ = ce_of(out1, seq1_out)
 
         out2 = model(seq2_in, max_steps=max_steps, training=True, should_refresh=False)
-        ce2 = ce_of(out2, seq2_out)
+        ce2, logit_stats = ce_of(out2, seq2_out)
 
         opt_step = step // ACCUMULATION_STEPS
         f_lambda = forget_lambda_schedule(opt_step)
@@ -63,8 +63,13 @@ def compute_grad_step(model, batch_tokens, step, max_steps, doc_boundary=False):
 
         # No NaN masking here: a non-finite loss must surface in the train loop
         # (which skips the update and aborts on a streak), not be silently zeroed.
+        # Logit-scale thermometer (#80): the CE scan's telemetry over window 2 —
+        # same segment 'token_loss' reads — so entropy/log-Z drift (collapse or
+        # blur) is visible in the metrics stream instead of surfacing as loss
+        # weirdness. Measurement only; the CE backward ignores its cotangent.
         new_diag = {
             **out2.diag,
+            **jax.lax.stop_gradient(logit_stats),
             'seg1_ce': jax.lax.stop_gradient(ce1),
             'token_loss': jax.lax.stop_gradient(ce2),
         }

--- a/losses.py
+++ b/losses.py
@@ -26,6 +26,12 @@ independent of XLA's rematerialization heuristics or the allocator's budget.
 The per-token loss and its gradients are identical to the naive full-logit CE (the vocab
 axis is never chunked); only the float32 sum over positions reorders, so a golden-run
 re-record is expected. The unit test asserts value AND gradient parity.
+
+The scan also accumulates logit-scale telemetry (#80) — mean softmax entropy, mean
+log Z, max |logit|, all over non-pad positions — since each chunk's full-vocab f32
+logits are already in hand here and nowhere else. Measurement only: the stats ride
+back as a second output whose cotangent the backward ignores, so they can never leak
+gradient into training.
 """
 
 from functools import partial
@@ -51,23 +57,45 @@ def _to_chunks(hidden, targets, pad_id, chunk_size):
 
 
 def _masked_chunked_loss(hidden, embedding, targets, pad_id, chunk_size):
-    """Scalar loss, scored chunk-by-chunk via scan so the forward never holds the full
-    vocab-wide logits. Shared by the custom_vjp primal and its forward rule."""
+    """Scalar loss plus logit-scale stats, scored chunk-by-chunk via scan so the
+    forward never holds the full vocab-wide logits. Shared by the custom_vjp primal
+    and its forward rule. Returns ``(loss, stats)`` where stats holds ``out_entropy``,
+    ``logz_mean`` and ``max_abs_logit``, each masked to non-pad positions."""
     embed_t = embedding.astype(hidden.dtype).T  # [d, vocab]
     h_steps, t_steps, _, _ = _to_chunks(hidden, targets, pad_id, chunk_size)
 
     def step(carry, xs):
-        loss_sum, count = carry
+        loss_sum, count, ent_sum, logz_sum, max_abs = carry
         h, t = xs
         # f32 logits accumulation matches the original head (preferred_element_type).
         logits = jnp.matmul(h, embed_t, preferred_element_type=jnp.float32)
         ce = optax.softmax_cross_entropy_with_integer_labels(logits, t)
         mask = (t != pad_id).astype(ce.dtype)
-        return (loss_sum + jnp.sum(ce * mask), count + jnp.sum(mask)), None
+        # Logit-scale telemetry (#80): a few reductions on logits already in hand.
+        # H = log Z − Σ p·logits (softmax entropy), per position.
+        logz = jax.nn.logsumexp(logits, axis=-1)
+        entropy = logz - jnp.sum(jax.nn.softmax(logits, axis=-1) * logits, axis=-1)
+        pos_max_abs = jnp.max(jnp.abs(logits), axis=-1)
+        carry = (
+            loss_sum + jnp.sum(ce * mask),
+            count + jnp.sum(mask),
+            ent_sum + jnp.sum(entropy * mask),
+            logz_sum + jnp.sum(logz * mask),
+            jnp.maximum(max_abs, jnp.max(jnp.where(mask > 0, pos_max_abs, 0.0))),
+        )
+        return carry, None
 
-    init = (jnp.asarray(0.0, jnp.float32), jnp.asarray(0.0, jnp.float32))
-    (loss_sum, count), _ = jax.lax.scan(step, init, (h_steps, t_steps))
-    return loss_sum / count.clip(min=1.0)
+    zero = jnp.asarray(0.0, jnp.float32)
+    init = (zero, zero, zero, zero, zero)
+    (loss_sum, count, ent_sum, logz_sum, max_abs), _ = jax.lax.scan(
+        step, init, (h_steps, t_steps))
+    denom = count.clip(min=1.0)
+    stats = {
+        'out_entropy': ent_sum / denom,
+        'logz_mean': logz_sum / denom,
+        'max_abs_logit': max_abs,
+    }
+    return loss_sum / denom, stats
 
 
 @partial(jax.custom_vjp, nondiff_argnums=(3, 4))
@@ -85,8 +113,13 @@ def chunked_cross_entropy(hidden, embedding, targets, pad_id, chunk_size=128):
                    penalty, so smaller is strictly leaner.
 
     Returns:
-        Scalar ``sum(CE * mask) / sum(mask)`` — identical to the naive computation (value
-        and gradients) up to float32 summation order.
+        ``(loss, stats)``:
+        loss  — scalar ``sum(CE * mask) / sum(mask)`` — identical to the naive
+                computation (value and gradients) up to float32 summation order.
+        stats — logit-scale telemetry over non-pad positions (#80): ``out_entropy``
+                (mean softmax entropy), ``logz_mean`` (mean log Z), ``max_abs_logit``.
+                Measurement only — the backward ignores their cotangent, so no
+                gradient can flow through them.
     """
     return _masked_chunked_loss(hidden, embedding, targets, pad_id, chunk_size)
 
@@ -95,12 +128,15 @@ def _cce_fwd(hidden, embedding, targets, pad_id, chunk_size):
     # Residuals are just the inputs — no logits saved, so the forward stays bounded.
     # targets is integer (non-differentiable) but can't be a nondiff_argnum because it is
     # a tracer; it rides in the residuals and gets a None cotangent in _cce_bwd.
-    loss = _masked_chunked_loss(hidden, embedding, targets, pad_id, chunk_size)
-    return loss, (hidden, embedding, targets)
+    out = _masked_chunked_loss(hidden, embedding, targets, pad_id, chunk_size)
+    return out, (hidden, embedding, targets)
 
 
 def _cce_bwd(pad_id, chunk_size, residuals, g):
     hidden, embedding, targets = residuals
+    # g mirrors the (loss, stats) output; the stats cotangent is dropped — they are
+    # diagnostics, structurally outside the training gradient.
+    g, _ = g
     b, s, d = hidden.shape
     vocab = embedding.shape[0]
     embed_t = embedding.astype(hidden.dtype).T  # [d, vocab]

--- a/metrics_logger.py
+++ b/metrics_logger.py
@@ -10,12 +10,14 @@ class MetricsLogger:
         self.diag_keys = [
             'temporal_drift', 'forget_density',
             'diversity_loss', 'tau',
+            'out_entropy', 'logz_mean', 'max_abs_logit',
         ]
         # Full set of fields for CSV
         self.fields = [
             "step", "ce", "loss", "seg1_ce",
             "grad_norm_avg", "avg_forget_cost",
             "diversity_loss", "temporal_drift", "forget_density", "tau",
+            "out_entropy", "logz_mean", "max_abs_logit",
             "depth_avg", "val_ce",
         ]
         # Warn once per metric name when a non-finite value shows up, so a broken
@@ -68,6 +70,9 @@ class MetricsLogger:
             f"Step {step:04d} | CE: {ce:.4f} (seg1: {seg1_ce:.4f}) | "
             f"Tau: {diag_dict.get('tau', 0):.4f} | Depth: {depth_avg:.2f}\n"
             f"      Loss: {loss:.4f} | Drift: {diag_dict.get('temporal_drift', 0):.6f} | "
+            f"H: {diag_dict.get('out_entropy', 0):.3f} | "
+            f"logZ: {diag_dict.get('logz_mean', 0):.2f} | "
+            f"max|logit|: {diag_dict.get('max_abs_logit', 0):.1f} | "
             f"Compute: {compute_time:.3f}s"
         )
 
@@ -96,6 +101,9 @@ class MetricsLogger:
                 "temporal_drift": f"{diag_dict.get('temporal_drift', 0):.6f}",
                 "forget_density": f"{diag_dict.get('forget_density', 0):.6f}",
                 "tau": f"{diag_dict.get('tau', 0):.6f}",
+                "out_entropy": f"{diag_dict.get('out_entropy', 0):.4f}",
+                "logz_mean": f"{diag_dict.get('logz_mean', 0):.4f}",
+                "max_abs_logit": f"{diag_dict.get('max_abs_logit', 0):.2f}",
                 "depth_avg": f"{depth_avg:.4f}" if depth_avg is not None else "",
                 "val_ce": f"{val_ce:.4f}" if val_ce is not None else "",
             }

--- a/tests/test_chunked_ce.py
+++ b/tests/test_chunked_ce.py
@@ -36,7 +36,7 @@ def test_value_matches_naive(chunk_size):
     hidden, embedding, targets = _fixture()
     pad_id = 0  # mask out the zero-token positions too, exercising the mask path
     naive = _naive_ce(hidden, embedding, targets, pad_id)
-    chunked = chunked_cross_entropy(hidden, embedding, targets, pad_id, chunk_size=chunk_size)
+    chunked, _ = chunked_cross_entropy(hidden, embedding, targets, pad_id, chunk_size=chunk_size)
     assert jnp.allclose(naive, chunked, rtol=1e-5, atol=1e-6), (float(naive), float(chunked))
 
 
@@ -46,7 +46,7 @@ def test_gradients_match_naive(chunk_size):
     pad_id = 0
 
     naive_g = jax.grad(lambda h, e: _naive_ce(h, e, targets, pad_id), argnums=(0, 1))(hidden, embedding)
-    chunk_g = jax.grad(lambda h, e: chunked_cross_entropy(h, e, targets, pad_id, chunk_size=chunk_size),
+    chunk_g = jax.grad(lambda h, e: chunked_cross_entropy(h, e, targets, pad_id, chunk_size=chunk_size)[0],
                        argnums=(0, 1))(hidden, embedding)
 
     assert jnp.allclose(naive_g[0], chunk_g[0], rtol=1e-4, atol=1e-6), "grad wrt hidden differs"
@@ -54,8 +54,11 @@ def test_gradients_match_naive(chunk_size):
 
 
 def test_all_padding_is_safe():
-    """A window that is entirely padding must not divide by zero."""
+    """A window that is entirely padding must not divide by zero — neither the loss
+    nor any of the telemetry stats."""
     hidden, embedding, _ = _fixture(seed=2)
     targets = jnp.zeros((2, 40), dtype=jnp.int32)
-    out = chunked_cross_entropy(hidden, embedding, targets, pad_id=0, chunk_size=16)
-    assert jnp.isfinite(out)
+    loss, stats = chunked_cross_entropy(hidden, embedding, targets, pad_id=0, chunk_size=16)
+    assert jnp.isfinite(loss)
+    for name, value in stats.items():
+        assert jnp.isfinite(value), name

--- a/tests/test_logit_telemetry.py
+++ b/tests/test_logit_telemetry.py
@@ -1,0 +1,84 @@
+"""Logit-scale telemetry (#80): the thermometer for output-distribution drift.
+
+The chunked-CE scan accumulates mean softmax entropy, mean log Z, and max |logit|
+over non-pad positions. Three contracts pinned here:
+
+1. The chunked, masked accumulation matches a naive full-logit computation.
+2. The stats are measurement-only — no gradient flows through them.
+3. The real grad step surfaces them on out.diag, where the metrics logger reads.
+"""
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+import pytest
+from flax import nnx
+
+from config import LATENT_DIM, MAX_SEQ_LEN
+from grad_step import compute_grad_step
+from losses import chunked_cross_entropy
+from model import UniversalReasoner
+
+
+def _naive_stats(hidden, embedding, targets, pad_id):
+    """The unchunked reference: full [b, s, vocab] logits, masked reductions."""
+    logits = jnp.matmul(hidden, embedding.astype(hidden.dtype).T,
+                        preferred_element_type=jnp.float32)
+    mask = targets != pad_id
+    logz = jax.nn.logsumexp(logits, axis=-1)
+    entropy = logz - jnp.sum(jax.nn.softmax(logits, axis=-1) * logits, axis=-1)
+    count = jnp.sum(mask).clip(min=1)
+    return {
+        'out_entropy': jnp.sum(entropy * mask) / count,
+        'logz_mean': jnp.sum(logz * mask) / count,
+        'max_abs_logit': jnp.max(jnp.where(mask, jnp.max(jnp.abs(logits), axis=-1), 0.0)),
+    }
+
+
+def _fixture(seed=0, b=2, s=40, d=8, vocab=17):
+    rng = np.random.default_rng(seed)
+    hidden = jnp.asarray(rng.standard_normal((b, s, d)), dtype=jnp.float32)
+    embedding = jnp.asarray(rng.standard_normal((vocab, d)), dtype=jnp.float32)
+    targets = jnp.asarray(rng.integers(0, vocab, size=(b, s)), dtype=jnp.int32)
+    return hidden, embedding, targets
+
+
+@pytest.mark.parametrize("chunk_size", [16, 13, 40, 64])  # divides, doesn't divide, ==s, >s
+def test_stats_match_naive(chunk_size):
+    hidden, embedding, targets = _fixture()
+    pad_id = 0  # some targets are 0, so the pad mask genuinely excludes positions
+    naive = _naive_stats(hidden, embedding, targets, pad_id)
+    _, stats = chunked_cross_entropy(hidden, embedding, targets, pad_id, chunk_size=chunk_size)
+    for name in naive:
+        assert jnp.allclose(naive[name], stats[name], rtol=1e-5, atol=1e-6), \
+            (name, float(naive[name]), float(stats[name]))
+
+
+def test_stats_carry_no_gradient():
+    """Differentiating through a stat must yield exactly zero — the backward drops
+    the stats cotangent, so telemetry can never leak into training gradients."""
+    hidden, embedding, targets = _fixture(seed=1)
+
+    def stat_sum(h, e):
+        _, stats = chunked_cross_entropy(h, e, targets, pad_id=0, chunk_size=16)
+        return stats['out_entropy'] + stats['logz_mean'] + stats['max_abs_logit']
+
+    gh, ge = jax.grad(stat_sum, argnums=(0, 1))(hidden, embedding)
+    assert not jnp.any(gh) and not jnp.any(ge)
+
+
+def test_grad_step_surfaces_stats_in_diag():
+    """The production grad step must expose the readings where the metrics logger
+    looks (out.diag), finite and within the softmax's hard bounds."""
+    model = UniversalReasoner(LATENT_DIM, nnx.Rngs(5), batch_size=1)
+    rng = np.random.default_rng(11)
+    batch = jnp.asarray(rng.integers(1, 5000, size=(1, 2 * MAX_SEQ_LEN + 1)), dtype=jnp.int32)
+    _, out, _, _ = compute_grad_step(model, batch, step=0, max_steps=1)
+
+    vocab = model.embed.embedding[...].shape[0]
+    entropy = float(out.diag['out_entropy'])
+    logz = float(out.diag['logz_mean'])
+    max_abs = float(out.diag['max_abs_logit'])
+    assert 0.0 <= entropy <= float(jnp.log(vocab)) + 1e-3
+    assert np.isfinite(logz)
+    assert np.isfinite(max_abs) and max_abs > 0.0


### PR DESCRIPTION
## Summary
Adds the logit-drift thermometer from #80: mean softmax entropy, mean log Z, and max |logit| over non-pad positions, accumulated inside the chunked-CE scan and surfaced through the diag into the metrics stream.

## What & why
With tied embeddings + f16 compute + one long run, the un-normalized logit scale can drift with no instrument watching it — collapse (entropy below the data's) and blur (the "drunk" model that never cools) are both invisible today and would only surface as loss weirdness. This wires the readings the base run (#16) should launch with, and is what makes the z-loss idea (#85) judgeable at all.

- `losses.py` — the stats are a few extra reductions in the existing `lax.scan` carry of `_masked_chunked_loss`, where each chunk's full-vocab f32 logits already exist (per the issue: nearly free, no second pass over the head). `chunked_cross_entropy` now returns `(loss, stats)`; the custom-VJP backward drops the stats cotangent, so the telemetry is *structurally* incapable of leaking gradient into training — measurement only, by construction.
- `grad_step.py` — window 2's stats (the same segment `token_loss` reads) ride `out.diag` under `out_entropy` / `logz_mean` / `max_abs_logit`. The `(loss, out, grads, grad_norm)` return contract is unchanged, so no other call site moves.
- `metrics_logger.py` — three new CSV columns + the readings on the per-log console line, and they join the non-finite-value warning set. The resume path already rewrites the CSV when the schema gains columns, and `plot_history.py` reads by `DictReader`, so old runs stay loadable.

Closes #80

## Validation / smoke-test performed
- [x] `JAX_PLATFORMS=cpu pytest tests/ -q` passes locally (full suite; skips are the usual GPU-only gates)
- Other checks run:
  - **Acceptance (values match naive)**: new `tests/test_logit_telemetry.py` pins the chunked, masked accumulation against a naive full-logit reference (entropy / log Z / max |logit|), across dividing and non-dividing chunk sizes, with real pad masking.
  - **No-gradient contract**: differentiating through the stats yields exactly zero for both `hidden` and `embedding`; the existing chunked-vs-naive gradient parity test still passes, so the loss gradients are untouched.
  - **Wiring**: the production `compute_grad_step` exposes finite readings in `out.diag`, with entropy inside the softmax's hard bounds; all-pad windows stay finite.
  - **Golden run**: `RUN_GOLDEN=1 pytest tests/test_golden_run.py` green with **no re-record** — the loss trajectory is bit-identical.
  - **Step-time (acceptance: unmeasurable within noise)**: interleaved CPU timing of `value_and_grad` of the CE alone at production shape (b1/s512/d512/vocab 50304): +60 ms median (+7.4%) at the isolated-loss level; against a measured ~15.2 s real CPU micro-step (`tools/bench_train_step.py --depth 8`, 2 CE calls ≈ +120 ms) that is ~0.8%, inside noise. The named accept gate — `bench_train_step.py` on the RTX 2060, where the reductions run on already-materialized f32 logits — remains to be read on the next GPU smoke, per the issue's third acceptance bullet.
  - `ruff check` clean on all touched files.

## Risk
- **Loss value and gradients unchanged** (golden green, gradient parity green). The only API change is `chunked_cross_entropy` returning `(loss, stats)`; its sole non-test caller (`grad_step.py`) is updated in the same commit.
- **Metrics CSV gains three columns** — handled by the existing gained-columns rewrite on resume; readers use `DictReader`.
- No change to model, checkpoint format, data path, or pinned deps. Worst case is a small step-time cost, priced above and re-checked on GPU.

## Checklist
- [x] Did not weaken or delete any test (no skips/xfails/loosened asserts to make it pass)
- [x] Smoke-tested; no multi-hour run was launched without sign-off
- [x] Pinned deps unchanged
- [x] Findings/claims backed by evidence in the PR (see Validation section)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TCSTo5AwfEJiUdGJds2UNs

---
_Generated by [Claude Code](https://claude.ai/code/session_01TCSTo5AwfEJiUdGJds2UNs)_