### PR TITLE
Retention under capacity pressure is real (#116): local-writer arms + slot-parking win

### DIFF
--- a/docs/findings/2026-07-18-budget-scratchpad-retention-win-slot-parking.md
+++ b/docs/findings/2026-07-18-budget-scratchpad-retention-win-slot-parking.md
@@ -1,0 +1,118 @@
+# Learned retention under capacity pressure is real: with the writer leak closed, 2 slots for 5 writes solves recall perfectly by parking r_1 in one slot and churning the other — while the 1-slot control's in-vector carry trains unreliably
+
+Status: confirmed
+Date: 2026-07-18
+Commit: e5f9c80 (claude/116-local-writer — local_writer arms + leak-guard tests)
+Run: tiny-config ablation (synthetic, no runs/ id)
+Measured with: `JAX_PLATFORMS=cpu python scratchpad_harness.py --arms unlimited_local --seeds 0,1,2 --K 5 --m 7 --steps 2500`, then `--arms budget1_local,budget2_local` (#116); addressing probe: deterministic seed-0 replay printing mean softmax address per write
+
+## Setup
+
+Take 3 of the #63 phase-2 question, with BOTH prior invalidators fixed: the
+eval-target bug (PR #76, `final_target`) and the writer side channel (#114 —
+a full-sequence causal encoder let the last write compute the recall answer
+directly, so no slot budget forced anything). The `_local` arms encode each
+(a_k, b_k) link as its own independent 2-token sequence (`encode_links`);
+write k sees link k + current memory ONLY. Two leak-guard tests pin this
+architecturally: link k's encoding is bit-identical regardless of other
+links' contents, and the gradient from the final answer to link 1 is exactly
+zero once the memory chain is stop-gradiented after write 1. Any correct
+recall of `(r_1 + r_K) mod m` therefore proves information survived in
+memory across K-1 subsequent writes — there is no other path.
+
+Task and bars pre-registered on #116 (including the pre-run amendment):
+recall target `(r_1 + r_K) mod m`, K=5, m=7, dim 64, 2500 steps, seeds
+{0,1,2}, slots-only readout. Ceiling first (rule 4): `unlimited_local` must
+reach ≥~0.9 or stop. Win bar: budget2_local beats budget1_local by
+≥2σ_pooled and approaches the ceiling. Kill bar: budget2_local at
+budget1_local's level. Amendment (before any number was seen): budget1 at
+chance is NOT required for validity — with local writers, budget1 can
+legitimately retain by re-copying r_1 through its single write vector; either
+outcome is informative.
+
+## Evidence
+
+Held-out final-answer accuracy (chance = 1/7 = 0.1429), 3 seeds:
+
+| arm | memory | seed 0 | seed 1 | seed 2 | mean | σ |
+|---|---|---|---|---|---|---|
+| unlimited_local (ceiling) | 5 slots, append-only | 0.9995 | 1.0000 | 1.0000 | 0.9998 | 0.0003 |
+| budget2_local (bet) | 2 slots, 5 writes | 1.0000 | 1.0000 | 1.0000 | **1.0000** | 0.0000 |
+| budget1_local (control) | 1 slot, 5 writes | 0.8740 | 0.1548 | 0.1460 | 0.3916 | 0.4178 |
+
+Win bar: budget2 − budget1 = +0.608, σ_pooled = 0.295 → **2.06σ** — clears
+the pre-registered 2σ, and budget2 doesn't approach the ceiling, it EQUALS it
+(three exact 1.0000s, σ = 0). The kill bar does not fire. Per-slot grades are
+≥0.994 at every write in EVERY seed of every arm — including budget1's two
+chance seeds, so what fails there is only the carry, never the chain
+computation.
+
+Learned addressing policy, budget2_local seed 0 (bit-exact replay, confirmed
+by reproducing final_acc 1.0000; mean softmax address = fraction of each slot
+overwritten, held-out batch):
+
+| write | slot 0 | slot 1 |
+|---|---|---|
+| 1 (r_1) | 0.396 | 0.604 |
+| 2 | 0.994 | 0.006 |
+| 3 | 0.996 | 0.004 |
+| 4 | 0.996 | 0.004 |
+| 5 | 0.995 | 0.005 |
+
+Write 1 lands (mostly) in slot 1; writes 2–5 route ~99.5% into slot 0,
+touching slot 1 at ~0.5% per step (r_1's imprint survives ≈0.995⁴ ≈ 98%
+intact). The write-1 spill into slot 0 is harmless — write 2 overwrites slot
+0 anyway. This is slot-parking: protect one address after its deposit, churn
+the other.
+
+## Reading
+
+**Retention under capacity pressure works, and it is an addressing behavior,
+not a vector-capacity behavior.** Given somewhere to park (S=2), the model
+learns keep-vs-evict reliably — perfectly, on every seed — with no forget
+gate, no retention bonus, nothing but capacity pressure and the final-answer
+loss. Forced to instead thread r_1 through its working vector (S=1, forced
+full overwrite), it usually loses it: 2/3 seeds at chance with flawless
+per-step computation. A 64-dim vector has plenty of ROOM for two mod-7
+values; what's missing at S=1 is a stable optimization path to using that
+room. The bits that matter are where the gradient can find them — a physical
+slot the addressing can choose not to touch — not merely somewhere they'd
+fit.
+
+Secondary: the #114 budget2 seed instability (0.14–0.97 under the leaky
+full-context writer) is GONE — σ = 0.0000 here. Consistent with the leak
+having offered two competing gradient paths (compute-at-the-end vs. retain);
+with only retention available, training is calm. Observation at n=3, not a
+claim.
+
+The 2.06σ margin is thin because the control's bimodality inflates σ_pooled;
+the statistics-free statement is stronger: budget2_local = ceiling, exactly,
+three for three.
+
+## Limitations
+
+Toy scale: n=3 seeds, single K=5/m=7/dim-64/2500-step point. The addressing
+probe covers one seed (deterministic replay). Whether S=1's in-vector carry
+becomes reliable with more steps/dim, and whether parking survives larger K
+(longer protection horizon) or S=2 with TWO values to protect, are untested —
+larger K was pre-named on #116 as the next knob if both arms saturated; only
+budget1 didn't, so the current point already separates the arms.
+
+## Relation to prior work
+
+- Completes the #63 phase-2 arc: phase 1 (2026-07-05, overwrite-is-free)
+  showed capacity costs nothing when nothing needs keeping; this shows the
+  complement — when something must be kept, the model chooses correctly.
+  The two prior invalid attempts: eval-target bug
+  (2026-07-05-…-recall-inconclusive-…, retracted), writer leak
+  (2026-07-16-…-writer-leaks).
+- Settles the locus question left open by the #114 finding (amended, PR
+  #117): with the writer architecturally unable to precompute the answer, the
+  0.9998 ceiling proves the READOUT retrieves two slots and combines them.
+- The graveyard contrast (2026-06-13-cross-window-hunch-inert): the hunch's
+  optional forget/blend gate collapsed because gradients could route around
+  memory entirely. Here the memory pathway is mandatory and capacity does the
+  forcing — same desideratum (learned retention), opposite wiring, opposite
+  outcome. That inversion — make memory the only path and let capacity
+  pressure teach the policy — is the design lesson to carry into the LM
+  scratchpad (#102).

--- a/docs/findings/README.md
+++ b/docs/findings/README.md
@@ -27,6 +27,7 @@ things, it doesn't go in this folder.
 - `2026-07-12-anneal-floor-wins-onset-is-a-state.md` — #95: anneal to a floor of λ≈0.1 (control-level σ, 7× calmer than zero); no fixed earlier onset is reliable — the grade must stay until the chain is decodable through the deep slots
 - `2026-07-15-f16-no-loss-scaling-no-dense-underflow.md` — #82: dense-kernel zero-grad fraction 0.0003 vs the 0.05 bar on the f16 no-loss-scaling path — underflow measurable but negligible at init; base run's early stretch is the confirming read
 - `2026-07-16-budget-scratchpad-recall-rerun-readout-fine-writer-leaks.md` — #114: corrected-eval rerun of #63 phase 2 — the readout combines two values at 0.99 (old diagnosis dead), but the token-visible writer leaks the answer past the S=1 control, so retention is still untested
+- `2026-07-18-budget-scratchpad-retention-win-slot-parking.md` — #116: retention under capacity pressure is real — leak closed, 2 slots for 5 writes hits 1.0000 on every seed by parking r_1 (~99.5% of later writes routed away from it), while the 1-slot in-vector carry trains unreliably
 
 ## Entry template
 

--- a/scratchpad_harness.py
+++ b/scratchpad_harness.py
@@ -1,4 +1,4 @@
-"""Toy proof harness for the supervised serial latent scratchpad (#38, #62, #63, #67, #73, #79).
+"""Toy proof harness for the supervised serial latent scratchpad (#38, #62, #63, #67, #73, #79, #116).
 
 The arms on the chained-affine-maps task (docs/design/serial-scratchpad.md):
 
@@ -134,6 +134,26 @@ class CrossBlock(nnx.Module):
         return x + self.down_proj(jax.nn.silu(self.gate_proj(h)) * self.up_proj(h))
 
 
+def encode_links(embed, encoder, tokens, per_link):
+    """Shared encode step. per_link=False: the standard causal encode over the
+    whole sequence -> [B, 2K, d]. per_link=True (#116): each (a_k, b_k) link is
+    embedded and encoded as its OWN 2-token sequence -> [B, K, 2, d] — there is
+    no attention path between links, so link j can reach step k != j only
+    through whatever the writes chose to keep in memory. This is the leak fix:
+    the #114 rerun showed a full-sequence causal encoder lets the LAST write
+    compute the recall answer directly, making every slot budget porous."""
+    h = embed(tokens)
+    if per_link:
+        bsz, seq, d = h.shape
+        assert seq % 2 == 0, "per-link encoding expects (a_k, b_k) pairs"
+        h = h.reshape(bsz * (seq // 2), 2, d)
+    for blk in encoder:
+        h = blk(h)
+    if per_link:
+        return h.reshape(bsz, seq // 2, 2, d)
+    return h
+
+
 class ScratchpadNet(nnx.Module):
     """embed -> causal encoder -> K slot writes (serial or parallel) -> readout.
 
@@ -148,17 +168,25 @@ class ScratchpadNet(nnx.Module):
                   slots. Final-answer CE becomes the model's only supervision
                   (#67), with the slot-by-slot readout kept as the instrument
                   that shows whether the decomposition emerged anyway.
+    local_writer=True (#116): tokens are encoded per link (encode_links), and
+                  slot k's write context is link k's two states + slots 1..k-1
+                  — the ONLY cross-step channel is the slots. Serial and
+                  slots-only-readout by requirement (asserted), since a
+                  full-sequence view anywhere would reopen the #114 leak.
     All modes share the identical parameter tree — the flags only change the
     data flow, which is what makes each comparison a one-variable ablation.
     """
 
     def __init__(self, *, dim, vocab, num_slots, num_heads=4, num_encoder_layers=2,
                  max_seq_len=64, serial=True, read_tokens=True, probe_only=False,
-                 rngs, dtype=jnp.float32):
+                 local_writer=False, rngs, dtype=jnp.float32):
+        assert not local_writer or (serial and not read_tokens), \
+            "local_writer requires serial=True and read_tokens=False (#116)"
         self.num_slots = num_slots
         self.serial = serial
         self.read_tokens = read_tokens
         self.probe_only = probe_only
+        self.local_writer = local_writer
         self.embed = nnx.Embed(vocab, dim, rngs=rngs, dtype=dtype)
         self.encoder = nnx.List([
             Block(dim, num_heads, max_seq_len, rngs, dtype) for _ in range(num_encoder_layers)
@@ -172,9 +200,9 @@ class ScratchpadNet(nnx.Module):
         self.answer_head = nnx.Linear(dim, vocab, rngs=rngs, dtype=dtype)
 
     def __call__(self, tokens):
-        h = self.embed(tokens)
-        for blk in self.encoder:
-            h = blk(h)
+        if self.local_writer:
+            assert tokens.shape[1] == 2 * self.num_slots, "one (a_k, b_k) link per slot"
+        h = encode_links(self.embed, self.encoder, tokens, self.local_writer)
         bsz = tokens.shape[0]
         queries = self.slot_index(jnp.arange(self.num_slots))[None, :, :]   # [1, K, d]
         queries = jnp.broadcast_to(queries, (bsz, self.num_slots, queries.shape[-1]))
@@ -182,7 +210,8 @@ class ScratchpadNet(nnx.Module):
         if self.serial:
             slots = []
             for k in range(self.num_slots):
-                ctx = jnp.concatenate([h] + slots, axis=1) if slots else h
+                base = h[:, k] if self.local_writer else h                  # link k only, or all tokens
+                ctx = jnp.concatenate([base] + slots, axis=1) if slots else base
                 slots.append(self.write_block(queries[:, k:k + 1], ctx))    # written once
             slots = jnp.concatenate(slots, axis=1)                          # [B, K, d]
         else:
@@ -190,7 +219,8 @@ class ScratchpadNet(nnx.Module):
 
         graded = jax.lax.stop_gradient(slots) if self.probe_only else slots
         slot_logits = self.slot_readout(graded)                             # [B, K, m]
-        return self.readout(h, slots), slot_logits
+        h_read = h[:, -1] if self.local_writer else h   # content unread: local_writer forces read_tokens=False
+        return self.readout(h_read, slots), slot_logits
 
     def readout(self, h, slots):
         """Answer logits from the readout context. A separate method so the #62
@@ -224,14 +254,24 @@ class BudgetScratchpadNet(nnx.Module):
     invertible, so a tokens-visible readout could recompute r_1 from r_K and
     the tokens directly, without ever consulting memory -- the #62 slots-only
     wiring closes that shortcut so a win can only mean genuine retention.
+
+    local_writer (#116) closes the OTHER shortcut the #114 rerun exposed: with
+    a full-sequence encoder, step k's write sees every link, so the LAST write
+    can compute the recall answer itself and carry it past any slot budget
+    (budget1 hit 0.897 that way). With local_writer=True each write sees only
+    its own link (encode_links) + the current memory -- information can cross
+    steps ONLY by surviving in memory. Requires read_tokens=False.
     """
 
     def __init__(self, *, dim, vocab, num_steps, num_slots, num_heads=4,
                  num_encoder_layers=2, max_seq_len=64, read_tokens=True,
-                 rngs, dtype=jnp.float32):
+                 local_writer=False, rngs, dtype=jnp.float32):
+        assert not (local_writer and read_tokens), \
+            "local_writer requires read_tokens=False (#116)"
         self.num_steps = num_steps
         self.num_slots = num_slots
         self.read_tokens = read_tokens
+        self.local_writer = local_writer
         self.embed = nnx.Embed(vocab, dim, rngs=rngs, dtype=dtype)
         self.encoder = nnx.List([
             Block(dim, num_heads, max_seq_len, rngs, dtype) for _ in range(num_encoder_layers)
@@ -248,9 +288,9 @@ class BudgetScratchpadNet(nnx.Module):
         self.answer_head = nnx.Linear(dim, vocab, rngs=rngs, dtype=dtype)
 
     def __call__(self, tokens):
-        h = self.embed(tokens)
-        for blk in self.encoder:
-            h = blk(h)
+        if self.local_writer:
+            assert tokens.shape[1] == 2 * self.num_steps, "one (a_k, b_k) link per step"
+        h = encode_links(self.embed, self.encoder, tokens, self.local_writer)
         bsz = tokens.shape[0]
         memory = jnp.broadcast_to(self.mem_init[...].astype(h.dtype),
                                   (bsz, self.num_slots, h.shape[-1]))
@@ -259,7 +299,8 @@ class BudgetScratchpadNet(nnx.Module):
         for k in range(self.num_steps):
             q_k = jnp.broadcast_to(self.step_index(jnp.array([k]))[None, :, :],
                                    (bsz, 1, h.shape[-1]))
-            ctx = jnp.concatenate([h, memory], axis=1)
+            tok_ctx = h[:, k] if self.local_writer else h                  # link k only, or all tokens
+            ctx = jnp.concatenate([tok_ctx, memory], axis=1)
             v_k = self.write_block(q_k, ctx)                                # [B, 1, d]
             slot_logits.append(self.slot_readout(v_k))                     # graded on THIS write
 
@@ -268,7 +309,8 @@ class BudgetScratchpadNet(nnx.Module):
             memory = (1 - addr[:, :, None]) * memory + addr[:, :, None] * v_k
 
         slot_logits = jnp.concatenate(slot_logits, axis=1)                 # [B, K, m]
-        return self.readout(h, memory), slot_logits
+        h_read = h[:, -1] if self.local_writer else h   # content unread: local_writer forces read_tokens=False
+        return self.readout(h_read, memory), slot_logits
 
     def readout(self, h, memory):
         """Same contract as ScratchpadNet.readout: read_tokens=False makes the
@@ -352,7 +394,10 @@ def parse_arm_spec(spec):
 # (r_1 + r_K) mod m with a slots-only readout (see docs/design/budget-scratchpad.md
 # for why tokens must be hidden there). overwrite stays on the plain chain
 # task (final = r_K), matched against serial exactly as #38 was.
-RECALL_ARMS = ("budget1", "budget2", "unlimited")
+# The _local variants (#116) are the same arms with per-link writer context
+# (local_writer=True) — the leak-closed rerun where retention must be real.
+RECALL_ARMS = ("budget1", "budget2", "unlimited",
+               "budget1_local", "budget2_local", "unlimited_local")
 
 
 def final_target(arm, sub, m):
@@ -405,7 +450,8 @@ def train_one_arm(arm, *, K=4, m=7, dim=64, heads=4, enc=2, steps=2500, batch=25
                   anneal_onset=0.4, anneal_decay=0.2, anneal_floor=0.0):
     assert arm in ("serial", "parallel", "depthonly", "slotsonly", "finalonly",
                    "annealed", "densedepth", "densedepth_tied",
-                   "overwrite", "budget1", "budget2", "unlimited"), f"unknown arm {arm!r}"
+                   "overwrite", "budget1", "budget2", "unlimited",
+                   "budget1_local", "budget2_local", "unlimited_local"), f"unknown arm {arm!r}"
     task = affine_chain_task(K, m)
     key = jax.random.PRNGKey(seed)
     key, dk_tr, dk_te = jax.random.split(key, 3)
@@ -423,15 +469,17 @@ def train_one_arm(arm, *, K=4, m=7, dim=64, heads=4, enc=2, steps=2500, batch=25
         model = BudgetScratchpadNet(dim=dim, vocab=m, num_steps=K, num_slots=1,
                                     num_heads=heads, num_encoder_layers=enc,
                                     max_seq_len=2 * K, read_tokens=True, rngs=nnx.Rngs(seed))
-    elif arm in ("budget1", "budget2"):
+    elif arm in ("budget1", "budget2", "budget1_local", "budget2_local"):
         model = BudgetScratchpadNet(dim=dim, vocab=m, num_steps=K,
-                                    num_slots=(1 if arm == "budget1" else 2),
+                                    num_slots=(1 if arm.startswith("budget1") else 2),
                                     num_heads=heads, num_encoder_layers=enc,
-                                    max_seq_len=2 * K, read_tokens=False, rngs=nnx.Rngs(seed))
-    elif arm == "unlimited":
+                                    max_seq_len=2 * K, read_tokens=False,
+                                    local_writer=arm.endswith("_local"), rngs=nnx.Rngs(seed))
+    elif arm in ("unlimited", "unlimited_local"):
         model = ScratchpadNet(dim=dim, vocab=m, num_slots=K, num_heads=heads,
                               num_encoder_layers=enc, max_seq_len=2 * K,
-                              serial=True, read_tokens=False, rngs=nnx.Rngs(seed))
+                              serial=True, read_tokens=False,
+                              local_writer=(arm == "unlimited_local"), rngs=nnx.Rngs(seed))
     else:
         model = ScratchpadNet(dim=dim, vocab=m, num_slots=K, num_heads=heads,
                               num_encoder_layers=enc, max_seq_len=2 * K,
@@ -491,7 +539,8 @@ def main():
                     help="any of serial,parallel,depthonly,slotsonly (#62),"
                          "finalonly (#67),annealed (#73),densedepth,"
                          "densedepth_tied (#79),overwrite,budget1,budget2,"
-                         "unlimited (#63); annealed takes an"
+                         "unlimited (#63),budget1_local,budget2_local,"
+                         "unlimited_local (#116); annealed takes an"
                          " optional onset and floor (#95), e.g. annealed@0.2"
                          " or annealed@0.4f0.1")
     ap.add_argument("--seeds", default="0,1,2")

--- a/tests/test_scratchpad_harness.py
+++ b/tests/test_scratchpad_harness.py
@@ -13,8 +13,8 @@ import pytest
 from flax import nnx
 
 from scratchpad_harness import (BudgetScratchpadNet, ScratchpadNet, affine_chain_task,
-                                arm_losses, final_target, grade_lambda, n_params,
-                                parse_arm_spec, train_one_arm)
+                                arm_losses, encode_links, final_target, grade_lambda,
+                                n_params, parse_arm_spec, train_one_arm)
 
 K, M, DIM = 3, 7, 32
 
@@ -355,8 +355,9 @@ def test_recall_arms_scored_against_their_trained_target():
 
 
 def test_budget_arms_train_and_beat_nothing_burns():
-    """#63: full train/eval path for the four new arms at toy size."""
-    for arm in ("overwrite", "budget1", "budget2", "unlimited"):
+    """#63/#116: full train/eval path for the budget and local-writer arms."""
+    for arm in ("overwrite", "budget1", "budget2", "unlimited",
+                "budget1_local", "budget2_local", "unlimited_local"):
         r = train_one_arm(arm, K=K, m=M, dim=DIM, steps=40,
                           batch=64, n_pool=512, n_test=128, seed=0)
         acc = r["final_acc"]
@@ -364,3 +365,72 @@ def test_budget_arms_train_and_beat_nothing_burns():
         assert r["params"] > 0
         for accs in (r["slot_acc"], r["cut_slot_acc"]):
             assert len(accs) == K and all(np.isfinite(a) for a in accs)
+
+
+def test_local_writer_encoding_isolates_links():
+    """#116 leak guard, half 1: with per-link encoding, link k's encoded states
+    must be bit-identical no matter what the OTHER links contain — there is no
+    attention path between links. (Half 2 — that write k consumes only link
+    k's states — is a one-line concat in the model, guarded by the gradient
+    test below.) The #114 leak was exactly this: a full-sequence causal
+    encoder let position 2K-1 carry link 1, so 'local context' by position
+    masking alone would still smuggle."""
+    task = affine_chain_task(K, M)
+    tok_a, _ = task(jax.random.PRNGKey(0), 16)
+    tok_b, _ = task(jax.random.PRNGKey(1), 16)
+    link = 1
+    tok_b = tok_b.at[:, 2 * link:2 * link + 2].set(tok_a[:, 2 * link:2 * link + 2])
+
+    model = BudgetScratchpadNet(dim=DIM, vocab=M, num_steps=K, num_slots=1,
+                                max_seq_len=2 * K, read_tokens=False,
+                                local_writer=True, rngs=nnx.Rngs(0))
+    h_a = encode_links(model.embed, model.encoder, tok_a, per_link=True)
+    h_b = encode_links(model.embed, model.encoder, tok_b, per_link=True)
+    np.testing.assert_array_equal(np.asarray(h_a[:, link]), np.asarray(h_b[:, link]))
+    assert not np.array_equal(np.asarray(h_a), np.asarray(h_b)), \
+        "sanity: the other links do differ"
+
+
+def test_local_writer_first_link_reaches_answer_only_through_memory():
+    """#116 leak guard, half 2: the gradient of the final answer w.r.t. link
+    1's ENCODED states must flow only through the memory chain. Cut the chain
+    — stop-gradient the memory after write 1 — and link 1's gradient must be
+    exactly zero; leave it intact and it must be nonzero. Under the #114
+    full-sequence writer this gradient survives the cut (the last write reads
+    link 1 directly), which is the leak."""
+    model = BudgetScratchpadNet(dim=DIM, vocab=M, num_steps=K, num_slots=1,
+                                max_seq_len=2 * K, read_tokens=False,
+                                local_writer=True, rngs=nnx.Rngs(0))
+    tokens, _ = affine_chain_task(K, M)(jax.random.PRNGKey(2), 8)
+
+    def answer_sum(h, cut_after_first):
+        bsz = tokens.shape[0]
+        memory = jnp.broadcast_to(model.mem_init[...].astype(h.dtype),
+                                  (bsz, model.num_slots, h.shape[-1]))
+        for k in range(K):
+            q_k = jnp.broadcast_to(model.step_index(jnp.array([k]))[None, :, :],
+                                   (bsz, 1, h.shape[-1]))
+            v_k = model.write_block(q_k, jnp.concatenate([h[:, k], memory], axis=1))
+            addr_in = jnp.concatenate([q_k[:, 0], memory.mean(axis=1)], axis=-1)
+            addr = jax.nn.softmax(model.addr_head(addr_in), axis=-1)
+            memory = (1 - addr[:, :, None]) * memory + addr[:, :, None] * v_k
+            if k == 0 and cut_after_first:
+                memory = jax.lax.stop_gradient(memory)
+        return jnp.sum(model.readout(h[:, -1], memory))
+
+    h = encode_links(model.embed, model.encoder, tokens, per_link=True)
+    g_cut = jax.grad(answer_sum)(h, cut_after_first=True)
+    g_open = jax.grad(answer_sum)(h, cut_after_first=False)
+    assert float(jnp.abs(g_cut[:, 0]).max()) == 0.0, \
+        "link 1 must be unreachable except through memory"
+    assert float(jnp.abs(g_open[:, 0]).max()) > 0.0, \
+        "sanity: through memory, link 1 does reach the answer"
+
+
+def test_local_arms_share_target_with_their_full_context_twins():
+    """#116: the _local arms train and score on the same recall target as
+    their #63 twins — the writer context is the ONLY variable."""
+    _, subs = affine_chain_task(K, M)(jax.random.PRNGKey(3), 32)
+    recall = np.asarray((subs[:, 0] + subs[:, -1]) % M)
+    for arm in ("budget1_local", "budget2_local", "unlimited_local"):
+        np.testing.assert_array_equal(np.asarray(final_target(arm, subs, M)), recall)


### PR DESCRIPTION
The finale of the #63 phase-2 arc, after two invalid attempts (eval-target bug → PR #76; writer side channel → #114/#115).

## Code
`local_writer` mode for both scratchpad classes: each (a_k, b_k) link is encoded as its own independent 2-token sequence, and write k's context is link k + current memory ONLY — the only cross-step channel is memory. Three new arms (`budget1_local`, `budget2_local`, `unlimited_local`) mirror the #63 recall arms with writer context as the single variable. Two leak-guard tests pin the closure architecturally (per-link encoding invariance; zero gradient from answer to link 1 when the memory chain is cut).

## Result (pre-registered on #116, bars amended BEFORE the run)

| arm | memory | s0 | s1 | s2 | mean |
|---|---|---|---|---|---|
| unlimited_local (ceiling) | 5 slots | 0.9995 | 1.0000 | 1.0000 | 0.9998 |
| budget2_local (bet) | **2 slots / 5 writes** | 1.0000 | 1.0000 | 1.0000 | **1.0000** |
| budget1_local (control) | 1 slot / 5 writes | 0.8740 | 0.1548 | 0.1460 | 0.3916 |

Win bar (≥2σ_pooled over control, approach ceiling): +0.608 = **2.06σ**, and budget2 *equals* the ceiling, σ=0. Addressing probe (bit-exact seed-0 replay): write 1 → slot 1 (0.604), writes 2–5 → slot 0 (~0.995) — textbook parking, learned from capacity pressure + final-answer loss alone, no forget gate, no retention bonus.

Also: the #114 budget2 seed instability (0.14–0.97) vanishes with the leak closed (σ=0.0000), and the ceiling result pins the #114 locus question — the readout retrieves two slots and combines them.

**Novelty verdict:** novel — a learned keep-vs-evict addressing policy emerging from capacity pressure alone on this harness, plus the slot-parking-vs-in-vector-carry contrast (the bits matter where the gradient can find them, not where they'd fit), is not something the literature settles at this exact question; finding recorded per rule 5.

Full CPU suite green (all tests incl. the two new guards), ruff clean.

Closes #116

🤖 Generated with [Claude Code](https://claude.com/claude-code)