### PR TITLE
Reject unknown MODEL_ARCH at launch (#104)

### DIFF
--- a/config.py
+++ b/config.py
@@ -49,6 +49,14 @@ NUM_GROUPS = NUM_HEADS // 4
 # The two arches have different param trees, so a checkpoint from one cannot be
 # resumed by the other — resuming an old reasoner run now requires the env var.
 MODEL_ARCH = os.environ.get("MODEL_ARCH", "refiner")
+_KNOWN_ARCHES = ("refiner", "reasoner")
+if MODEL_ARCH not in _KNOWN_ARCHES:
+    # Fail closed at import (#104): the selector otherwise falls through to a
+    # default, so a typo would silently train the wrong architecture for the
+    # whole run — the one failure mode a launch banner does not reliably catch.
+    raise SystemExit(
+        f"MODEL_ARCH={MODEL_ARCH!r} is not a known architecture; "
+        f"use one of {', '.join(_KNOWN_ARCHES)} (unset defaults to 'refiner')")
 # Blockwise memory-lean attention for the refiner (#66): removes the O(seq²)
 # score/probability transients that dominate the grad-step peak (mem_profile).
 # Opt-in until the dim960 GPU fit-test + wall-clock bench pass on the box;

--- a/tests/test_arch_guard.py
+++ b/tests/test_arch_guard.py
@@ -1,0 +1,33 @@
+"""MODEL_ARCH must fail closed (#104): the selector's fallthrough default means
+a typo would silently train the wrong architecture for a whole run — on the
+base run, ~9 GPU-hours discovered late or never. Import-time validation turns
+that into an immediate, explicit launch failure.
+
+Subprocess-based: config validates at import, and this process has long since
+imported it, so each case gets a fresh interpreter.
+"""
+
+import os
+import subprocess
+import sys
+
+def _import_config_with(arch):
+    env = {**os.environ, "JAX_PLATFORMS": "cpu"}
+    if arch is None:
+        env.pop("MODEL_ARCH", None)
+    else:
+        env["MODEL_ARCH"] = arch
+    return subprocess.run([sys.executable, "-c", "import config"],
+                          env=env, capture_output=True, text=True)
+
+def test_unknown_model_arch_fails_closed_before_anything_builds():
+    r = _import_config_with("refnier")
+    assert r.returncode != 0, "a typo'd MODEL_ARCH must refuse to start"
+    assert "refnier" in r.stderr, "the error must echo the bad value"
+    assert "refiner" in r.stderr and "reasoner" in r.stderr, \
+        "the error must list the valid names"
+
+def test_known_arches_and_unset_default_still_launch():
+    for arch in ("refiner", "reasoner", None):
+        r = _import_config_with(arch)
+        assert r.returncode == 0, f"MODEL_ARCH={arch!r} must be accepted: {r.stderr}"


### PR DESCRIPTION
A typo in `MODEL_ARCH` currently fails open — the selector quietly falls through to the default and trains the wrong architecture for the whole run; on the #16 base run that's ~9 GPU-hours of the wrong model, discovered late or never (the vanilla-control launch is exactly the moment the env var must be typed by hand).

Fix: validate at the point of read (`config.py`) — an unknown value exits immediately, echoing the bad value and listing the valid names. Both valid names and the unset default (`refiner`) are pinned by subprocess tests (the issue text's "defaults to reasoner" predates #88's default flip; the guard pins the post-#88 truth).

Closes #104

🤖 Generated with [Claude Code](https://claude.com/claude-code)