### PR TITLE
Derive DECAY_STEPS from the run's token budget — don't anneal cold before training ends (#83)

### DIFF
--- a/config.py
+++ b/config.py
@@ -61,6 +61,19 @@ REFINER_ENCODER_LAYERS = int(os.environ.get("REFINER_ENCODER_LAYERS", "7"))
 MAX_STEPS_LIMIT = 8
 BATCH_SIZE = 1
 ACCUMULATION_STEPS = 128
+# Target tokens consumed per optimizer step: each micro-step scores two
+# MAX_SEQ_LEN prediction windows, ACCUMULATION_STEPS micro-steps make one opt step.
+TOKENS_PER_OPT_STEP = ACCUMULATION_STEPS * BATCH_SIZE * 2 * MAX_SEQ_LEN
+
+# Planned token budget for the run (#83) — env-overridable per run like the seeds,
+# recorded in run_metadata.json. Drives schedules.DECAY_STEPS so the LR cosine
+# bottoms out when training ends instead of at a constant chosen for past short
+# runs (15000 opt steps ≈ 2.0B tokens — an anneal that would sit frozen at the
+# 1e-6 floor for most of a longer run). Accepts plain ints or scientific notation
+# ("2e9"). Unset → the historical 15000-step horizon, so existing configs and the
+# golden run resolve unchanged.
+_TOKEN_BUDGET_ENV = os.environ.get("TRAIN_TOKEN_BUDGET")
+TRAIN_TOKEN_BUDGET = int(float(_TOKEN_BUDGET_ENV)) if _TOKEN_BUDGET_ENV else None
 # Padding reuses the tokenizer's end-of-text id (sequences are eot-separated, so the
 # pad token and the document separator are the same symbol). r50k_base eot = 50256.
 PAD_TOKEN_ID = 50256

--- a/run_tracker.py
+++ b/run_tracker.py
@@ -19,7 +19,9 @@ from config import (
     NUM_GROUPS,
     DATA_SEED,
     MODEL_SEED,
+    TRAIN_TOKEN_BUDGET,
 )
+from schedules import DECAY_STEPS
 
 class RunTracker:
     def __init__(self, runs_root="runs"):
@@ -72,6 +74,9 @@ class RunTracker:
             "NUM_GROUPS": NUM_GROUPS,
             "DATA_SEED": DATA_SEED,
             "MODEL_SEED": MODEL_SEED,
+            # The run's recipe horizon (#83): budget in, resolved anneal out.
+            "TRAIN_TOKEN_BUDGET": TRAIN_TOKEN_BUDGET,
+            "DECAY_STEPS": DECAY_STEPS,
         }
 
     def _check_compatibility(self, metadata_path):

--- a/schedules.py
+++ b/schedules.py
@@ -1,32 +1,70 @@
 import numpy as np
 import optax
 
-from config import MAX_STEPS_LIMIT, DATA_SEED
+from config import MAX_STEPS_LIMIT, DATA_SEED, TOKENS_PER_OPT_STEP, TRAIN_TOKEN_BUDGET
 
+# Warmup is absolute: it stabilizes the optimizer's first moments, a fixed-cost
+# phase that does not grow with the run.
 WARMUP_STEPS = 1000
-DECAY_STEPS = 15000
 
