### PR TITLE
#86: sinusoidal time signal opens the depth dial — parity at trained depths, +5σ past the cap; production default flipped

### DIFF
--- a/ablation_harness.py
+++ b/ablation_harness.py
@@ -141,8 +141,9 @@ VOCAB = {"parity": 2, "cumsum5": 5, "statetrack": 5}
 
 def train_one(task_fn, vocab, depth, *, arch="refiner", dim=96, heads=4, enc=2, steps=2500,
               batch=256, lr=2e-3, wd=0.01, seed=0, gate_bias=0.0, grad_last=None,
-              per_pass_loss=False, islands=False, readouts=False,
-              n_pool=32768, n_test=4096, eval_batch=256, train_seq=SEQ, test_seq=None):
+              per_pass_loss=False, islands=False, readouts=False, time_signal="learned",
+              eval_depths=None, n_pool=32768, n_test=4096, eval_batch=256,
+              train_seq=SEQ, test_seq=None):
     # When test_seq > train_seq this is a length-generalization probe: the model
     # trains on length train_seq and is evaluated on longer sequences, so it must
     # use RoPE positions it never saw in training. test_seq=None -> same length.
@@ -165,7 +166,8 @@ def train_one(task_fn, vocab, depth, *, arch="refiner", dim=96, heads=4, enc=2, 
     else:
         model = CausalRefiner(dim=dim, vocab_size=vocab, num_heads=heads,
                               num_encoder_layers=enc, max_depth=max(depth, 1),
-                              max_seq_len=max(train_seq, test_seq), gate_bias=gate_bias, rngs=nnx.Rngs(seed))
+                              max_seq_len=max(train_seq, test_seq), gate_bias=gate_bias,
+                              time_signal=time_signal, rngs=nnx.Rngs(seed))
     n_params = sum(int(x.size) for x in jax.tree_util.tree_leaves(nnx.state(model, nnx.Param)))
     opt = nnx.Optimizer(model, optax.adamw(lr, weight_decay=wd), wrt=nnx.Param)
 
@@ -217,15 +219,30 @@ def train_one(task_fn, vocab, depth, *, arch="refiner", dim=96, heads=4, enc=2, 
         a, c, m = eval_chunk_sums(model, te_inp[s], te_tgt[s], te_mask[s], depth)
         acc_sum, ce_sum, count = acc_sum + float(a), ce_sum + float(c), count + float(m)
 
+    # Depth-transfer eval (#86): score the trained model at OTHER depths on the
+    # full held-out pool. Past the model's max_depth the learned time signal
+    # clamps to its last row by construction; the sinusoidal/none arms have no
+    # ceiling — measuring whether extra loops convert into accuracy is the point.
+    extra_depth_acc = {}
+    for d in (eval_depths or []):
+        a_sum = m_sum = 0.0
+        for i in range(0, te_inp.shape[0], eval_batch):
+            s = slice(i, i + eval_batch)
+            a, _, m = eval_chunk_sums(model, te_inp[s], te_tgt[s], te_mask[s], d)
+            a_sum, m_sum = a_sum + float(a), m_sum + float(m)
+        extra_depth_acc[d] = a_sum / m_sum
+
     if not readouts:
+        if eval_depths:
+            return acc_sum / count, ce_sum / count, n_params, {"eval_depths": extra_depth_acc}
         return acc_sum / count, ce_sum / count, n_params
 
     # #75 readouts (refiner only) — how each part of the model reacts:
     #   per-pass accuracy: is every pass improving the draft, or does the work
     #     happen late? gate openness: do early passes make real updates?
     #   depth transfer: trained at `depth`, evaled at 1..12 — past max_depth the
-    #     time embedding saturates (jnp.take clips the row index), so passes
-    #     beyond training depth reuse the last time signal.
+    #     learned time embedding reuses its last row (explicit clamp in the model,
+    #     #86), so passes beyond training depth repeat the final time signal.
     @nnx.jit(static_argnames=["depth"])
     def eval_passes(model, inp, tgt, mask, depth):
         logits_all, gates = model(inp, depth=depth, return_all_iters=True)
@@ -243,6 +260,8 @@ def train_one(task_fn, vocab, depth, *, arch="refiner", dim=96, heads=4, enc=2, 
         "gate_open": None if gate_open is None else [float(x) for x in gate_open],
         "transfer": transfer,
     }
+    if eval_depths:
+        extras["eval_depths"] = extra_depth_acc
     return acc_sum / count, ce_sum / count, n_params, extras
 
 
@@ -268,6 +287,12 @@ def main():
                     help="cut the gradient chain at every pass boundary (#75) — pair with --per-pass-loss. refiner-only.")
     ap.add_argument("--readouts", action="store_true",
                     help="print #75 readouts: per-pass accuracy, gate openness per pass, depth-transfer curve (eval at depths 1..12). refiner-only.")
