### PR TITLE
Per-pass stabilizer confirmation: killed as registered, statetrack clause survives (#77)

### DIFF
--- a/docs/findings/2026-07-12-per-pass-stabilizer-confirmation.md
+++ b/docs/findings/2026-07-12-per-pass-stabilizer-confirmation.md
@@ -1,0 +1,74 @@
+# The per-pass stabilizer claim dies as registered — parity's rescue was islands-specific — but chain-intact per-pass supervision eliminates the statetrack collapse mode across 12 matched seeds
+
+Status: killed per pre-registration (conjunction failed on the parity clause); the surviving statetrack clause is now well-supported, recorded as scoped
+Date: 2026-07-12
+Commit: 436c723  Run: tiny-config ablation (synthetic, no runs/ id)  Measured with: `python ablation_harness.py --task {parity,statetrack} --depths 8 --steps 2500 --seed {0..5|6..11} [--per-pass-loss] [--readouts]` (CPU, f32)
+
+## Setup
+
+#77's hypothesis, spun out of #75's readouts: grading every refinement pass
+(`--per-pass-loss`, gradient chain intact) removes the depth-8 collapse mode of
+deep weight-shared recurrence. Pre-registered keep required BOTH clauses:
+parity (c) beats final-only (a) by ≥2σ_pooled over 6 seeds, AND statetrack
+collapse count (acc < 0.5) over 6 fresh seeds lower/equal in (c) with zero (c)
+collapses. Kill: parity gap under 2σ → "the #75 parity readout was an
+islands-specific or seed artifact; record and stop."
+
+Matched pairs throughout (same seed ⇒ same init/pools/minibatch order). The
+three #75 parity controls were reused: `ablation_harness.py`/`plan_a_model.py`
+are byte-identical since commit 3bfe1fd (diff checked), and pipeline
+determinism has reproduced exact numbers twice before.
+
+## Evidence
+
+**Parity, depth 8, seeds {0..5} (chance 0.5) — the primary clause: FAILED.**
+
+| arm | seeds 0..5 | mean ± σ |
+|---|---|---|
+| (a) final-only | .582 / .628 / .532 / .627 / .577 / .560 | 0.584 ± 0.037 |
+| (c) per-pass, chain intact | .531 / .624 / .788 / .574 / .915 / .560 | 0.665 ± 0.153 |
+
+Δ = +0.081 at +0.73σ against the 2σ bar. Per the pre-registration the #75
+parity rescue (0.929 ± 0.059) was **islands-specific, not a seed artifact**:
+that rescue used per-pass grading PLUS a severed chain, and grading alone does
+not reproduce it (two seeds lift, four stay at coin-flip). On parity, the
+unstable cross-pass feedback loop apparently IS the pathology — #75's cut
+removed it; supervision alone only sometimes fights it.
+
+**Statetrack, depth 8, fresh seeds {6..11} — the secondary clause: PASSED.**
+
+| arm | seeds 6..11 | mean ± σ | collapses |
+|---|---|---|---|
+| (a) final-only | .981 / .750 / .894 / **.414** / .983 / .980 | 0.834 ± 0.225 | 1 (+2 degraded) |
+| (c) per-pass | .987 / .985 / .988 / .987 / .986 / .987 | 0.9867 ± 0.0013 | 0 |
+
+Pooled with #75's seeds {0..5}, the 12-matched-seed picture: control
+0.852 ± 0.230 with 2 collapses (seeds 3, 9) and 2 degraded seeds (7: 0.750,
+8: 0.894); per-pass 0.9864 ± 0.0022 with **12/12 seeds in [0.982, 0.989]**.
+The control's failure mode is real and recurrent (~2/12 collapse, ~4/12
+off-nominal); per-pass supervision has never produced an off-nominal seed.
+
+## Verdict and what survives
+
+The claim **as registered is killed** — the keep was a conjunction and parity
+failed it. What survives, scoped honestly: chain-intact per-pass supervision
+eliminates the training-instability mode **on statetrack**, the task family
+where the refiner's depth actually earns its keep
+(2026-06-16-plan-a-depth-ablation.md), with a 100× variance reduction
+(σ 0.0022 vs 0.2295) at zero inference cost. It is not a universal deep-
+recurrence stabilizer: parity's pathology needs the chain cut, which costs
+accuracy where cross-pass credit matters (#75). Related evidence from the
+other instrument: the scratchpad's per-slot grade also stabilizes
+(2026-07-10-grade-annealing-scaffold-not-crutch.md — σ up 7× when annealed
+away), so "local grading stabilizes what it touches" now has two independent
+demonstrations, each scoped to its own mechanism.
+
+## Limitations
+
+Toy scale, depth 8, uniform loss weighting. The statetrack stabilizer clause
+passed its pre-registered form, but the accuracy-mean comparison remains
+untested at ≥2σ rigor in the working mode (both #75 attempts stayed inside the
+bar). Before any real-scale adoption: the per-pass loss multiplies LM-head CE
+cost by depth, which collides with chunked CE (#19) — needs a design pass, and
+the grade-annealing result suggests a cheaper shape (per-pass grade as warm-up
+scaffold with a floor, cf. #95/#101) rather than run-long full weighting.


### PR DESCRIPTION
## Summary
Runs #77's pre-registered confirmation of the per-pass-supervision stabilizer (21 fresh CPU runs, docs-only diff — the harness flags already merged in #78). Verdict: **killed as registered** — the parity clause failed (+0.73σ vs the 2σ bar), proving #75's parity rescue was islands-specific. The statetrack clause **passed decisively**: over 12 matched seeds, chain-intact per-pass supervision has zero collapses and σ 0.0022 vs the control's 2 collapses, 2 degraded seeds, σ 0.23.

Closes #77.

## What & why
One file: `docs/findings/2026-07-12-per-pass-stabilizer-confirmation.md`. Evidence:

| clause | result |
|---|---|
| parity (c) ≥2σ over (a), 6 seeds | **FAILED** — 0.665 ± 0.153 vs 0.584 ± 0.037, Δ/σ = +0.73. Grading alone doesn't fix parity; #75's rescue needed the chain cut too. |
| statetrack collapse count, fresh seeds 6–11 | **PASSED** — control 0.834 ± 0.225 (one 0.414 collapse, 0.750 and 0.894 degraded) vs per-pass 0.9867 ± 0.0013, all six in [0.985, 0.988]. |

The keep was a conjunction, so the universal-stabilizer claim dies; what's recorded as surviving is scoped: per-pass supervision eliminates the collapse mode *on statetrack* — the task where the refiner's depth earns its keep — at ~100× variance reduction and zero inference cost. Connects to the grade-annealing finding (#73): local grading stabilizing what it touches now has two independent demonstrations. Real-scale adoption stays blocked on a chunked-CE (#19) design pass; #73/#95 suggest the cheap shape is a warm-up scaffold with a floor, not run-long weighting.

Protocol notes: matched pairs throughout; the three #75 parity controls were reused after verifying `ablation_harness.py`/`plan_a_model.py` are byte-identical since 3bfe1fd.

## Validation / smoke-test performed
- [x] `JAX_PLATFORMS=cpu pytest tests/ -q` passes locally (all green)
- Other checks run: 21 × 2500-step CPU runs per #77's pre-registered protocol (its own approved budget); stats computed against the criteria as written.

## Risk
None to code — docs-only diff. The risk surface is epistemic and it's the point: the finding records a kill honestly so the scoped statetrack result can't inflate into a universal claim later.

## Checklist
- [x] Did not weaken or delete any test (no skips/xfails/loosened asserts to make it pass)
- [x] Smoke-tested; no multi-hour run was launched without sign-off (#77's pre-approved CPU budget)
- [x] Pinned deps unchanged, or the bump is justified above
- [x] Findings/claims backed by evidence in the PR or a linked finding issue

---
**Left unmerged for owner review by request.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0197gv8bdynUDPSuzG8882xS

---
_Generated by [Claude Code](https://claude.ai/code/session_0197gv8bdynUDPSuzG8882xS)_