### PR TITLE
CLAUDE.md: partial-cpu drafts carry a context-free resume protocol

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -167,7 +167,11 @@ in issues. Working plans stay local and gitignored (`docs/plans/`, `aux*`).
   whenever (cloud sessions parallelize freely, the card doesn't), park it as a **draft
   PR** stating exactly what waits on the GPU, and the GPU tail takes its turn in the
   serial queue when the card is back. The claim (assignee + draft PR) keeps the parked
-  issue out of the ready-queue meanwhile.
+  issue out of the ready-queue meanwhile. The draft's "what waits" section is a
+  **resume protocol a context-free session can execute**: exact commands (including
+  the env/config knobs that make them hit the changed code), what counts as pass
+  against what baseline, and the pre-named fallback if it fails — finishing must need
+  only the card, never this conversation's memory. (Template case: PR #98 / #84.)
 - **`bug`** — a defect; attaches to whichever type it lives in. A bug that **blocks the
   active lane** (e.g. a crash stopping the running GPU job) jumps the queue — fix what's
   in the way first. A bug on a path nobody is running waits its turn.


### PR DESCRIPTION
## Summary
One-paragraph extension to the #106 partial-cpu convention: the parked draft's "what waits on the GPU" section must be a **resume protocol a context-free session can execute** — exact commands (including the env/config knobs that make them hit the changed code), pass criteria against a named baseline, and the pre-named fallback on failure.

## What & why
Doc-only, cherry-picked out of PR #98 so the convention reaches main (and every cloud session that reads CLAUDE.md) now, instead of waiting behind #98's GPU gates. The lesson it encodes came from writing #98's protocol: the first draft said "run `tools/bench_train_step.py`" — which defaults to the reasoner and would never have touched the changed refiner code. Commands need their knobs (`MODEL_ARCH=refiner`), a named baseline (this branch vs `main`, back-to-back), and a pre-named fallback, or the GPU session ends up reconstructing intent from a conversation it never had. PR #98 / #84 is cited in the text as the template case.

When #98 later merges, this hunk is byte-identical there — the merge is a clean no-op.

## Validation / smoke-test performed
- [x] `JAX_PLATFORMS=cpu pytest tests/ -q` — N/A beyond doc rendering: markdown-only diff, no code touched.
- Other checks run: none needed (single CLAUDE.md paragraph).

## Risk
None — documentation only.

## Checklist
- [x] Did not weaken or delete any test (no skips/xfails/loosened asserts to make it pass)
- [x] Smoke-tested; no multi-hour run was launched without sign-off
- [x] Pinned deps unchanged
- [x] Findings/claims backed by evidence in the PR (the #98 gate-2 example above)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BARGqUVYyJuF574C9iaZ6o

---
_Generated by [Claude Code](https://claude.ai/code/session_01BARGqUVYyJuF574C9iaZ6o)_