+    ap.add_argument("--time-signal", default="learned", choices=["learned", "sinusoidal", "none"],
+                    help="the refine loop's 'which pass am I on' signal (#86): learned table (today), "
+                         "sinusoidal step encoding (no depth ceiling), or none (time-blind). refiner-only.")
+    ap.add_argument("--eval-depths", default=None,
+                    help="after training, also eval the model at these depths on the full held-out pool "
+                         "(comma list, e.g. 12,16) — the #86 extensibility read. refiner-only.")
     ap.add_argument("--lr", type=float, default=2e-3)
     ap.add_argument("--train-seq", type=int, default=SEQ)
     ap.add_argument("--test-seq", type=int, default=None,
@@ -283,9 +308,10 @@ def main():
         vocab = VOCAB[args.task]
         task_desc = args.task
     depths = [int(d) for d in args.depths.split(",")]
+    eval_depths = None if args.eval_depths is None else [int(d) for d in args.eval_depths.split(",")]
     test_seq = args.train_seq if args.test_seq is None else args.test_seq
 
-    print(f"== depth ablation: arch={args.arch} dim={args.dim} task={task_desc} (train_seq={args.train_seq}, test_seq={test_seq}, vocab={vocab}) steps={args.steps} seed={args.seed} gate_bias={args.gate_bias} grad_last={args.grad_last} per_pass={args.per_pass_loss} islands={args.islands} lr={args.lr} ==")
+    print(f"== depth ablation: arch={args.arch} dim={args.dim} task={task_desc} (train_seq={args.train_seq}, test_seq={test_seq}, vocab={vocab}) steps={args.steps} seed={args.seed} gate_bias={args.gate_bias} grad_last={args.grad_last} per_pass={args.per_pass_loss} islands={args.islands} time_signal={args.time_signal} lr={args.lr} ==")
     print(f"{'depth':>6} {'params':>9} {'val_acc':>9} {'val_ce':>9} {'sec':>7}")
     results = {}
     for d in depths:
@@ -294,16 +320,19 @@ def main():
                         steps=args.steps, seed=args.seed, gate_bias=args.gate_bias,
                         grad_last=args.grad_last, per_pass_loss=args.per_pass_loss,
                         islands=args.islands, readouts=args.readouts, lr=args.lr,
+                        time_signal=args.time_signal, eval_depths=eval_depths,
                         train_seq=args.train_seq, test_seq=test_seq)
         acc, ce, n_params = out[:3]
         results[d] = (acc, ce)
         print(f"{d:>6} {n_params / 1e6:>8.2f}M {acc:>9.4f} {ce:>9.4f} {time.time() - t0:>7.1f}")
+        extras = out[3] if len(out) > 3 else {}
         if args.readouts:
-            extras = out[3]
             print("  pass_acc: " + " ".join(f"{a:.4f}" for a in extras["pass_acc"]))
             if extras["gate_open"] is not None:
                 print("  gate_open: " + " ".join(f"{g:.4f}" for g in extras["gate_open"]))
             print("  transfer: " + " ".join(f"d{k}={v:.4f}" for k, v in extras["transfer"].items()))
+        if "eval_depths" in extras:
+            print("  eval_depths: " + " ".join(f"d{k}={v:.4f}" for k, v in extras["eval_depths"].items()))
 
     base_acc = results[depths[0]][0]
     best_d = max(results, key=lambda d: results[d][0])

--- a/config.py
+++ b/config.py
@@ -56,6 +56,15 @@ CHUNKED_ATTENTION = os.environ.get("CHUNKED_ATTENTION", "0") == "1"
 # (which is looped up to MAX_STEPS_LIMIT times). Tuned to land the param count
 # near the reasoner baseline; init prints the actual count for both arches.
 REFINER_ENCODER_LAYERS = int(os.environ.get("REFINER_ENCODER_LAYERS", "7"))
