### PR TITLE
Keep RotaryAttention's additive mask bias f32 (#99)

### DIFF
--- a/layers.py
+++ b/layers.py
@@ -96,7 +96,11 @@ class RotaryAttention(nnx.Module):
         v = v.astype(COMPUTE_DTYPE)
 
         if mask is not None and mask.dtype != jnp.bool_:
-            attn_bias = mask.astype(COMPUTE_DTYPE)
+            # Bias stays f32 (#99, same hazard as #84): the -1e9 mask entries
+            # overflow to -inf under an f16 cast, and a fully-masked row's
+            # softmax then yields NaN. dot_product_attention adds the bias to
+            # f32 logits (QK accumulates in f32), so the cast bought nothing.
+            attn_bias = mask.astype(jnp.float32)
             mask_arg = None
         else:
             attn_bias = None

--- a/tests/test_mask_bias_finite.py
+++ b/tests/test_mask_bias_finite.py
@@ -18,6 +18,8 @@ import numpy as np
 import pytest
 from flax import nnx
 
+import layers
+from layers import RotaryAttention
 from plan_a_model import CausalAttention, CausalRefiner
 
 
@@ -48,3 +50,35 @@ def test_refiner_leading_pad_stays_finite_in_f16(chunked):
 
     logits = np.asarray(model(tokens, depth=2, pad_mask=pad_mask))
     assert np.isfinite(logits).all(), "non-finite logits from a leading-pad batch in f16"
+
+
+def test_rotary_attention_additive_mask_stays_finite_in_f16(monkeypatch):
+    """#99: the reasoner path's RotaryAttention has the same hazard — its
+    additive float masks carry -1e9 entries (slot masks, model.py constants),
+    and the pre-fix cast to COMPUTE_DTYPE overflowed them to -inf in f16.
+    COMPUTE_DTYPE is read at call time, so patching it forces the production
+    f16 path on the CPU lane too; batch element 1 masks every key, giving
+    genuinely fully-masked rows."""
+    monkeypatch.setattr(layers, "COMPUTE_DTYPE", jnp.float16)
+    attn = RotaryAttention(4, 32, num_groups=4, rngs=nnx.Rngs(0))
+    x = jnp.asarray(np.random.default_rng(2).normal(size=(2, 8, 32)), jnp.float32)
+    additive_mask = jnp.zeros((2, 1, 8, 8), jnp.float32).at[1].add(-1e9)
+
+    out = np.asarray(attn(x, mask=additive_mask))
+    assert np.isfinite(out).all(), \
+        "non-finite RotaryAttention output on fully-masked rows (additive-bias branch)"
+
+
+def test_rotary_attention_boolean_mask_stays_finite_in_f16(monkeypatch):
+    """Contrast branch: a fully-masked BOOLEAN row goes through
+    dot_product_attention's mask argument, whose masked path uses its own
+    finite large-negative constant — pinned here so the two branches' contracts
+    stay documented together."""
+    monkeypatch.setattr(layers, "COMPUTE_DTYPE", jnp.float16)
+    attn = RotaryAttention(4, 32, num_groups=4, rngs=nnx.Rngs(0))
+    x = jnp.asarray(np.random.default_rng(3).normal(size=(2, 8, 32)), jnp.float32)
+    bool_mask = jnp.ones((2, 1, 8, 8), bool).at[1].set(False)
+
+    out = np.asarray(attn(x, mask=bool_mask))
+    assert np.isfinite(out).all(), \
+        "non-finite RotaryAttention output on fully-masked rows (boolean-mask branch)"


### PR DESCRIPTION
The reasoner-path twin of PR #98: `layers.py` cast the additive mask (with its −1e9 entries) to COMPUTE_DTYPE, which in f16 overflows to −inf — any fully-masked row then softmaxes to NaN. Fix keeps the bias f32 into `dot_product_attention` (which adds it to f32 logits anyway, so the tensor-core path is untouched; the f32 CPU lane is a bitwise no-op — goldens unaffected).

Matters now because the reasoner is the vanilla control that #16 launches **first** for ~9 GPU-hours.

Tests: patch call-time COMPUTE_DTYPE to f16 so the production path runs on the CPU lane; the additive-bias test **reproduces the NaN on unfixed code** (verified by stash/run/pop) and must stay finite; the boolean-mask branch pinned for contrast. Full CPU suite green, ruff clean.

Per the issue, the GPU tail (one `RUN_TESTS_ON_GPU=1` pass, same shape as #84's) can ride along whenever the card next runs the suite — the CPU-side monkeypatch already exercises the identical f16 numerics.

Closes #99

🤖 Generated with [Claude Code](https://claude.com/claude-code)