-learning_schedule = optax.warmup_cosine_decay_schedule(
-    init_value=1e-5,
-    peak_value=1e-4,
-    warmup_steps=WARMUP_STEPS, 
-    decay_steps=DECAY_STEPS, 
-    end_value=1e-6
-)
+# The LR anneal's horizon must match the run length (#83). DECAY_STEPS derives
+# from the planned token budget (config.TRAIN_TOKEN_BUDGET); with no budget set
+# it stays at the historical 15000 opt steps, so existing configs and the golden
+# run resolve unchanged.
+_DEFAULT_DECAY_STEPS = 15000
+
+
+def resolve_decay_steps(token_budget, tokens_per_opt_step=TOKENS_PER_OPT_STEP):
+    """Opt-step horizon for the run: token budget / tokens per opt step
+    (None → the historical default). A budget that doesn't clear warmup is a
+    config error, not a run worth starting — fail loud."""
+    if token_budget is None:
+        return _DEFAULT_DECAY_STEPS
+    steps = round(token_budget / tokens_per_opt_step)
+    if steps <= WARMUP_STEPS:
+        raise ValueError(
+            f"TRAIN_TOKEN_BUDGET={token_budget} resolves to {steps} opt steps, "
+            f"inside the {WARMUP_STEPS}-step warmup — the cosine would never decay."
+        )
+    return steps
+
+
+def build_learning_schedule(decay_steps):
+    """The run's LR schedule at an explicit horizon; module-level
+    learning_schedule is this at the resolved DECAY_STEPS."""
+    return optax.warmup_cosine_decay_schedule(
+        init_value=1e-5,
+        peak_value=1e-4,
+        warmup_steps=WARMUP_STEPS,
+        decay_steps=decay_steps,
+        end_value=1e-6
+    )
+
+
+DECAY_STEPS = resolve_decay_steps(TRAIN_TOKEN_BUDGET)
+learning_schedule = build_learning_schedule(DECAY_STEPS)
+
+# The λ anneals deliberately do NOT follow DECAY_STEPS (#83): they relax
+# regularization pressure over early training — absolute-step optimizer
+# dynamics, like warmup — not a function of the run's energy budget. On a
+# longer run they sit at their end values from 15k on, which is today's
+# behavior made explicit rather than silently stretched. (For the refiner
+# arch both terms are exactly zero anyway.)
+LAMBDA_DECAY_STEPS = 15000
 
 forget_lambda_schedule = optax.warmup_cosine_decay_schedule(
-    init_value=0.0, 
-    peak_value=0.05, 
-    warmup_steps=WARMUP_STEPS, 
-    decay_steps=DECAY_STEPS, 
+    init_value=0.0,
+    peak_value=0.05,
+    warmup_steps=WARMUP_STEPS,
+    decay_steps=LAMBDA_DECAY_STEPS,
     end_value=0.001
 )
 
 diversity_lambda_schedule = optax.warmup_cosine_decay_schedule(
-    init_value=0.0, 
-    peak_value=1.0, 
-    warmup_steps=WARMUP_STEPS, 
-    decay_steps=DECAY_STEPS, 
+    init_value=0.0,
+    peak_value=1.0,
+    warmup_steps=WARMUP_STEPS,
+    decay_steps=LAMBDA_DECAY_STEPS,
     end_value=0.1
 )
 