+# The refine loop's "which pass am I on" signal (#86). Default sinusoidal:
+# matched the learned table at every trained depth (within 0.5σ) and converted
+# never-trained extra depth into accuracy (+5σ over the clamped table at d12/d16
+# on the length-shift split), so inference depth is an open dial instead of a
+# ceiling baked into the checkpoint. "learned" restores the table (control runs);
+# "none" is the time-blind arm (unstable at depth 8 — 1/3 seeds collapsed; see
+# docs/findings/2026-07-10-sinusoidal-time-signal-opens-the-depth-dial.md).
+# The param tree is identical in all modes, so checkpoints are interchangeable.
+REFINER_TIME_SIGNAL = os.environ.get("REFINER_TIME_SIGNAL", "sinusoidal")
 
 # Training
 MAX_STEPS_LIMIT = 8

--- a/docs/findings/2026-07-10-sinusoidal-time-signal-opens-the-depth-dial.md
+++ b/docs/findings/2026-07-10-sinusoidal-time-signal-opens-the-depth-dial.md
@@ -1,0 +1,100 @@
+# A sinusoidal time signal matches the learned table at trained depths and converts never-trained extra depth into accuracy — the 8-cap was an artifact of the table, not the architecture
+
+Status: confirmed (pre-registered keep criterion met: parity within 0.5σ everywhere, +5σ past the cap)
+Date: 2026-07-10
+Commit: a9ed29d  Run: tiny-config ablation (synthetic, no runs/ id)  Measured with:
+`python ablation_harness.py --task statetrack --depths 1,2,4,8 --steps 2500 --seed {0,1,2} --time-signal {learned,sinusoidal,none}` (parity)
+`python ablation_harness.py --task statetrack --depths 8 --steps 2500 --seed {0,1,2} --time-signal {learned,sinusoidal,none} --test-seq 48 --eval-depths 12,16` (extensibility; CPU, f32)
+
+## Setup
+
+The refine loop's "which pass am I on" input (#86). Three arms, one variable:
+**learned** — the production `nnx.Embed(max_depth+1, dim)` table (control);
+**sinusoidal** — `sinusoidal_step_encoding(step, dim)`, the transformer-PE /
+diffusion-timestep construction, no parameters, defined for any step;
+**none** — time-blind, the block conditions only on the state it refines (added at
+the user's direction, pre-registered on the issue before any run). All arms build
+an identical param tree and init stream (the table exists even where unused), so
+same seed ⇒ same init, pools, minibatch order. statetrack, dim 96, 2500 steps,
+seeds {0,1,2}.
+
+Criteria pre-registered on #86: keep a treatment iff it is within 2σ_pooled of the
+table at every trained depth {1,2,4,8} (in-distribution) AND beats the clamped
+table at depths {12,16} on the length-48 split by ≥2σ_pooled. Preference if
+several pass: none > sinusoidal > learned.
+
+**Premise correction, found while wiring (before any run):** the issue assumed
+depth > 8 "silently clamps onto the depth-8 signal". On our pinned JAX,
+`nnx.Embed`'s out-of-range gather **NaN-fills** instead — every pre-#86
+depth-overrun reading (e.g. the 2026-07-05 transfer probe's "d10+ reads as
+chance") was argmax over NaN logits, not a clamped signal. The model now clamps
+explicitly (`min(step, max_depth)`), so the control arm here genuinely measures
+"the table's best effort past its rows is its last row".
+
+## Evidence
+
+Parity — trained-at-depth, in-distribution, mean ± σ over seeds (chance = 0.20):
+
+| arm | d1 | d2 | d4 | d8 |
+|---|---|---|---|---|
+| learned | 0.809 ± 0.019 | 0.874 ± 0.036 | 0.961 ± 0.024 | 0.972 ± 0.012 |
+| sinusoidal | 0.803 ± 0.009 | 0.888 ± 0.046 | 0.949 ± 0.046 | 0.962 ± 0.029 |
+| none | 0.799 ± 0.014 | 0.847 ± 0.033 | 0.976 ± 0.003 | 0.728 ± 0.391 |
+
+Sinusoidal deltas vs the table: −0.4σ, +0.3σ, −0.3σ, −0.5σ — indistinguishable.
+The learned rows earn nothing the formula doesn't provide.
+
+Extensibility — trained at depth 8 on seq 24, evaluated on the length-48 split:
+
+| arm | d8 | d12 | d16 |
+|---|---|---|---|
+| learned | 0.653 ± 0.016 | 0.476 ± 0.037 | 0.400 ± 0.033 |
+| sinusoidal | 0.644 ± 0.035 | **0.737 ± 0.065 (+5.0σ)** | **0.725 ± 0.087 (+4.9σ)** |
+| none | 0.502 ± 0.230 | 0.575 ± 0.293 | 0.587 ± 0.303 |
+
+Two separate facts in that table:
+
+1. **The clamped table doesn't just stop paying past its rows — extra loops
+   actively hurt** (0.653 → 0.476 → 0.400). Repeating the last time signal walks
+   the state off a cliff. Serving a table-signal model above its trained depth is
+   worse than not turning the dial.
+2. **The sinusoidal arm converts depth it never trained on into accuracy**
+   (0.644 → 0.737 → 0.725): +26 accuracy points over the control at d12, +33 at
+   d16, on the split where the 2026-06-13 run-7 curve was still climbing.
+   Inference-time depth is an open dial, exactly as diffusion-style continuous
+   step conditioning suggested it would be.
+
+**The time-blind arm fails the bar, but instructively.** Mechanical verdict: kill
+(+0.5σ / +0.9σ past the cap — no ≥2σ gain). The per-seed detail matters: seeds 0
+and 1 *extend as well as sinusoidal* (extend d16: 0.752 / 0.772), but seed 2
+collapsed during depth-8 training (0.277 in the parity grid, 0.238 ≈ chance in the
+extend grid — deterministically, twice: same init, same data, both grids). The
+collapse inflates σ so much that a naive z-test would call the arm "within 2σ" at
+trained depths; we decline to launder a 0.69-accuracy crater as noise. Honest
+summary: **the state alone is sufficient for the computation (2 of 3 seeds match
+everything, and extend), but the step signal acts as a training stabilizer for
+deep recurrence** — without it, the depth-8 collapse mode (#77's subject) fires
+more readily. This is evidence FOR #77's per-pass-supervision-as-stabilizer test:
+if per-pass grading removes the collapse mode, the time-blind arm (zero params,
+maximally extensible, no counter for halting to latch onto) deserves a rematch.
+
+## Decision
+
+The refiner's production time signal defaults to **sinusoidal** from this commit
+(`REFINER_TIME_SIGNAL` in config.py, env-overridable; the model class default
+stays `learned` so the class remains config-free and old harness comparisons stay
+reproducible). The param tree is unchanged in all modes, so nothing about
+checkpoint shape moves. The base run (#16) therefore launches with an open depth
+dial instead of a baked 8-cap — the decision #86 existed to force.
+
+## Limitations
+
+Toy scale, one task (statetrack), 3 seeds, fixed-depth training (the production
+trainer samples depth 1..8 per step; parity under random-depth sampling is
+unverified, though nothing in the mechanism is depth-sampling-specific). d12 vs
+d16 are within each other's noise — where the extended curve plateaus is unknown;
+depth >16 unprobed. The extensibility read is one length-shift split (48). The
+stability asymmetry (time-blind collapses 1/3 seeds; table and sinusoidal 0/3
+here) is too few seeds to rank table vs sinusoidal on stability — and the table
+arm has its own recorded collapse history (#77: a learned-table statetrack
+control collapsed at seed 3), so no arm is immune.

--- a/docs/findings/README.md
+++ b/docs/findings/README.md
@@ -21,6 +21,7 @@ things, it doesn't go in this folder.
 - `2026-07-04-gpt2-yardstick-calibrated.md` — the GPT-2-small yardstick reproduces the reference reading (#48)
 - `2026-07-04-slots-only-readout-compression-real.md` — #62: a readout blinded to tokens stays within noise; compression real
 - `2026-07-04-final-only-supervision-decomposition-is-taught.md` — #67: without the per-slot grade the scratchpad sits at chance; the decomposition is taught, not emergent
+- `2026-07-10-sinusoidal-time-signal-opens-the-depth-dial.md` — #86: sinusoidal step signal matches the table at trained depths, +5σ past the cap; production default flipped
 
 ## Entry template
 

--- a/plan_a_model.py
+++ b/plan_a_model.py
@@ -19,6 +19,18 @@ from attention import chunked_causal_attention
 from rope import rope_tables, apply_rope
 
 
+def sinusoidal_step_encoding(step, dim, base=10000.0):
+    """Continuous "which pass am I on" signal (#86): sin/cos of the step index at
+    dim/2 geometrically spaced frequencies — the transformer positional-encoding /
+    diffusion-timestep construction. A formula, not a table: defined for ANY step
+    (nothing to clamp past max_depth) and smooth in step, so pass 9 gets a
+    near-neighbor of pass 8's signal instead of an alien input."""
+    half = dim // 2
+    freqs = base ** (-jnp.arange(half, dtype=jnp.float32) / half)
+    angles = jnp.asarray(step, jnp.float32) * freqs
+    return jnp.concatenate([jnp.sin(angles), jnp.cos(angles)])
+
+
 class CausalAttention(nnx.Module):
     """Multi-head self-attention, RoPE, causal mask folded into an additive bias.
 
@@ -105,12 +117,24 @@ class CausalRefiner(nnx.Module):
 
     def __init__(self, *, dim, vocab_size, num_heads=4, num_encoder_layers=2,
                  max_depth=8, max_seq_len=512, use_gate=True, gate_bias=0.0,
-                 chunked_attention=False, rngs, dtype=jnp.float32):
+                 chunked_attention=False, time_signal="learned", rngs, dtype=jnp.float32):
+        assert time_signal in ("learned", "sinusoidal", "none"), time_signal
+        assert dim % 2 == 0, "dim must be even for the sinusoidal step encoding"
         self.dim = dim
         self.vocab_size = vocab_size
         self.max_depth = max_depth
         self.use_gate = use_gate
         self.dtype = dtype
+        # Which "pass k" signal the refine loop receives (#86):
+        #   learned    — per-depth embedding table (today's default). max_depth + 1
+        #                rows; a depth overrun silently clamps onto the last row.
+        #   sinusoidal — computed from the step index; no ceiling to bake in.
+        #   none       — time-blind: the block conditions only on the state it is
+        #                refining. No step counter at all.
+        # The table and its norm are created in EVERY mode so all three arms share
+        # an identical param tree and init stream — the matched-pair requirement —
+        # and so the default arm's checkpoints are untouched by this knob existing.
+        self.time_signal = time_signal
 
         self.embed = nnx.Embed(vocab_size, dim, rngs=rngs, dtype=dtype)
         self.time_embed = nnx.Embed(max_depth + 1, dim, rngs=rngs, dtype=dtype)
@@ -171,8 +195,17 @@ class CausalRefiner(nnx.Module):
                 z = z_enc + jax.lax.stop_gradient(z - z_enc)
             elif cut is not None and step == cut and cut > 0:
                 z = z_enc + jax.lax.stop_gradient(z - z_enc)
-            t_signal = self.time_embed(jnp.asarray(step))
-            z_in = self.time_norm(z) + self.time_signal_norm(t_signal)[None, None, :]
+            if self.time_signal == "none":
+                z_in = self.time_norm(z)
+            else:
+                # Explicit clamp on the table (#86): past max_depth the table's best
+                # effort is to reuse its last row. Without this, the out-of-range
+                # gather NaN-fills on this JAX version and silently poisons every
+                # depth-overrun eval (the pre-#86 transfer probes' d10+ readings).
+                t_signal = (self.time_embed(jnp.asarray(min(step, self.max_depth)))
+                            if self.time_signal == "learned"
+                            else sinusoidal_step_encoding(step, self.dim).astype(self.dtype))
+                z_in = self.time_norm(z) + self.time_signal_norm(t_signal)[None, None, :]
             z_new = self.refine_block(z_in, pad_bias)
             if self.use_gate:
                 g = jax.nn.sigmoid(self.gate(jnp.concatenate([z_new, z], axis=-1)))

--- a/plan_a_trainer.py
+++ b/plan_a_trainer.py
@@ -30,6 +30,7 @@ from config import (
     PAD_TOKEN_ID,
     COMPUTE_DTYPE,
     REFINER_ENCODER_LAYERS,
+    REFINER_TIME_SIGNAL,
     CHUNKED_ATTENTION,
 )
 from layers import ReasonerOutput
@@ -46,13 +47,13 @@ class RefinerForTraining(nnx.Module):
     def __init__(self, latent_dim, rngs, *, vocab_size=VOCAB_SIZE, num_heads=NUM_HEADS,
                  encoder_layers=REFINER_ENCODER_LAYERS, max_depth=MAX_STEPS_LIMIT,
                  max_seq_len=MAX_SEQ_LEN, pad_token_id=PAD_TOKEN_ID, dtype=COMPUTE_DTYPE,
-                 chunked_attention=CHUNKED_ATTENTION):
+                 chunked_attention=CHUNKED_ATTENTION, time_signal=REFINER_TIME_SIGNAL):
         self.pad_token_id = pad_token_id
         self.refiner = CausalRefiner(
             dim=latent_dim, vocab_size=vocab_size, num_heads=num_heads,
             num_encoder_layers=encoder_layers, max_depth=max_depth,
             max_seq_len=max_seq_len, dtype=dtype, rngs=rngs,
-            chunked_attention=chunked_attention,
+            chunked_attention=chunked_attention, time_signal=time_signal,
         )
         # Vestigial: written by the trainer's hunch bookkeeping, never read here.
         # Kept tiny ([1, 1, dim]) since it carries no information.

--- a/run_tracker.py
+++ b/run_tracker.py
@@ -20,6 +20,7 @@ from config import (
     DATA_SEED,
     MODEL_SEED,
     TRAIN_TOKEN_BUDGET,
+    REFINER_TIME_SIGNAL,
 )
 from schedules import DECAY_STEPS
 
@@ -77,6 +78,9 @@ class RunTracker:
             # The run's recipe horizon (#83): budget in, resolved anneal out.
             "TRAIN_TOKEN_BUDGET": TRAIN_TOKEN_BUDGET,
             "DECAY_STEPS": DECAY_STEPS,
+            # Refiner-only; recorded even for reasoner runs (harmless) so cards
+            # always answer "which time signal was this?" (#86).
+            "REFINER_TIME_SIGNAL": REFINER_TIME_SIGNAL,
         }
 
     def _check_compatibility(self, metadata_path):

--- a/tests/test_plan_a.py
+++ b/tests/test_plan_a.py
@@ -17,12 +17,13 @@ import optax
 import pytest
 from flax import nnx
 
-from plan_a_model import CausalRefiner
+from plan_a_model import CausalRefiner, sinusoidal_step_encoding
 
 
-def _tiny(vocab=37, dim=64, seq=32, enc=2):
+def _tiny(vocab=37, dim=64, seq=32, enc=2, time_signal="learned"):
     return CausalRefiner(dim=dim, vocab_size=vocab, num_heads=4, num_encoder_layers=enc,
-                         max_depth=8, max_seq_len=seq, rngs=nnx.Rngs(0))
+                         max_depth=8, max_seq_len=seq, time_signal=time_signal,
+                         rngs=nnx.Rngs(0))
 
 
 @pytest.mark.parametrize("depth", [1, 2, 4, 8])
@@ -154,3 +155,73 @@ def test_depth_is_static_and_varies_output():
     d1 = np.asarray(m(tok, depth=1))
     d8 = np.asarray(m(tok, depth=8))
     assert np.max(np.abs(d1 - d8)) > 1e-3, "depth had no effect on the output"
+
+
+# ── time-signal arms (#86) ───────────────────────────────────────────────────
+
+def test_time_signal_arms_share_param_tree_and_init():
+    """The three arms must be a matched pair's dream: identical param tree AND
+    identical init values (the table is created even when unused, keeping the RNG
+    stream aligned), so an ablation differs in exactly one thing — signal source."""
+    states = [nnx.state(_tiny(time_signal=ts), nnx.Param) for ts in ("learned", "sinusoidal", "none")]
+    flat = [jax.tree_util.tree_leaves_with_path(s) for s in states]
+    assert [tuple(p for p, _ in f) for f in flat] == [tuple(p for p, _ in flat[0])] * 3
+    for path_leaf in zip(*flat):
+        arrays = [np.asarray(leaf) for _, leaf in path_leaf]
+        assert all(np.array_equal(arrays[0], a) for a in arrays[1:]), path_leaf[0][0]
+
+
+def test_learned_table_clamps_past_max_depth():
+    """The premise of #86, pinned: past max_depth the learned arm reuses its LAST
+    row (explicit clamp in the loop), so passes 9+ are indistinguishable from pass
+    8 — but the forward stays finite. Without the clamp the raw gather NaN-fills
+    on this JAX version (second assert documents the hazard the clamp guards)."""
+    m = _tiny()
+    tok = jnp.arange(1, 17)[None, :]
+    out12 = np.asarray(m(tok, depth=12))
+    assert np.isfinite(out12).all(), "depth overrun poisoned the forward"
+    raw = np.asarray(m.time_embed(jnp.asarray(12)))
+    assert not np.isfinite(raw).any(), \
+        "raw out-of-range gather no longer NaN-fills — revisit whether the clamp is still needed"
+
+
+def test_sinusoidal_signal_extends_past_max_depth():
+    """The formula must keep discriminating where the table clamps: step 12's
+    encoding differs from step 8's (and from every trained step's), stays finite,
+    and is deterministic."""
+    dim = 64
+    codes = np.stack([np.asarray(sinusoidal_step_encoding(k, dim)) for k in range(17)])
+    assert np.isfinite(codes).all()
+    for k in range(9, 17):
+        dists = np.abs(codes[:9] - codes[k]).max(axis=1)
+        assert dists.min() > 1e-3, f"step {k}'s encoding collides with a trained step"
+    np.testing.assert_array_equal(codes[12], np.asarray(sinusoidal_step_encoding(12, dim)))
+
+
+@pytest.mark.parametrize("time_signal", ["sinusoidal", "none"])
+def test_alternative_arms_ignore_the_table(time_signal):
+    """Wiring check: in the sinusoidal/time-blind arms the table must be inert —
+    zeroing it changes nothing, and it receives no gradient — while the learned
+    arm demonstrably depends on it."""
+    tok = jnp.arange(1, 17)[None, :]
+    tgt = jax.random.randint(jax.random.PRNGKey(7), (1, 16), 0, 37)
+
+    m = _tiny(time_signal=time_signal)
+    before = np.asarray(m(tok, depth=4))
+    m.time_embed.embedding[...] = jnp.zeros_like(m.time_embed.embedding[...])
+    np.testing.assert_array_equal(before, np.asarray(m(tok, depth=4)))
+
+    def loss(mm):
+        lg = mm(tok, depth=4)
+        return jnp.mean(optax.softmax_cross_entropy_with_integer_labels(logits=lg, labels=tgt))
+
+    grads = nnx.grad(loss)(m)
+    assert float(jnp.abs(grads["time_embed"]["embedding"][...]).max()) == 0.0
+    blk_norm = max(float(jnp.abs(x).max()) for x in jax.tree_util.tree_leaves(grads["refine_block"]))
+    assert blk_norm > 0.0, "refine block lost its gradient in this arm"
+
+    m_learned = _tiny()
+    before = np.asarray(m_learned(tok, depth=4))
+    m_learned.time_embed.embedding[...] = jnp.zeros_like(m_learned.time_embed.embedding[...])
+    assert np.abs(before - np.asarray(m_learned(tok, depth=4))).max() > 1e-4, \
+        "learned arm did not actually read the table (sanity)"

--- a/tests/test_plan_a.py
+++ b/tests/test_plan_a.py
@@ -198,6 +198,19 @@ def test_sinusoidal_signal_extends_past_max_depth():
     np.testing.assert_array_equal(codes[12], np.asarray(sinusoidal_step_encoding(12, dim)))
 
 
+def test_production_default_is_sinusoidal():
+    """The #86 decision, pinned: the production adapter threads config's
+    REFINER_TIME_SIGNAL into the refiner, and the shipped default is sinusoidal
+    (the class default stays 'learned' so the harness's historical comparisons
+    remain reproducible)."""
+    from config import REFINER_TIME_SIGNAL
+    from plan_a_trainer import RefinerForTraining
+    assert REFINER_TIME_SIGNAL == "sinusoidal"
+    m = RefinerForTraining(32, nnx.Rngs(0), vocab_size=11, num_heads=4,
+                           encoder_layers=1, max_depth=2, max_seq_len=16)
+    assert m.refiner.time_signal == REFINER_TIME_SIGNAL
+
+
 @pytest.mark.parametrize("time_signal", ["sinusoidal", "none"])
 def test_alternative_arms_ignore_the_table(time_signal):
     """Wiring check: in the sinusoidal/time-blind arms the table must be inert —


### PR DESCRIPTION
## Summary
Runs the #86 three-arm time-signal ablation end to end (learned table / sinusoidal / time-blind, the third arm added and pre-registered at the user's direction) and applies the verdict: the refiner's production time signal defaults to **sinusoidal**, making inference-time depth an open dial instead of an 8-cap baked into the checkpoint — decided before the base run (#16) freezes it.

## What & why
**Wiring** (`plan_a_model.py`, `ablation_harness.py`): `CausalRefiner` grows `time_signal ∈ {learned, sinusoidal, none}`. All modes build an identical param tree and init stream (the table exists even where unused) so every comparison is a true matched pair; checkpoints are shape-interchangeable across modes. Harness grows `--time-signal` and `--eval-depths`.

**Premise correction found while wiring (before any run):** the issue assumed depth > 8 "silently clamps onto the depth-8 signal". On our pinned JAX, `nnx.Embed`'s out-of-range gather **NaN-fills** — every pre-#86 depth-overrun reading (the 2026-07-05 "d10+ reads as chance") was argmax over NaN logits. The loop now clamps explicitly (`min(step, max_depth)`), so the control arm measures what the issue intended. A test pins both the clamp and the NaN hazard it guards.

**Verdicts** (pre-registered on #86 before any result; statetrack, dim 96, seeds {0,1,2}; full evidence in `docs/findings/2026-07-10-sinusoidal-time-signal-opens-the-depth-dial.md`):

Parity, trained-at-depth, in-distribution (mean ± σ):
| arm | d1 | d2 | d4 | d8 |
|---|---|---|---|---|
| learned | 0.809±0.019 | 0.874±0.036 | 0.961±0.024 | 0.972±0.012 |
| sinusoidal | 0.803±0.009 | 0.888±0.046 | 0.949±0.046 | 0.962±0.029 |

Extensibility, trained d8 on seq 24, length-48 split:
| arm | d8 | d12 | d16 |
|---|---|---|---|
| learned | 0.653±0.016 | 0.476±0.037 | 0.400±0.033 |
| sinusoidal | 0.644±0.035 | **0.737±0.065 (+5.0σ)** | **0.725±0.087 (+4.9σ)** |

- **Sinusoidal: KEEP** — parity deltas all within 0.5σ; past the cap it *converts never-trained depth into accuracy* while the clamped table actively degrades (extra clamped loops walk the state off a cliff: 0.653 → 0.400).
- **Time-blind: KILL on the extensibility bar, instructively** — seeds 0/1 extend as well as sinusoidal (d16: 0.752/0.772); seed 2 collapses deterministically during depth-8 training (0.277/0.238, twice, same init and data). The collapse inflates σ enough that a naive z-test would "pass" the parity bar; the finding declines to launder a 0.69-accuracy crater as noise. Reading: the state alone suffices for the computation, but the step signal is a **training stabilizer** for deep recurrence — direct evidence for the #77 test, and grounds for a time-blind rematch if #77's per-pass grading removes the collapse mode.

**The decision** (`config.py`, `plan_a_trainer.py`, `run_tracker.py`): `REFINER_TIME_SIGNAL` env knob, default `sinusoidal`, recorded in `run_metadata.json`. The `CausalRefiner` class default stays `learned` so the class remains config-free and historical harness comparisons stay reproducible; the production adapter threads the config value. A test pins the threading and the shipped default.

Closes #86

## Validation / smoke-test performed
- [x] `JAX_PLATFORMS=cpu pytest tests/ -q` passes locally (full suite; skips are the usual GPU-only gates)
- Other checks run:
  - The full pre-registered grid: 18 harness runs (3 arms × 3 seeds × {parity depths 1,2,4,8; extensibility train-d8 → eval 12,16 on length-48}), ~13 CPU-hours, exact commands in the finding. Verdicts computed mechanically by a fixed script against the pre-registered bars.
  - New tests: param-tree/init equality across arms (the matched-pair guarantee); the explicit clamp keeps depth-overrun finite + the raw NaN-fill hazard it guards; sinusoidal encodings stay distinct past max_depth; sinusoidal/none arms provably ignore the table (zeroing it is a no-op, zero gradient) while the learned arm provably reads it; production default threading.
  - `ruff check` clean on all touched files.

## Risk
- **Default behavior change for refiner runs**: new refiner runs train with the sinusoidal signal unless `REFINER_TIME_SIGNAL=learned`. Param tree unchanged in all modes, so old checkpoints load — but a checkpoint trained with the table should be *resumed* with `REFINER_TIME_SIGNAL=learned` (the weights co-adapted to it; the metadata records which).
- Reasoner arch, goldens (reasoner-only), trainer loop, data path, deps: untouched.
- The depth-overrun clamp changes behavior only where the model previously produced NaN.

## Checklist
- [x] Did not weaken or delete any test (no skips/xfails/loosened asserts to make it pass)
- [x] Smoke-tested; no multi-hour run was launched without sign-off (the grid is CPU toy-scale, per the issue's own budget)
- [x] Pinned deps unchanged
- [x] Findings/claims backed by evidence in the PR and the linked finding

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TCSTo5AwfEJiUdGJds2UNs

---
_Generated by [Claude Code](https://claude.ai/code/session_01TCSTo5AwfEJiUdGJds2UNs)_