### PR TITLE
Grade-annealing ablation: the per-slot grade is a scaffold, not a crutch (#73)

### DIFF
--- a/docs/findings/2026-07-10-grade-annealing-scaffold-not-crutch.md
+++ b/docs/findings/2026-07-10-grade-annealing-scaffold-not-crutch.md
@@ -51,7 +51,9 @@ Two reads underneath the headline number:
   matched control held 0.999. One seed in three losing ~0.14 is not a collapse,
   but it is not the control's flat line either.
 
-Slot probes (read through the grade head, frozen once λ = 0): at the cut the
+Slot probes (read through the grade head, which stops receiving gradient once
+λ = 0 — only AdamW's weight decay drifts it after that, uniformly, so its
+argmax readout is unaffected): at the cut the
 annealed chains look like the control's (seed 0's slot 4 still forming at
 0.572); at the end the frozen head reads 0.74–1.00. Seed 2's end probes dropped
 roughly uniformly (0.80–0.85) rather than deepest-first as the issue guessed.
@@ -71,7 +73,8 @@ roughly uniformly (0.80–0.85) rather than deepest-first as the issue guessed.
 - Toy scale, one task family, 3 seeds — σ_annealed estimated from 3 points is
   itself noisy; the scaffold verdict clears the pre-registered bar but the bar
   is wide because the annealed arm's own spread sets it.
-- The end-of-run slot probe is read through a head frozen at step 1500; slot
+- The end-of-run slot probe is read through a head that stops learning at
+  step 1500; slot
   representations that drifted while staying informative under-read. Final
   accuracy is the load-bearing metric; the probes are directional only.
 - 1000 grade-free steps can't distinguish "seed 2 found a stable plateau at