--- a/tests/test_schedules.py
+++ b/tests/test_schedules.py
@@ -1,0 +1,109 @@
+"""LR-horizon resolution (#83): DECAY_STEPS derives from the run's token budget
+so the cosine bottoms out when training ends, not 2.0B tokens in.
+
+Pinned here: the derivation math, the acceptance criteria (end step hits
+end_value, half-budget is mid-cosine), the unset-env default that keeps the
+golden run untouched, the loud failure on a degenerate budget, the deliberate
+decision that the λ anneals keep their own absolute horizon, and the recording
+of budget + resolved horizon in run metadata. Env-override cases run in a
+subprocess because config.py reads the environment at import time.
+"""
+
+import json
+import os
+import subprocess
+import sys
+
+import numpy as np
+import pytest
+
+from config import TOKENS_PER_OPT_STEP
+from schedules import (
+    DECAY_STEPS,
+    LAMBDA_DECAY_STEPS,
+    WARMUP_STEPS,
+    build_learning_schedule,
+    diversity_lambda_schedule,
+    forget_lambda_schedule,
+    resolve_decay_steps,
+)
+
+REPO = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+
+LR_PEAK, LR_END = 1e-4, 1e-6
+
+
+def test_tokens_per_opt_step_matches_recipe():
+    """The issue's arithmetic: 128 accumulation × batch 1 × 1024 target tokens
+    per micro-step. If the batch recipe changes, this constant must follow."""
+    assert TOKENS_PER_OPT_STEP == 128 * 1 * 2 * 512
+
+
+@pytest.mark.skipif(bool(os.environ.get("TRAIN_TOKEN_BUDGET")),
+                    reason="suite invoked with an explicit TRAIN_TOKEN_BUDGET")
+def test_unset_budget_keeps_historical_horizon():
+    """No budget → today's 15000, so existing configs (and the golden run's
+    trajectory) resolve exactly as before this change."""
+    assert resolve_decay_steps(None) == 15000
+    assert DECAY_STEPS == 15000
+
+
+def test_derived_horizon_is_budget_over_tokens_per_step():
+    assert resolve_decay_steps(40_000 * TOKENS_PER_OPT_STEP) == 40_000
+
+
+def test_anneal_ends_at_budget_and_half_budget_is_mid_cosine():
+    """The acceptance criteria: schedule value at the configured end step equals
+    end_value; at half-budget it's mid-cosine."""
+    decay = resolve_decay_steps(30_000 * TOKENS_PER_OPT_STEP)
+    sched = build_learning_schedule(decay)
+
+    assert np.isclose(float(sched(decay)), LR_END, rtol=1e-6)
+    assert np.isclose(float(sched(decay * 2)), LR_END, rtol=1e-6)  # floor, not rebound
+
+    half = decay // 2
+    frac = (half - WARMUP_STEPS) / (decay - WARMUP_STEPS)
+    expected = LR_END + 0.5 * (LR_PEAK - LR_END) * (1 + np.cos(np.pi * frac))
+    assert np.isclose(float(sched(half)), expected, rtol=1e-3)
+
+
+def test_budget_inside_warmup_fails_loud():
+    with pytest.raises(ValueError):
+        resolve_decay_steps(WARMUP_STEPS * TOKENS_PER_OPT_STEP // 2)
+
+
+def test_lambda_schedules_keep_their_own_horizon():
+    """Deliberate (#83): the λ anneals relax regularization pressure over early
+    training — absolute-step dynamics — and must not silently stretch with the
+    LR horizon. Their end values land at LAMBDA_DECAY_STEPS regardless."""
+    assert LAMBDA_DECAY_STEPS == 15000
+    assert np.isclose(float(forget_lambda_schedule(LAMBDA_DECAY_STEPS)), 0.001, rtol=1e-6)
+    assert np.isclose(float(diversity_lambda_schedule(LAMBDA_DECAY_STEPS)), 0.1, rtol=1e-6)
+
+
+def _resolved_in_subprocess(env_overrides):
+    env = {**os.environ, **env_overrides}
+    out = subprocess.check_output(
+        [sys.executable, "-c",
+         "import json, config, schedules; print(json.dumps("
+         "{'budget': config.TRAIN_TOKEN_BUDGET, 'decay': schedules.DECAY_STEPS}))"],
+        env=env, cwd=REPO,
+    )
+    return json.loads(out)
+
+
+def test_env_override_resolves_horizon():
+    budget = 20_000 * TOKENS_PER_OPT_STEP
+    assert _resolved_in_subprocess({"TRAIN_TOKEN_BUDGET": str(budget)}) == \
+        {"budget": budget, "decay": 20_000}
+    # Scientific notation is accepted: 2e9 ≈ the historical 2.0B-token horizon.
+    resolved = _resolved_in_subprocess({"TRAIN_TOKEN_BUDGET": "2e9"})
+    assert resolved == {"budget": 2_000_000_000,
+                        "decay": round(2e9 / TOKENS_PER_OPT_STEP)}
+
+
+def test_horizon_recorded_in_run_metadata():
+    from run_tracker import RunTracker
+    params = RunTracker.get_hyperparameters()
+    assert params["DECAY_STEPS"] == DECAY_STEPS
+    assert "TRAIN_TOKEN_BUDGET" in params

--- a/trainer.py
+++ b/trainer.py
@@ -24,6 +24,8 @@ from config import (
     MAX_STEPS_LIMIT,
     DATA_SEED,
     MODEL_SEED,
+    TOKENS_PER_OPT_STEP,
+    TRAIN_TOKEN_BUDGET,
     resolve_root,
 )
 from model import UniversalReasoner
@@ -33,6 +35,8 @@ from optimizers import optimizer_chain, create_sft_optimizer
 from schedules import (
     CURRICULUM_START_WEIGHTS,
     SFT_MIX_WEIGHTS,
+    DECAY_STEPS,
+    WARMUP_STEPS,
     get_curriculum_weights,
     get_average_curriculum_weights,
     sample_reasoning_depth,
@@ -80,6 +84,14 @@ def init_model_and_optimizer():
 
     print(f"📐 Architecture '{MODEL_ARCH}': {_param_count(model) / 1e6:.1f}M parameters "
           f"(MODEL_SEED={MODEL_SEED}, DATA_SEED={DATA_SEED})")
+    # The resolved LR horizon must be visible at launch (#83): an anneal that
+    # bottoms out before the budget ends is undertraining masquerading as an
+    # architecture problem.
+    budget_note = (f"TRAIN_TOKEN_BUDGET={TRAIN_TOKEN_BUDGET:,}" if TRAIN_TOKEN_BUDGET is not None
+                   else "TRAIN_TOKEN_BUDGET unset — historical default")
+    print(f"🗓️ LR horizon: DECAY_STEPS={DECAY_STEPS:,} opt steps "
+          f"(warmup {WARMUP_STEPS:,}) ≈ {DECAY_STEPS * TOKENS_PER_OPT_STEP / 1e9:.2f}B "
+          f"target tokens ({budget_note})")
     optimizer = nnx.Optimizer(model, optimizer_chain, wrt=nnx.Param)
 
     return model, optimizer


### PR DESCRIPTION
## Summary
The LR cosine's horizon now derives from the run's planned token budget (`TRAIN_TOKEN_BUDGET`, env-overridable per run like the seeds) instead of the hardcoded 15000 opt steps. Unset, everything resolves exactly as before.

## What & why
`schedules.py` hardcoded `DECAY_STEPS = 15000` — at 128 accum × batch 1 × 1024 target tokens per micro-step, the cosine reaches its 1e-6 floor after ≈2.0B tokens. The base run (#16) contemplates budgets well past that, and an anneal that bottoms out early leaves the system effectively frozen for the rest of the run — undertraining that would masquerade as an architecture problem, on the run whose whole purpose is to rule that confound out.

- `config.py` — `TRAIN_TOKEN_BUDGET` (env; accepts plain ints or `2e9`-style; unset → `None`) and `TOKENS_PER_OPT_STEP` (131072, the recipe arithmetic from the issue).
- `schedules.py` — `DECAY_STEPS = resolve_decay_steps(TRAIN_TOKEN_BUDGET)`: budget ÷ tokens-per-opt-step, or the historical 15000 when unset. A budget that doesn't clear warmup raises (config error, fail loud). `WARMUP_STEPS` stays absolute per the issue. `build_learning_schedule(decay_steps)` exposes the LR schedule at an explicit horizon for tests.
- **The deliberate λ decision the issue asked for**: the `forget`/`diversity` anneals do **not** follow `DECAY_STEPS`. They get their own explicitly-named `LAMBDA_DECAY_STEPS = 15000`: they relax regularization pressure over early training — absolute-step optimizer dynamics, like warmup — not a function of the run's energy budget. On a longer run they sit at their end values from 15k on, which is today's behavior made explicit rather than silently stretched (and for the refiner arch both terms multiply exact zeros anyway). Pinned by a test so a future change must be deliberate too.
- `trainer.py` — the resolved horizon prints at launch: `🗓️ LR horizon: DECAY_STEPS=15,000 opt steps (warmup 1,000) ≈ 1.97B target tokens (TRAIN_TOKEN_BUDGET unset — historical default)`.
- `run_tracker.py` — budget + resolved `DECAY_STEPS` land in `run_metadata.json` (and therefore the model card's config snapshot).

**Must land before the #16 launch** — it changes the recipe, so it can't slip in mid-run.

Closes #83

## Validation / smoke-test performed
- [x] `JAX_PLATFORMS=cpu pytest tests/ -q` passes locally (full suite; skips are the usual GPU-only gates)
- Other checks run:
  - **Acceptance tests** (new `tests/test_schedules.py`): schedule value at the configured end step equals `end_value` (and stays at the floor past it); at half-budget it matches the analytic mid-cosine value; the derivation math (`budget/TOKENS_PER_OPT_STEP`); unset env → 15000; degenerate budget raises; λ horizon pinned; env override verified in a subprocess (config reads env at import time, same pattern as `test_seed_config.py`); `run_metadata.json` recording verified.
  - **Golden-run implications checked** (the issue's third acceptance bullet): `RUN_GOLDEN=1` green with **no re-record** — the default resolves to today's 15000, so the trajectory is untouched.
  - Manually exercised the launch path: the horizon line prints and `run_metadata.json` carries `"TRAIN_TOKEN_BUDGET": null, "DECAY_STEPS": 15000` on a default run.
  - `ruff check` clean on all touched files.

## Risk
- **Default behavior is bit-identical** (golden green; `optimizers.py`'s `learning_schedule` resolves to the same schedule when the env is unset).
- With a budget set, the LR anneal stretches — that's the fix, and it's recorded per run in `run_metadata.json` so runs stay comparable on paper.
- The λ schedules are numerically unchanged in all cases (same 15000 horizon, now under their own name).
- No model, checkpoint, data-path, or pinned-dep changes.

## Checklist
- [x] Did not weaken or delete any test (no skips/xfails/loosened asserts to make it pass)
- [x] Smoke-tested; no multi-hour run was launched without sign-off
- [x] Pinned deps unchanged
- [x] Findings/claims backed by evidence in the PR (see Validation section)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TCSTo5AwfEJiUdGJds2UNs

---
_Generated by [Claude Code](https://claude.ai/code/session_01TCSTo5AwfEJiUdGJds2UNs)_