### PR TITLE
CI: skip draft PRs and markdown-only changes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,10 +1,17 @@
 name: CI
 
+# Trigger policy (#110): skip draft PRs (parked partial-cpu work re-triggers via
+# ready_for_review the moment it's undrafted, so nothing merges unchecked) and
+# markdown-only changes (paths-ignore skips only when EVERY changed file is .md —
+# a mixed .md+code diff still runs everything).
 on:
   push:
     branches: [main]
+    paths-ignore: ["**.md"]
   pull_request:
     branches: [main]
+    types: [opened, synchronize, reopened, ready_for_review]
+    paths-ignore: ["**.md"]
 
 # Three named jobs so each load-bearing check is a separately visible (and
 # separately requireable) status (#45):
@@ -17,9 +24,12 @@ on:
 # CPU-only throughout (FORCE_F32_COMPUTE via tests/conftest.py or explicit env)
 # so CI runs while the GPU trains; the real f16 path stays RUN_TESTS_ON_GPU=1.
 
+# Each job carries the draft guard (an `if` on the job, since a workflow can't
+# be conditioned as a whole); push events have no PR payload, so they pass.
 jobs:
   test:
     name: pytest (CPU)
+    if: ${{ github.event_name == 'push' || !github.event.pull_request.draft }}
     runs-on: ubuntu-latest
     env:
       # CPU-only CI for the unit tests; no GPU/CUDA, no training runs.
@@ -47,6 +57,7 @@ jobs:
 
   golden:
     name: golden-run (CPU)
+    if: ${{ github.event_name == 'push' || !github.event.pull_request.draft }}
     runs-on: ubuntu-latest
     env:
       JAX_PLATFORMS: cpu
@@ -74,6 +85,7 @@ jobs:
 
   smoke:
     name: overfit smoke (CPU)
+    if: ${{ github.event_name == 'push' || !github.event.pull_request.draft }}
     runs-on: ubuntu-latest
     env:
       JAX_PLATFORMS: cpu

--- a/.github/workflows/review-gate.yml
+++ b/.github/workflows/review-gate.yml
@@ -12,13 +12,19 @@ name: Review Gate
 # When neither secret is set (forks, or not yet configured) the job skips
 # gracefully — the pytest CI job remains the hard gate either way.
 
+# Trigger policy (#110), same as ci.yml — doubly worth it here since every run
+# spends Claude tokens: skip drafts (ready_for_review re-triggers on undraft)
+# and markdown-only diffs.
 on:
   pull_request:
     branches: [main]
+    types: [opened, synchronize, reopened, ready_for_review]
+    paths-ignore: ["**.md"]
 
 jobs:
   review:
     name: code-reviewer verdict
+    if: ${{ !github.event.pull_request.draft }}
     runs-on: ubuntu-latest
     permissions:
       contents: read


### PR DESCRIPTION
## Summary
CI (`ci.yml`, three jobs) and the review gate (`review-gate.yml`, which spends Claude tokens per run) now run only for **ready-for-review** PRs whose diff touches **something other than `.md` files**. Motivating cases: #106 (a CLAUDE.md-only PR that ran three CI jobs + an AI review, twice counting the merge push) and #109 (a deliberately-parked draft that triggered everything on creation).

## What & why
- **`pull_request` triggers** on both workflows gain `types: [opened, synchronize, reopened, ready_for_review]` and `paths-ignore: ["**.md"]`.
- **Job-level draft guards**: `if: !github.event.pull_request.draft` on all four jobs (CI's guard also passes `push` events, which carry no PR payload).
- **`push` to main** gains the same `paths-ignore`, so doc-only merge commits skip too.

The two safety properties that make this correct:
1. **Nothing merges unchecked.** The `ready_for_review` event fires the full suite the moment a draft is flipped — the exact flow the partial-cpu convention uses (park as draft → GPU day → undraft → CI runs → merge). Drafts skip CI *while parked*, which is when their state is provisional anyway.
2. **Mixed diffs still run.** `paths-ignore` skips only when *every* changed file matches — a PR touching `.md` + code runs everything. "Skip no-op merges" means doc-only, not docs-adjacent.

Caveat recorded on #110: if branch protection ever marks these jobs as *required* checks, doc-only PRs would show perpetually-pending statuses; no required checks exist today, and the standard no-op-fallback remedy is noted on the issue for if that changes.

Closes #110

## Validation / smoke-test performed
- [x] `JAX_PLATFORMS=cpu pytest tests/ -q` — N/A: workflow YAML only, no Python touched.
- Other checks run:
  - Both files parse clean (PyYAML); trigger types, paths-ignore, and all four job-level `if` guards verified in the parsed structure.
  - Live verification is this PR itself plus the next occurrences of each case (acceptance list on #110): this PR is ready-for-review and touches `.yml`, so all jobs must run on it.

## Risk
- Behavioral only, no code: worst failure mode is CI not running when it should. The two named risks (unchecked undraft-merge, skipped mixed diff) are addressed by the `ready_for_review` type and the all-files-must-match semantics of `paths-ignore` respectively, and #110's acceptance list covers observing both live.
- If a future doc-only PR *should* run CI for some reason, pushing any non-md file (or re-running from the Actions tab) restores it.

## Checklist
- [x] Did not weaken or delete any test (no skips/xfails/loosened asserts to make it pass)
- [x] Smoke-tested; no multi-hour run was launched without sign-off
- [x] Pinned deps unchanged
- [x] Findings/claims backed by evidence in the PR (see Validation)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BARGqUVYyJuF574C9iaZ6o

---
_Generated by [Claude Code](https://claude.ai/code/session_01BARGqUVYyJuF574C9iaZ6o)_