--- a/docs/findings/2026-07-10-grade-annealing-scaffold-not-crutch.md
+++ b/docs/findings/2026-07-10-grade-annealing-scaffold-not-crutch.md
@@ -1,0 +1,78 @@
+# Annealed to zero mid-training, the per-slot grade proves to be a scaffold — the chain survives on final-answer loss alone, but removal costs stability
+
+Status: toy-proof (the #73 gate; completes the #67 story)
+Date: 2026-07-10
+Commit: 243b8b1  Run: tiny-config ablation (synthetic, no runs/ id)  Measured with: `JAX_PLATFORMS=cpu FORCE_F32_COMPUTE=1 python scratchpad_harness.py --arms serial,annealed --seeds 0,1,2 --K 4 --m 7 --steps 2500`
+
+## Setup
+
+#67 proved the per-slot grade is load-bearing: final-answer-only supervision
+from scratch never forms the chain (0.1341 ± 0.004 vs the graded 0.9922 ± 0.011).
+That kills "the decomposition emerges for free" but says nothing about whether
+the grade must stay on forever. This ablation anneals it away mid-run: the
+`annealed` arm is the graded serial arm with λ_slot fully on for steps 0–1000,
+linearly decayed 1000–1500, and exactly zero for 1500–2500 — a full 1000
+final-only steps to expose decay. One variable, matched pairs, seeds {0,1,2},
+same protocol as #38/#67 (affine chain K=4, m=7, dim 64, held-out 4096). The
+re-run graded control reproduced the #38/#67 numbers *exactly* (0.9988 /
+0.9790 / 0.9988), so the harness refactor changed nothing. Held-out accuracy
+is measured at the grade-off step (1500) and at the end, for both arms.
+
+Pre-registered on the issue: annealed within 2σ_pooled of its matched graded
+control → **scaffold**; ≥2σ below *and* trending down across the grade-free
+stretch → **crutch**; ≥2σ below but flat → **frozen-but-stable**.
+
+## Evidence
+
+Held-out final-answer accuracy:
+
+| arm | seed 0 | seed 1 | seed 2 | mean | σ |
+|---|---|---|---|---|---|
+| serial (graded throughout, control) | 0.9988 | 0.9790 | 0.9988 | 0.9922 | 0.011 |
+| annealed @ step 1500 (grade just off) | 0.6902 | 0.9919 | 0.9915 | 0.8912 | — |
+| annealed @ step 2500 (1000 grade-free steps) | 0.9524 | 0.9963 | 0.8494 | **0.9327** | 0.075 |
+
+Δ vs control = 0.060 < 2σ_pooled = 0.108 → the pre-registered **scaffold**
+verdict. The crutch criterion fails on both of its clauses: the gap is under
+2σ, and the grade-free trend is not a decay — it is *mixed* (+0.26, +0.00,
+−0.14 across seeds). Nothing returns to the chance regime: the worst seed ends
+at 0.849, six-fold above the 0.134 final-only-from-scratch floor (#67).
+
+Two reads underneath the headline number:
+
+- **Final-only CE can refine a formed chain it could never have built.** Seed 0
+  sat at 0.690 when the grade switched off and climbed to 0.952 across the
+  grade-free stretch — the exact loss that stays at chance from scratch (#67)
+  drives real improvement once the grade has nucleated the decomposition. The
+  asymmetry is clean: per-step supervision creates the road; final-answer loss
+  can then drive on it.
+- **But the grade was also a stabilizer.** Seed variance grows ~7× when it goes
+  (σ 0.011 → 0.075), and seed 2 genuinely decayed, 0.9915 → 0.8494, while its
+  matched control held 0.999. One seed in three losing ~0.14 is not a collapse,
+  but it is not the control's flat line either.
+
+Slot probes (read through the grade head, frozen once λ = 0): at the cut the
+annealed chains look like the control's (seed 0's slot 4 still forming at
+0.572); at the end the frozen head reads 0.74–1.00. Seed 2's end probes dropped
+roughly uniformly (0.80–0.85) rather than deepest-first as the issue guessed.
+
+## What this bounds
+
+- The LM-scale cost estimate collapses: per-step targets are a **warm-up
+  budget, not a run-long budget**. The bet's expensive branch (#67) shrinks to
+  a nucleation phase plus an anneal.
+- Budget for the stability wrinkle: removing the grade entirely trades a small
+  mean gap for a large variance. The natural follow-ups (filed as the
+  pre-registration requires): how early can the anneal start, and does a small
+  floor (λ ≈ 0.1) keep the variance of the graded arm at zero marginal cost.
+
+## Limitations
+
+- Toy scale, one task family, 3 seeds — σ_annealed estimated from 3 points is
+  itself noisy; the scaffold verdict clears the pre-registered bar but the bar
+  is wide because the annealed arm's own spread sets it.
+- The end-of-run slot probe is read through a head frozen at step 1500; slot
+  representations that drifted while staying informative under-read. Final
+  accuracy is the load-bearing metric; the probes are directional only.
+- 1000 grade-free steps can't distinguish "seed 2 found a stable plateau at
+  0.85" from "seed 2 decays slowly"; a longer grade-free tail would resolve it.

--- a/docs/findings/README.md
+++ b/docs/findings/README.md
@@ -21,6 +21,7 @@ things, it doesn't go in this folder.
 - `2026-07-04-gpt2-yardstick-calibrated.md` — the GPT-2-small yardstick reproduces the reference reading (#48)
 - `2026-07-04-slots-only-readout-compression-real.md` — #62: a readout blinded to tokens stays within noise; compression real
 - `2026-07-04-final-only-supervision-decomposition-is-taught.md` — #67: without the per-slot grade the scratchpad sits at chance; the decomposition is taught, not emergent
+- `2026-07-10-grade-annealing-scaffold-not-crutch.md` — #73: the grade is a scaffold — annealed to zero mid-run the chain survives on final-answer loss (within 2σ), but seed variance grows ~7×
 
 ## Entry template
 

--- a/scratchpad_harness.py
+++ b/scratchpad_harness.py
@@ -1,6 +1,6 @@
-"""Toy proof harness for the supervised serial latent scratchpad (#38, #62, #67).
+"""Toy proof harness for the supervised serial latent scratchpad (#38, #62, #67, #73).
 
-Five arms on the chained-affine-maps task (docs/design/serial-scratchpad.md):
+Six arms on the chained-affine-maps task (docs/design/serial-scratchpad.md):
 
   serial    — K ordered sub-slots, each written ONCE by a shared cross-attention
               write block reading tokens + EARLIER slots only, each graded
@@ -19,6 +19,14 @@ Five arms on the chained-affine-maps task (docs/design/serial-scratchpad.md):
               (stop-gradient probe): the model is taught by final-answer CE
               only, while the readout head still measures what each slot
               carries. The does-the-decomposition-emerge ablation (#67).
+  annealed  — the graded serial arm, but λ_slot follows a schedule: fully on
+              for the first 40% of training, linear decay to zero across
+              40–60%, exactly zero for the last 40%. The scaffold-or-crutch
+              ablation (#73): #67 proved the grade must be present to
+              nucleate the chain — this asks whether, once the chain exists,
+              it sustains itself on final-answer loss alone. Held-out
+              accuracy is also measured at the grade-off step so decay across
+              the grade-free stretch is visible (crutch vs frozen-but-stable).
 
 Task: r_0 = 0; r_k = (r_{k-1} * a_k + b_k) mod m from tokens [a_1 b_1 ... a_K b_K].
 Affine composition mod m is non-commutative — no order-free shortcut — and
@@ -166,8 +174,38 @@ def n_params(model):
     return sum(int(x.size) for x in jax.tree_util.tree_leaves(nnx.state(model, nnx.Param)))
 
 
+def grade_lambda(step, total_steps):
+    """λ_slot schedule for the annealed arm (#73): fully on for the first 40%
+    of training, linear decay across 40–60%, exactly zero afterwards. At the
+    pre-registered 2500 steps that is on for 0–1000, decay 1000–1500, off for
+    1500–2500 — a full 1000 grade-free steps to expose decay."""
+    on_until, off_from = 0.4 * total_steps, 0.6 * total_steps
+    if step < on_until:
+        return 1.0
+    if step >= off_from:
+        return 0.0
+    return 1.0 - (step - on_until) / (off_from - on_until)
+
+
+def arm_losses(arm, mdl, tok, sub, lam, depth):
+    """Loss and logits for one arm. lam is the slot-grade weight λ_slot —
+    fixed at 1.0 for every arm except annealed (#73), which passes
+    grade_lambda(step). In the finalonly arm the slots are stop-gradiented
+    inside the model, so the grade term only fits the diagnostic probe head —
+    the model's sole teacher there is the final-answer CE (#67)."""
+    final = sub[:, -1]
+    if arm == "depthonly":
+        logits = mdl(tok, depth=depth)[:, -1]                # answer at last position
+        ce_final = optax.softmax_cross_entropy_with_integer_labels(logits, final).mean()
+        return ce_final, (logits, None)
+    answer_logits, slot_logits = mdl(tok)
+    ce_final = optax.softmax_cross_entropy_with_integer_labels(answer_logits, final).mean()
+    ce_slots = optax.softmax_cross_entropy_with_integer_labels(slot_logits, sub).mean()
+    return ce_final + lam * ce_slots, (answer_logits, slot_logits)
+
+
 def train_one_arm(arm, *, K=4, m=7, dim=64, heads=4, enc=2, steps=2500, batch=256,
-                  lr=2e-3, wd=0.01, seed=0, n_pool=32768, n_test=4096, slot_lambda=1.0):
+                  lr=2e-3, wd=0.01, seed=0, n_pool=32768, n_test=4096):
     task = affine_chain_task(K, m)
     key = jax.random.PRNGKey(seed)
     key, dk_tr, dk_te = jax.random.split(key, 3)
@@ -186,26 +224,11 @@ def train_one_arm(arm, *, K=4, m=7, dim=64, heads=4, enc=2, steps=2500, batch=25
                               probe_only=(arm == "finalonly"), rngs=nnx.Rngs(seed))
     opt = nnx.Optimizer(model, optax.adamw(lr, weight_decay=wd), wrt=nnx.Param)
 
-    def losses(mdl, tok, sub):
-        final = sub[:, -1]
-        if arm == "depthonly":
-            logits = mdl(tok, depth=K)[:, -1]                    # answer at last position
-            ce_final = optax.softmax_cross_entropy_with_integer_labels(logits, final).mean()
-            return ce_final, (logits, None)
-        answer_logits, slot_logits = mdl(tok)
-        ce_final = optax.softmax_cross_entropy_with_integer_labels(answer_logits, final).mean()
-        # The grade: λ fixed at 1.0 (pre-registered — see the design doc). In
-        # the finalonly arm the slots are stop-gradiented inside the model, so
-        # this same term only fits the diagnostic probe head — the model's
-        # sole teacher there is ce_final (#67).
-        ce_slots = optax.softmax_cross_entropy_with_integer_labels(slot_logits, sub).mean()
-        return ce_final + slot_lambda * ce_slots, (answer_logits, slot_logits)
-
     @nnx.jit
-    def step(mdl, op, k):
+    def step(mdl, op, k, lam):
         idx = jax.random.randint(k, (batch,), 0, tr_tok.shape[0])
         def loss_fn(mm):
-            loss, _ = losses(mm, tr_tok[idx], tr_sub[idx])
+            loss, _ = arm_losses(arm, mm, tr_tok[idx], tr_sub[idx], lam, K)
             return loss
         loss, grads = nnx.value_and_grad(loss_fn)(mdl)
         op.update(mdl, grads)
@@ -213,24 +236,38 @@ def train_one_arm(arm, *, K=4, m=7, dim=64, heads=4, enc=2, steps=2500, batch=25
 
     @nnx.jit
     def eval_all(mdl):
-        _, (answer_logits, slot_logits) = losses(mdl, te_tok, te_sub)
+        _, (answer_logits, slot_logits) = arm_losses(arm, mdl, te_tok, te_sub, 1.0, K)
         final_acc = jnp.mean(answer_logits.argmax(-1) == te_sub[:, -1])
         slot_acc = (jnp.mean(slot_logits.argmax(-1) == te_sub, axis=0)
                     if slot_logits is not None else jnp.zeros(K))
         return final_acc, slot_acc
 
-    for _ in range(steps):
+    # The grade-off step: where the annealed λ_slot reaches exactly zero. Every
+    # arm is evaluated here too, so annealed-vs-control is a matched comparison
+    # at both checkpoints and decay across the grade-free stretch is measurable.
+    cut = min(int(round(0.6 * steps)), steps - 1)
+    cut_final = cut_slots = None
+    for i in range(steps):
+        if i == cut:
+            cut_final, cut_slots = eval_all(model)
         key, k = jax.random.split(key)
-        step(model, opt, k)
+        step(model, opt, k, grade_lambda(i, steps) if arm == "annealed" else 1.0)
 
     final_acc, slot_acc = eval_all(model)
-    return float(final_acc), [float(x) for x in slot_acc], n_params(model)
+    return {
+        "final_acc": float(final_acc),
+        "slot_acc": [float(x) for x in slot_acc],
+        "cut_final_acc": float(cut_final),
+        "cut_slot_acc": [float(x) for x in cut_slots],
+        "params": n_params(model),
+    }
 
 
 def main():
     ap = argparse.ArgumentParser()
     ap.add_argument("--arms", default="serial,parallel,depthonly",
-                    help="any of serial,parallel,depthonly,slotsonly (#62),finalonly (#67)")
+                    help="any of serial,parallel,depthonly,slotsonly (#62),"
+                         "finalonly (#67),annealed (#73)")
     ap.add_argument("--seeds", default="0,1,2")
     ap.add_argument("--K", type=int, default=4, help="number of chained sub-steps = number of slots")
     ap.add_argument("--m", type=int, default=7, help="modulus (prime); vocab and chance level 1/m")
@@ -238,16 +275,22 @@ def main():
     ap.add_argument("--dim", type=int, default=64)
     args = ap.parse_args()
 
+    cut = min(int(round(0.6 * args.steps)), args.steps - 1)
     print(f"== serial-scratchpad proof (#38): K={args.K} m={args.m} dim={args.dim} "
-          f"steps={args.steps} (chance={1/args.m:.3f}) ==")
-    print(f"{'arm':>10} {'seed':>5} {'params':>9} {'final_acc':>10} {'sec':>7}  slot_accs")
+          f"steps={args.steps} (chance={1/args.m:.3f}, grade-off step={cut}) ==")
+    print(f"{'arm':>10} {'seed':>5} {'params':>9} {'acc@cut':>8} {'final_acc':>10} {'sec':>7}"
+          "  slot_accs cut[...] end[...]")
+    def fmt(accs):
+        return " ".join(f"{a:.3f}" for a in accs) if any(accs) else "-"
+
     for arm in args.arms.split(","):
         for seed in [int(s) for s in args.seeds.split(",")]:
             t0 = time.time()
-            acc, slot_acc, params = train_one_arm(arm, K=args.K, m=args.m,
-                                                  dim=args.dim, steps=args.steps, seed=seed)
-            slots = " ".join(f"{a:.3f}" for a in slot_acc) if any(slot_acc) else "-"
-            print(f"{arm:>10} {seed:>5} {params/1e6:>8.2f}M {acc:>10.4f} {time.time()-t0:>7.1f}  [{slots}]",
+            r = train_one_arm(arm, K=args.K, m=args.m,
+                              dim=args.dim, steps=args.steps, seed=seed)
+            print(f"{arm:>10} {seed:>5} {r['params']/1e6:>8.2f}M {r['cut_final_acc']:>8.4f} "
+                  f"{r['final_acc']:>10.4f} {time.time()-t0:>7.1f}  "
+                  f"cut[{fmt(r['cut_slot_acc'])}] end[{fmt(r['slot_acc'])}]",
                   flush=True)
 
 

--- a/tests/test_scratchpad_harness.py
+++ b/tests/test_scratchpad_harness.py
@@ -11,7 +11,8 @@ import numpy as np
 import optax
 from flax import nnx
 
-from scratchpad_harness import ScratchpadNet, affine_chain_task, n_params, train_one_arm
+from scratchpad_harness import (ScratchpadNet, affine_chain_task, arm_losses,
+                                grade_lambda, n_params, train_one_arm)
 
 K, M, DIM = 3, 7, 32
 
@@ -139,13 +140,53 @@ def test_finalonly_grade_is_a_detached_probe():
         "graded arm: slot CE must still teach the write block"
 
 
+def test_grade_lambda_matches_the_preregistered_schedule():
+    """#73 pre-registration at 2500 steps: grade fully on for 0–1000, linear
+    decay 1000–1500, exactly zero for 1500–2500. The schedule is written in
+    fractions of the budget so the toy-sized test runs exercise it too."""
+    S = 2500
+    assert grade_lambda(0, S) == 1.0
+    assert grade_lambda(999, S) == 1.0
+    assert grade_lambda(1250, S) == 0.5
+    assert grade_lambda(1500, S) == 0.0
+    assert grade_lambda(2499, S) == 0.0
+    lams = [grade_lambda(i, S) for i in range(S)]
+    assert all(b <= a for a, b in zip(lams, lams[1:])), "λ must never rise"
+
+
+def test_annealed_lambda_zero_kills_the_grade_gradient():
+    """annealed (#73): once λ_slot hits zero the slot grade must teach nothing
+    — the grade head gets exactly zero gradient (its only loss path is the
+    slot CE) — while final-answer CE keeps teaching the write block. That is
+    what makes the post-anneal stretch a true final-only regime (#67's regime,
+    warm-started from a formed chain)."""
+    tokens, subs = affine_chain_task(K, M)(jax.random.PRNGKey(3), 8)
+    model = ScratchpadNet(dim=DIM, vocab=M, num_slots=K, max_seq_len=2 * K,
+                          serial=True, rngs=nnx.Rngs(0))
+
+    def total_loss(mdl, lam):
+        loss, _ = arm_losses("annealed", mdl, tokens, subs, lam, K)
+        return loss
+
+    grads = nnx.to_flat_state(nnx.grad(lambda mm: total_loss(mm, 0.0))(model))
+    by_top = {}
+    for path, leaf in grads:
+        mx = float(jnp.abs(leaf[...]).max())
+        by_top[path[0]] = max(by_top.get(path[0], 0.0), mx)
+    assert by_top["slot_readout"] == 0.0, "λ=0: the grade head must be frozen"
+    assert by_top["write_block"] > 0.0, "λ=0: final CE must still teach the write block"
+
+
 def test_all_arms_train_and_beat_nothing_burns():
     """Full train/eval path runs for every arm at toy size, losses finite, and
     the graded arms report per-slot accuracies (the collapse detector)."""
-    for arm in ("serial", "parallel", "depthonly", "slotsonly", "finalonly"):
-        acc, slot_acc, params = train_one_arm(arm, K=K, m=M, dim=DIM, steps=40,
-                                              batch=64, n_pool=512, n_test=128, seed=0)
+    for arm in ("serial", "parallel", "depthonly", "slotsonly", "finalonly", "annealed"):
+        r = train_one_arm(arm, K=K, m=M, dim=DIM, steps=40,
+                          batch=64, n_pool=512, n_test=128, seed=0)
+        acc = r["final_acc"]
         assert np.isfinite(acc) and 0.0 <= acc <= 1.0, f"{arm}: bad final acc {acc}"
-        assert params > 0
+        assert np.isfinite(r["cut_final_acc"]), f"{arm}: missing grade-off checkpoint"
+        assert r["params"] > 0
         if arm != "depthonly":
-            assert len(slot_acc) == K and all(np.isfinite(a) for a in slot_acc)
+            for accs in (r["slot_acc"], r["cut_slot_acc"]):
+                assert len(accs) == K and all(np.isfinite(a) for a in accs)

--- a/tests/test_scratchpad_harness.py
+++ b/tests/test_scratchpad_harness.py
@@ -147,6 +147,7 @@ def test_grade_lambda_matches_the_preregistered_schedule():
     S = 2500
     assert grade_lambda(0, S) == 1.0
     assert grade_lambda(999, S) == 1.0
+    assert grade_lambda(1000, S) == 1.0   # the on/decay boundary itself
     assert grade_lambda(1250, S) == 0.5
     assert grade_lambda(1500, S) == 0.0
     assert grade_lambda(2499, S) == 0.0
@@ -173,7 +174,7 @@ def test_annealed_lambda_zero_kills_the_grade_gradient():
     for path, leaf in grads:
         mx = float(jnp.abs(leaf[...]).max())
         by_top[path[0]] = max(by_top.get(path[0], 0.0), mx)
-    assert by_top["slot_readout"] == 0.0, "λ=0: the grade head must be frozen"
+    assert by_top["slot_readout"] == 0.0, "λ=0: the grade head must get zero gradient"
     assert by_top["write_block"] > 0.0, "λ=0: final CE must still teach the write block"
 
 


### PR DESCRIPTION
## Summary
Runs the #73 ablation: anneal λ_slot to zero mid-training and ask whether the chain, once nucleated by the grade, survives on final-answer loss alone. Verdict by the pre-registered criterion: **scaffold** — with a recorded stability wrinkle.

Closes #73

## What & why
- **`scratchpad_harness.py`** — adds the `annealed` arm: identical to the graded serial arm except λ_slot follows the pre-registered schedule (fully on for the first 40% of steps = 0–1000, linear decay 40–60% = 1000–1500, exactly zero after — 1000 grade-free steps to expose decay). Every arm now also evaluates held-out accuracy at the grade-off step, so annealed-vs-control is a matched comparison at both checkpoints and the grade-free trend (crutch vs frozen-but-stable) is measurable. The per-arm loss is lifted to module-level `arm_losses()` so the wiring guard can test the real code path; `train_one_arm` now returns a dict (both callers updated).
- **`tests/test_scratchpad_harness.py`** — guards the pre-registered schedule values (1.0 at 0–1000, 0.5 at 1250, 0.0 from 1500, never rising) and that λ=0 freezes the grade head while final CE still teaches the write block; the all-arms smoke now includes `annealed`.
- **`docs/findings/2026-07-10-grade-annealing-scaffold-not-crutch.md`** — the result:

| arm | seed 0 | seed 1 | seed 2 | mean | σ |
|---|---|---|---|---|---|
| serial control (grade on throughout) | 0.9988 | 0.9790 | 0.9988 | 0.9922 | 0.011 |
| annealed @ 1500 (grade just off) | 0.6902 | 0.9919 | 0.9915 | 0.8912 | — |
| annealed @ 2500 | 0.9524 | 0.9963 | 0.8494 | **0.9327** | 0.075 |

Δ = 0.060 < 2σ_pooled = 0.108 → **scaffold**. Nothing returns to the #67 chance floor (0.134); seed 0 *climbed* 0.69 → 0.95 on final-only loss — the loss that sits at chance from scratch refines a chain it could never build. Caveats recorded: seed variance grows ~7× without the grade, and one seed decayed 0.99 → 0.85. LM-scale implication: per-step targets are a warm-up budget, not a run-long budget.

The re-run graded control reproduced the #38/#67 numbers exactly (0.9988 / 0.9790 / 0.9988), validating that the harness refactor changed nothing.

## Validation / smoke-test performed
- [x] `JAX_PLATFORMS=cpu pytest tests/ -q` passes locally (93 passed, GPU-only skips)
- Other checks run: the full 6-run ablation itself (`JAX_PLATFORMS=cpu FORCE_F32_COMPUTE=1 python scratchpad_harness.py --arms serial,annealed --seeds 0,1,2 --K 4 --m 7 --steps 2500`, ~15 min CPU); `ruff check` clean on changed files.

## Risk
CPU-only toy harness; no production training path, checkpoint format, or pinned dep touched. `train_one_arm`'s return type changed from tuple to dict — its only callers (`main()` and the tests) are updated in this PR.

## Checklist
- [x] Did not weaken or delete any test (no skips/xfails/loosened asserts to make it pass)
- [x] Smoke-tested; no multi-hour run was launched without sign-off
- [x] Pinned deps unchanged, or the bump is justified above
- [x] Findings/claims backed by evidence in the PR or a linked finding issue

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BitU2BHqVSp5QqnjwcE9GX

---
_Generated by [Claude Code](https://claude.ai/code/session_01BitU2BHqVSp5QqnjwcE9GX)_