### PR TITLE
Anneal-onset sweep + floor λ: anneal to a floor, gate the onset on chain state (#95)

### DIFF
--- a/docs/findings/2026-07-12-anneal-floor-wins-onset-is-a-state.md
+++ b/docs/findings/2026-07-12-anneal-floor-wins-onset-is-a-state.md
@@ -47,13 +47,13 @@ letter of the criterion is vacuous there and the per-seed collapse count is
 the real readout: **3/3 → 2/3 → 1/3 → 0/3 across onsets 10/20/30/40%.**
 
 The slot probes at the grade-off step say *why*, cleanly: in every collapsing
-run the chain was decodable only through slot 2 (slot 3 ≤ 0.29); in every
-recovering run slot 3 had formed (≥ 0.57) — including #73's seed 0 (slot 4
+run the chain was decodable only through slot 2 (slot 3 ≤ 0.291); in every
+recovering run slot 3 had formed (≥ 0.570) — including #73's seed 0 (slot 4
 still half-formed at 0.572, recovered to 0.95) and onset-20%'s seed 2 (slot 4
 at just 0.331, recovered to 0.99). Final-answer loss can finish and polish a
 chain that reaches the deep slots, but cannot extend one stuck at depth 2 —
 and worse, the already-formed shallow slots then *erode* (slot 1 decodability
-falls from ~0.99 to 0.35–0.70 in the collapsed runs). The viable-onset
+falls from 0.95–0.99 to 0.25–0.70 in the collapsed runs). The viable-onset
 boundary is therefore **a state, not a time**: the grade must stay until the
 chain is decodable through the deep slots, and how long that takes varies by
 seed (seed 0 needed ~40% of the budget; seed 2 was ready by 20%).

--- a/docs/findings/2026-07-12-anneal-floor-wins-onset-is-a-state.md
+++ b/docs/findings/2026-07-12-anneal-floor-wins-onset-is-a-state.md
@@ -1,0 +1,84 @@
+# Anneal the grade to a small floor, not to zero — and the anneal can't start at a fixed time, only once the chain has actually formed
+
+Status: toy-proof (the #95 gate; the recipe #73's scaffold verdict asked for)
+Date: 2026-07-12
+Commit: 6f05ef0  Run: tiny-config ablation (synthetic, no runs/ id)  Measured with: `JAX_PLATFORMS=cpu FORCE_F32_COMPUTE=1 python scratchpad_harness.py --arms annealed,annealed@0.1,annealed@0.2,annealed@0.3,annealed@0.4f0.1 --seeds 0,1,2 --K 4 --m 7 --steps 2500`
+
+## Setup
+
+#73 left two questions: how early can the grade anneal start (the warm-up is
+the LM-scale cost), and does annealing to a small residual λ instead of zero
+buy back the stability that full removal cost (σ grew ~7×). The schedule is
+now parameterized: `annealed@X` starts the decay at fraction X of training
+(decay window fixed at 20% of the budget), `fY` decays to floor λ=Y and holds.
+Same protocol as #38/#67/#73; the graded control's numbers are reused from
+#73 (reproduced exactly there, same determinism). The plain `annealed` arm was
+re-run as a replay check and reproduced #73's every number **bitwise**,
+proving the parameterization refactor inert.
+
+## Evidence
+
+Held-out final-answer accuracy (control from #73: 0.9922 ± 0.011; chance 0.143):
+
+| arm | grade off at | seed 0 | seed 1 | seed 2 | mean | σ | collapsed seeds |
+|---|---|---|---|---|---|---|---|
+| annealed@0.1 | step 750 | 0.1421 | 0.1401 | 0.1421 | 0.1414 | 0.001 | 3/3 |
+| annealed@0.2 | step 1000 | 0.1548 | 0.2659 | 0.9937 | 0.4715 | 0.456 | 2/3 |
+| annealed@0.3 | step 1250 | 0.1992 | 0.9895 | 0.9973 | 0.7287 | 0.459 | 1/3 |
+| annealed (=@0.4, #73 replay) | step 1500 | 0.9524 | 0.9963 | 0.8494 | 0.9327 | 0.075 | 0/3 |
+| **annealed@0.4f0.1 (floor)** | step 1500 | 0.9885 | 0.9954 | 0.9736 | **0.9858** | **0.011** | 0/3 |
+
+**The floor buys the stability back, decisively.** Both pre-registered clauses
+hold with room to spare: σ = 0.0111 vs the ≤ 2×0.0114 bar — statistically the
+fully-graded control's spread, a 7× reduction vs annealing to zero — and the
+mean sits 0.006 from the control (bar was 0.023). A residual λ=0.1 costs 10%
+of the slot-grade signal and eliminates both failure modes of full removal
+(the wobble, and #73-seed-2's slow decay). As a bonus the probe head keeps
+learning, so the end-of-run slot readout stays calibrated (0.96–1.00 across
+all seeds/slots) — the stale-probe caveat of #73 disappears.
+
+**No earlier onset is reliable, and the failure is bimodal, not gradual.**
+Onset 10% collapses to chance on all three seeds. At 20% and 30% each seed
+either collapses (0.15–0.27) or fully recovers (0.99) — nothing in between.
+The pre-registered "within 2σ_pooled" test is honest only for onset 10%
+(cleanly not viable): for 20%/30% the collapses inflate the arm's own σ to
+~0.46, widening 2σ_pooled to ~0.65 — a bar that wide rejects nothing, so the
+letter of the criterion is vacuous there and the per-seed collapse count is
+the real readout: **3/3 → 2/3 → 1/3 → 0/3 across onsets 10/20/30/40%.**
+
+The slot probes at the grade-off step say *why*, cleanly: in every collapsing
+run the chain was decodable only through slot 2 (slot 3 ≤ 0.29); in every
+recovering run slot 3 had formed (≥ 0.57) — including #73's seed 0 (slot 4
+still half-formed at 0.572, recovered to 0.95) and onset-20%'s seed 2 (slot 4
+at just 0.331, recovered to 0.99). Final-answer loss can finish and polish a
+chain that reaches the deep slots, but cannot extend one stuck at depth 2 —
+and worse, the already-formed shallow slots then *erode* (slot 1 decodability
+falls from ~0.99 to 0.35–0.70 in the collapsed runs). The viable-onset
+boundary is therefore **a state, not a time**: the grade must stay until the
+chain is decodable through the deep slots, and how long that takes varies by
+seed (seed 0 needed ~40% of the budget; seed 2 was ready by 20%).
+
+## What this bounds
+
+- **The LM-scale recipe, updated:** anneal to a small floor (λ ≈ 0.1), not to
+  zero — same warm-up saving, none of the instability. And don't schedule the
+  anneal by step count; gate it on a measurement (per-slot decodability
+  through the deep slots), because the nucleation time is run-dependent.
+- The per-step-target budget from #73 stands, refined: targets must flow at
+  full weight until the chain is *fully formed*, then a 10%-weight trickle
+  suffices. At this scale nucleation took 20–40% of the budget depending on
+  seed.
+- A probe-gated anneal (switch on decodability, not step count) is the natural
+  follow-up if the scratchpad ladder advances; at toy scale the slot-3 probe
+  separated every outcome with a wide margin (0.29 vs 0.57).
+
+## Limitations
+
+- Toy scale, one task family, 3 seeds per arm. The onset arms' bimodality
+  makes their means/σ descriptive only; the collapse fractions and the
+  slot-probe separation carry the conclusion.
+- Floor tested at a single value (0.1) and single onset (40%); the floor's
+  lower bound and its interaction with earlier onsets are unmeasured (a
+  floor might rescue onset 20–30% — untested).
+- The slot-3-decodability threshold (somewhere in 0.29–0.57) is bracketed by
+  9 runs, not mapped; treat it as a diagnostic direction, not a number.

--- a/docs/findings/README.md
+++ b/docs/findings/README.md
@@ -22,6 +22,7 @@ things, it doesn't go in this folder.
 - `2026-07-04-slots-only-readout-compression-real.md` — #62: a readout blinded to tokens stays within noise; compression real
 - `2026-07-04-final-only-supervision-decomposition-is-taught.md` — #67: without the per-slot grade the scratchpad sits at chance; the decomposition is taught, not emergent
 - `2026-07-10-grade-annealing-scaffold-not-crutch.md` — #73: the grade is a scaffold — annealed to zero mid-run the chain survives on final-answer loss (within 2σ), but seed variance grows ~7×
+- `2026-07-12-anneal-floor-wins-onset-is-a-state.md` — #95: anneal to a floor of λ≈0.1 (control-level σ, 7× calmer than zero); no fixed earlier onset is reliable — the grade must stay until the chain is decodable through the deep slots
 
 ## Entry template
 

--- a/scratchpad_harness.py
+++ b/scratchpad_harness.py
@@ -27,6 +27,10 @@ Six arms on the chained-affine-maps task (docs/design/serial-scratchpad.md):
               it sustains itself on final-answer loss alone. Held-out
               accuracy is also measured at the grade-off step so decay across
               the grade-free stretch is visible (crutch vs frozen-but-stable).
+              #95 parameterizes the schedule on the command line: the arm spec
+              `annealed@0.2` starts the decay at 20% of training (window stays
+              20%), and `annealed@0.4f0.1` decays to a floor of λ=0.1 and
+              holds, instead of going to zero. Plain `annealed` is #73's arm.
 
 Task: r_0 = 0; r_k = (r_{k-1} * a_k + b_k) mod m from tokens [a_1 b_1 ... a_K b_K].
 Affine composition mod m is non-commutative — no order-free shortcut — and
@@ -36,6 +40,7 @@ decomposes exactly into the K sub-results the slots are graded on.
 """
 
 import argparse
+import re
 import time
 
 import jax
@@ -174,17 +179,37 @@ def n_params(model):
     return sum(int(x.size) for x in jax.tree_util.tree_leaves(nnx.state(model, nnx.Param)))
 
 
-def grade_lambda(step, total_steps):
-    """λ_slot schedule for the annealed arm (#73): fully on for the first 40%
-    of training, linear decay across 40–60%, exactly zero afterwards. At the
-    pre-registered 2500 steps that is on for 0–1000, decay 1000–1500, off for
-    1500–2500 — a full 1000 grade-free steps to expose decay."""
-    on_until, off_from = 0.4 * total_steps, 0.6 * total_steps
+def grade_lambda(step, total_steps, onset=0.4, decay=0.2, floor=0.0):
+    """λ_slot schedule for the annealed arm: fully on until onset (fraction of
+    the budget), linear decay to `floor` across the decay window, held at
+    `floor` afterwards. The defaults are #73's pre-registered arm — at 2500
+    steps: on for 0–1000, decay 1000–1500, zero for 1500–2500. #95 sweeps the
+    onset (how early can the grade start to go?) and the floor (does a small
+    residual grade buy back the stability that full removal cost?)."""
+    # off_from is built by summing the two scaled terms (not (onset+decay) *
+    # total_steps): for the #73 defaults this reproduces that run's boundary
+    # arithmetic bitwise, so plain `annealed` still replays the recorded result.
+    on_until = onset * total_steps
+    off_from = on_until + decay * total_steps
     if step < on_until:
         return 1.0
     if step >= off_from:
-        return 0.0
-    return 1.0 - (step - on_until) / (off_from - on_until)
+        return floor
+    return 1.0 - (1.0 - floor) * (step - on_until) / (off_from - on_until)
+
+
+def parse_arm_spec(spec):
+    """'annealed@0.2' → onset 0.2; 'annealed@0.4f0.1' → onset 0.4, floor 0.1;
+    plain arm names (including plain 'annealed') pass through unchanged."""
+    m = re.fullmatch(r"annealed(?:@(0?\.\d+))?(?:f(0?\.\d+))?", spec)
+    if not m:
+        return spec, {}
+    kw = {}
+    if m.group(1):
+        kw["anneal_onset"] = float(m.group(1))
+    if m.group(2):
+        kw["anneal_floor"] = float(m.group(2))
+    return "annealed", kw
 
 
 def arm_losses(arm, mdl, tok, sub, lam, depth):
@@ -205,7 +230,8 @@ def arm_losses(arm, mdl, tok, sub, lam, depth):
 
 
 def train_one_arm(arm, *, K=4, m=7, dim=64, heads=4, enc=2, steps=2500, batch=256,
-                  lr=2e-3, wd=0.01, seed=0, n_pool=32768, n_test=4096):
+                  lr=2e-3, wd=0.01, seed=0, n_pool=32768, n_test=4096,
+                  anneal_onset=0.4, anneal_decay=0.2, anneal_floor=0.0):
     task = affine_chain_task(K, m)
     key = jax.random.PRNGKey(seed)
     key, dk_tr, dk_te = jax.random.split(key, 3)
@@ -242,21 +268,27 @@ def train_one_arm(arm, *, K=4, m=7, dim=64, heads=4, enc=2, steps=2500, batch=25
                     if slot_logits is not None else jnp.zeros(K))
         return final_acc, slot_acc
 
-    # The grade-off step: where the annealed λ_slot reaches exactly zero. Every
+    # The grade-off step: where the annealed λ_slot reaches its floor. Every
     # arm is evaluated here too, so annealed-vs-control is a matched comparison
     # at both checkpoints and decay across the grade-free stretch is measurable.
-    cut = min(int(round(0.6 * steps)), steps - 1)
+    # Non-annealed arms keep #73's 0.6 checkpoint as a plain mid-training probe.
+    cut_frac_steps = (anneal_onset * steps + anneal_decay * steps
+                      if arm == "annealed" else 0.6 * steps)
+    cut = min(int(round(cut_frac_steps)), steps - 1)
     cut_final = cut_slots = None
     for i in range(steps):
         if i == cut:
             cut_final, cut_slots = eval_all(model)
         key, k = jax.random.split(key)
-        step(model, opt, k, grade_lambda(i, steps) if arm == "annealed" else 1.0)
+        step(model, opt, k,
+             grade_lambda(i, steps, anneal_onset, anneal_decay, anneal_floor)
+             if arm == "annealed" else 1.0)
 
     final_acc, slot_acc = eval_all(model)
     return {
         "final_acc": float(final_acc),
         "slot_acc": [float(x) for x in slot_acc],
+        "cut_step": cut,
         "cut_final_acc": float(cut_final),
         "cut_slot_acc": [float(x) for x in cut_slots],
         "params": n_params(model),
@@ -267,7 +299,9 @@ def main():
     ap = argparse.ArgumentParser()
     ap.add_argument("--arms", default="serial,parallel,depthonly",
                     help="any of serial,parallel,depthonly,slotsonly (#62),"
-                         "finalonly (#67),annealed (#73)")
+                         "finalonly (#67),annealed (#73); annealed takes an"
+                         " optional onset and floor (#95), e.g. annealed@0.2"
+                         " or annealed@0.4f0.1")
     ap.add_argument("--seeds", default="0,1,2")
     ap.add_argument("--K", type=int, default=4, help="number of chained sub-steps = number of slots")
     ap.add_argument("--m", type=int, default=7, help="modulus (prime); vocab and chance level 1/m")
@@ -275,21 +309,21 @@ def main():
     ap.add_argument("--dim", type=int, default=64)
     args = ap.parse_args()
 
-    cut = min(int(round(0.6 * args.steps)), args.steps - 1)
     print(f"== serial-scratchpad proof (#38): K={args.K} m={args.m} dim={args.dim} "
-          f"steps={args.steps} (chance={1/args.m:.3f}, grade-off step={cut}) ==")
-    print(f"{'arm':>10} {'seed':>5} {'params':>9} {'acc@cut':>8} {'final_acc':>10} {'sec':>7}"
-          "  slot_accs cut[...] end[...]")
+          f"steps={args.steps} (chance={1/args.m:.3f}) ==")
+    print(f"{'arm':>16} {'seed':>5} {'params':>9} {'cut':>5} {'acc@cut':>8} {'final_acc':>10}"
+          f" {'sec':>7}  slot_accs cut[...] end[...]")
     def fmt(accs):
         return " ".join(f"{a:.3f}" for a in accs) if any(accs) else "-"
 
-    for arm in args.arms.split(","):
+    for spec in args.arms.split(","):
+        arm, anneal_kw = parse_arm_spec(spec)
         for seed in [int(s) for s in args.seeds.split(",")]:
             t0 = time.time()
             r = train_one_arm(arm, K=args.K, m=args.m,
-                              dim=args.dim, steps=args.steps, seed=seed)
-            print(f"{arm:>10} {seed:>5} {r['params']/1e6:>8.2f}M {r['cut_final_acc']:>8.4f} "
-                  f"{r['final_acc']:>10.4f} {time.time()-t0:>7.1f}  "
+                              dim=args.dim, steps=args.steps, seed=seed, **anneal_kw)
+            print(f"{spec:>16} {seed:>5} {r['params']/1e6:>8.2f}M {r['cut_step']:>5} "
+                  f"{r['cut_final_acc']:>8.4f} {r['final_acc']:>10.4f} {time.time()-t0:>7.1f}  "
                   f"cut[{fmt(r['cut_slot_acc'])}] end[{fmt(r['slot_acc'])}]",
                   flush=True)
 

--- a/scratchpad_harness.py
+++ b/scratchpad_harness.py
@@ -200,9 +200,15 @@ def grade_lambda(step, total_steps, onset=0.4, decay=0.2, floor=0.0):
 
 def parse_arm_spec(spec):
     """'annealed@0.2' → onset 0.2; 'annealed@0.4f0.1' → onset 0.4, floor 0.1;
-    plain arm names (including plain 'annealed') pass through unchanged."""
+    plain arm names (including plain 'annealed') pass through unchanged.
+    A near-miss anneal spec is an error, not a fall-through: silently training
+    it as some other arm would print a fully-graded run under an
+    annealed-looking label."""
     m = re.fullmatch(r"annealed(?:@(0?\.\d+))?(?:f(0?\.\d+))?", spec)
     if not m:
+        if spec.startswith("annealed"):
+            raise ValueError(f"bad anneal spec {spec!r} — annealed[@<onset>][f<floor>] "
+                             "with fractions in (0,1), e.g. annealed@0.2 or annealed@0.4f0.1")
         return spec, {}
     kw = {}
     if m.group(1):
@@ -232,6 +238,8 @@ def arm_losses(arm, mdl, tok, sub, lam, depth):
 def train_one_arm(arm, *, K=4, m=7, dim=64, heads=4, enc=2, steps=2500, batch=256,
                   lr=2e-3, wd=0.01, seed=0, n_pool=32768, n_test=4096,
                   anneal_onset=0.4, anneal_decay=0.2, anneal_floor=0.0):
+    assert arm in ("serial", "parallel", "depthonly", "slotsonly", "finalonly",
+                   "annealed"), f"unknown arm {arm!r}"
     task = affine_chain_task(K, m)
     key = jax.random.PRNGKey(seed)
     key, dk_tr, dk_te = jax.random.split(key, 3)

--- a/tests/test_scratchpad_harness.py
+++ b/tests/test_scratchpad_harness.py
@@ -12,7 +12,8 @@ import optax
 from flax import nnx
 
 from scratchpad_harness import (ScratchpadNet, affine_chain_task, arm_losses,
-                                grade_lambda, n_params, train_one_arm)
+                                grade_lambda, n_params, parse_arm_spec,
+                                train_one_arm)
 
 K, M, DIM = 3, 7, 32
 
@@ -153,6 +154,31 @@ def test_grade_lambda_matches_the_preregistered_schedule():
     assert grade_lambda(2499, S) == 0.0
     lams = [grade_lambda(i, S) for i in range(S)]
     assert all(b <= a for a, b in zip(lams, lams[1:])), "λ must never rise"
+
+
+def test_grade_lambda_onset_and_floor_parameterization():
+    """#95 sweeps the schedule: onset moves the decay start (window stays 20%
+    of the budget), floor makes the decay land on a residual grade instead of
+    zero and hold it there."""
+    S = 2500
+    # onset 0.2: on 0–500, decay 500–1000, off 1000+
+    assert grade_lambda(499, S, onset=0.2) == 1.0
+    assert grade_lambda(750, S, onset=0.2) == 0.5
+    assert grade_lambda(1000, S, onset=0.2) == 0.0
+    # floor 0.1: decays 1.0 → 0.1 across #73's window, then holds
+    assert grade_lambda(999, S, floor=0.1) == 1.0
+    assert grade_lambda(1250, S, floor=0.1) == 0.55
+    assert grade_lambda(1500, S, floor=0.1) == 0.1
+    assert grade_lambda(2499, S, floor=0.1) == 0.1
+
+
+def test_parse_arm_spec_round_trips():
+    assert parse_arm_spec("serial") == ("serial", {})
+    assert parse_arm_spec("annealed") == ("annealed", {})
+    assert parse_arm_spec("annealed@0.2") == ("annealed", {"anneal_onset": 0.2})
+    assert parse_arm_spec("annealed@0.4f0.1") == \
+        ("annealed", {"anneal_onset": 0.4, "anneal_floor": 0.1})
+    assert parse_arm_spec("annealedf0.1") == ("annealed", {"anneal_floor": 0.1})
 
 
 def test_annealed_lambda_zero_kills_the_grade_gradient():

--- a/tests/test_scratchpad_harness.py
+++ b/tests/test_scratchpad_harness.py
@@ -9,6 +9,7 @@ import jax
 import jax.numpy as jnp
 import numpy as np
 import optax
+import pytest
 from flax import nnx
 
 from scratchpad_harness import (ScratchpadNet, affine_chain_task, arm_losses,
@@ -179,6 +180,17 @@ def test_parse_arm_spec_round_trips():
     assert parse_arm_spec("annealed@0.4f0.1") == \
         ("annealed", {"anneal_onset": 0.4, "anneal_floor": 0.1})
     assert parse_arm_spec("annealedf0.1") == ("annealed", {"anneal_floor": 0.1})
+
+
+def test_near_miss_arm_specs_refuse_to_run():
+    """A typo'd anneal spec must raise, never silently train some other arm
+    under an annealed-looking label — that would fabricate a sweep row."""
+    for bad in ("annealed@", "annealed@0.2f", "annealed@1.0", "annealed@abc"):
+        with pytest.raises(ValueError):
+            parse_arm_spec(bad)
+    with pytest.raises(AssertionError):
+        train_one_arm("annealed@0.2", K=K, m=M, dim=DIM, steps=2,
+                      batch=8, n_pool=16, n_test=8, seed=0)
 
 
 def test_annealed_lambda_zero_kills_the_grade_gradient():


### PR DESCRIPTION
## Summary
Runs the #95 sweep: how early can the grade anneal start, and does annealing to a small floor λ instead of zero buy back the stability #73 lost. Answers: **no fixed earlier onset is reliable** (the warm-up is a state — the chain must be decodable through the deep slots — not a time), and **the floor wins decisively** (control-level seed variance, 7× calmer than annealing to zero).

Closes #95

## What & why
- **`scratchpad_harness.py`** — parameterizes the anneal schedule: `grade_lambda` takes an onset (where decay starts, as a fraction of the budget; window stays 20%) and a floor (the residual λ the decay lands on and holds). CLI arm specs: `annealed@0.2`, `annealed@0.4f0.1`; plain `annealed` is #73's arm, unchanged. The grade-off checkpoint now follows each arm's own schedule (and is returned as `cut_step`). Boundary arithmetic sums the scaled terms so the default arm replays #73's recorded run **bitwise** — verified by re-running it (all three seeds identical to the digit).
- **`tests/test_scratchpad_harness.py`** — pins the parameterized schedule values (onset moves the window, floor is held after decay) and the arm-spec parser round-trips.
- **`docs/findings/2026-07-12-anneal-floor-wins-onset-is-a-state.md`** — the result (control = #73's graded serial, 0.9922 ± 0.011; chance 0.143):

| arm | grade off at | final (seeds 0/1/2) | mean | σ | collapsed |
|---|---|---|---|---|---|
| annealed@0.1 | 750 | 0.1421 / 0.1401 / 0.1421 | 0.1414 | 0.001 | 3/3 |
| annealed@0.2 | 1000 | 0.1548 / 0.2659 / 0.9937 | 0.4715 | 0.456 | 2/3 |
| annealed@0.3 | 1250 | 0.1992 / 0.9895 / 0.9973 | 0.7287 | 0.459 | 1/3 |
| annealed (#73 replay) | 1500 | 0.9524 / 0.9963 / 0.8494 | 0.9327 | 0.075 | 0/3 |
| **annealed@0.4f0.1** | 1500 | 0.9885 / 0.9954 / 0.9736 | **0.9858** | **0.011** | 0/3 |

Floor arm: both pre-registered clauses met with room (σ 0.0111 ≤ 2× control's 0.0114; mean gap 0.006 < 2σ_pooled 0.023) — and the residual grade keeps the probe head calibrated, removing #73's stale-probe caveat. Onset sweep: failures are bimodal per seed (collapse to ~chance or full recovery, nothing between); the pre-registered 2σ_pooled test is only honest for onset 10% (cleanly dead) — for 20/30% the collapses inflate the arm's own σ until the bar rejects nothing, so the finding reports the per-seed collapse count as the real readout and flags the criterion's pathology explicitly. The slot probes at the grade-off step separate every outcome: chain decodable through slot 3 (≥0.57) → final-only loss finishes and polishes it; stuck at slot 2 (≤0.29) → the whole chain unravels, shallow slots included. LM-scale recipe update: anneal to λ≈0.1, and gate the anneal on measured per-slot decodability, not a step count.

## Validation / smoke-test performed
- [x] `JAX_PLATFORMS=cpu pytest tests/ -q` passes locally (11/11 in the harness test file; full suite green with the usual GPU-only skips)
- Other checks run: the 15-run sweep itself (~45 min CPU, command in the finding); the plain `annealed` replay arm reproduced #73's published numbers bitwise (all three seeds, every column), proving the refactor inert; `ruff check` clean on changed files.

## Risk
CPU-only toy harness; no production training path, checkpoint format, or pinned dep touched. `grade_lambda`/`train_one_arm` gain keyword args with defaults that replay #73 bitwise; `train_one_arm`'s dict gains a `cut_step` key (additive).

## Checklist
- [x] Did not weaken or delete any test (no skips/xfails/loosened asserts to make it pass)
- [x] Smoke-tested; no multi-hour run was launched without sign-off
- [x] Pinned deps unchanged, or the bump is justified above
- [x] Findings/claims backed by evidence in the PR or a linked finding issue

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BitU2BHqVSp5QqnjwcE9GX

---
_Generated by [Claude Code](https://claude.ai/code/session_01BitU2BHqVSp5QqnjwcE9GX)_