### PR TITLE
Trajectory-visible halting collapses anyway (#123): the incentive is the pathology, not the observability

### DIFF
--- a/docs/findings/2026-07-19-trajectory-visible-halting-collapses-incentive-not-observability.md
+++ b/docs/findings/2026-07-19-trajectory-visible-halting-collapses-incentive-not-observability.md
@@ -1,0 +1,96 @@
+# Letting the halting head reread the model's whole thought trajectory does not prevent ACT-style collapse — on a validated-solvable task, halting slams to minimum depth with or without visibility, pinning the graveyard failure on the incentive, not the observability
+
+Status: confirmed (negative — bar 3 of the pre-registration)
+Date: 2026-07-19
+Commit: 9071ae9 (claude/123-trajectory-halting — HaltingScratchpadNet + variable_chain_task)
+Run: tiny-config ablation (synthetic, no runs/ id)
+Measured with: `JAX_PLATFORMS=cpu python scratchpad_harness.py --arms halt_off,halt_state,halt_traj --seeds 0,1,2 --K 4 --steps 10000` (log `aux_123_retry.log`; ceiling-validation diagnostics in `aux_123_protocol.log` / `aux_123_diag*.log`) (#123)
+
+## Setup
+
+Hypothesis (#123): thinking-token models can judge "have I thought enough"
+because their past thinking is visible to attention; the graveyard's ACT
+collapse (learned halting → minimum depth, surviving reward shaping) was
+measured with a halting decision blind to everything but the current state.
+Two live autopsies — observability (the head couldn't see the evidence) vs
+incentive (the gradient prefers quitting regardless) — separated here for the
+first time.
+
+Design: halting as a READOUT choice on the serial scratchpad — all K writes
+always run (grades on, #67), a per-step answer is read from slots 1..k, and
+p = softmax(halt logits) weights the per-step answer CE plus a ponder cost
+λ_p·E[halt step] (λ_p = 0.2, pre-registered). Min-depth collapse is
+expressible but never architecturally forced. One variable, identical param
+tree: `halt_traj`'s halt query cross-attends slots 1..k (can reread the
+trajectory); `halt_state`'s sees slot k alone (the graveyard configuration).
+`halt_off` (read out at K, no halting) is the rule-4 ceiling.
+
+Task: variable-length affine chain, k_eff ~ U{1..K} real links then
+recognizable pad links, sub-targets stationary after the chain ends — "done"
+is detectable as the state no longer changing, and non-degenerate halting has
+k_eff to track. First attempt at K=6/2500 steps FAILED its validity gate
+(ceiling 0.46) — recorded on the issue; ceiling-first diagnostics found
+K=4/10000 steps solvable (0.999) and the comparison was re-pre-registered
+there before any arm ran.
+
+## Evidence
+
+K=4, m=7, dim 64, 10000 steps, 3 seeds (chance = 1/7 ≈ 0.143; random halting
+would put p(halt@1) ≈ 0.25 and corr ≈ 0):
+
+| arm | full-depth acc | halted acc | corr(halt step, k_eff) | p(halt@1) | mean halt step |
+|---|---|---|---|---|---|
+| halt_off (ceiling) | 0.9990 / 0.9915 / 0.9985 (**0.996**) | — | — | — | — |
+| halt_state | 0.670 / 0.675 / 0.630 (**0.658**) | 0.665 | +0.03 / +0.10 / +0.03 (**0.05**) | 0.999 / 0.980 / 0.982 | 1.00–1.04 |
+| halt_traj | 0.481 / 0.629 / 0.620 (**0.577**) | 0.663 | +0.02 / +0.02 / +0.01 (**0.02**) | 0.995 / 0.999 / 0.998 | 1.00–1.02 |
+
+Pre-registered bar 3 fires: `halt_traj` collapses — corr ≈ 0.02 (bar: ≥ 0.8
+to win, < 0.5 = collapse), halt mass ≥ 99.5% on step 1 in every seed,
+statistically indistinguishable from the blind control. Full trajectory
+visibility rescued nothing; there is not even a marginal visibility edge
+(traj 0.02 vs state 0.05 — both zero).
+
+Secondary observation: the halting objective ROTS the surrounding model.
+Both halting arms' full-depth accuracy falls to ~0.58–0.66 on a task their
+halting-free twin solves at 0.996 — with p collapsed onto step 1, the answer
+CE trains almost only the step-1 readout, and later-step competence starves.
+Collapse is not just a wrong halting policy; it degrades the capability it
+was supposed to meter.
+
+## Reading
+
+The graveyard's ACT autopsy is now specific: **the collapse is an incentive
+pathology, not an information one.** "Halt now" pays its ponder-cost savings
+deterministically on every example; "halt later when the chain is longer"
+pays rarely and noisily through the answer CE — the optimizer takes the sure
+thing, even when the evidence for continuing sits fully readable in the halt
+head's attention window, on a task the same parameters demonstrably solve.
+Any future attack on learned halting here must therefore change the payment
+structure (and the graveyard already shows naive reward shaping is not
+enough), not the halting head's inputs. Explicit effort remains the policy;
+the depth dial stays with the caller (#86 made it an open dial).
+
+## Limitations
+
+Toy scale (0.27M params, K=4, one λ_p = 0.2 point, 3 seeds); halting-as-
+readout differs from classic ACT's halting-as-compute-cut, so the mapping to
+the original graveyard entry is by failure signature (min-depth mass, shaping-
+resistant), not identical mechanics. A λ_p sweep was not run (pre-registered
+single point); λ_p → 0 trivially removes collapse but also removes the point
+of halting. corr uses argmax-halt vs k_eff on held-out data.
+
+## Relation to prior work
+
+- Sharpens the graveyard candidate finding (ACT collapses at small scale,
+  survives reward shaping) from "it fails" to "it fails FOR the incentive
+  reason": the observability alternative is now measured and dead.
+- Components are standard (ACT/PonderNet halting; memory slots) — the
+  contribution is the matched-pair separation of observability vs incentive
+  as the collapse cause, with the halting context as the single variable on
+  a validated-solvable task. Not found in the literature: recorded as novel
+  per rule 5 (uncertain → novel). A novel negative is exactly the moat.
+- Sibling: #39 (cosine convergence halting) proposes NON-learned halting —
+  a rule on state movement, no gradient economics — and is untouched by this
+  result; if anything, "done = state stops changing" being detectable here
+  (the task's stationarity is trivially visible in the slots) makes the
+  rule-based sibling more attractive than the learned version.

--- a/docs/findings/README.md
+++ b/docs/findings/README.md
@@ -29,6 +29,7 @@ things, it doesn't go in this folder.
 - `2026-07-16-budget-scratchpad-recall-rerun-readout-fine-writer-leaks.md` — #114: corrected-eval rerun of #63 phase 2 — the readout combines two values at 0.99 (old diagnosis dead), but the token-visible writer leaks the answer past the S=1 control, so retention is still untested
 - `2026-07-18-budget-scratchpad-retention-win-slot-parking.md` — #116: retention under capacity pressure is real — leak closed, 2 slots for 5 writes hits 1.0000 on every seed by parking r_1 (~99.5% of later writes routed away from it), while the 1-slot in-vector carry trains unreliably
 - `2026-07-18-sinusoidal-time-signal-depth-extrapolates.md` — #86: sinusoidal step signal matches the learned table at trained depths (2σ parity) and converts never-trained loops 9–16 into +0.11 accuracy under length shift, where the clamped table collapses to chance with NaN loss — depth becomes an open dial
+- `2026-07-19-trajectory-visible-halting-collapses-incentive-not-observability.md` — #123: letting the halting head reread the whole thought trajectory does NOT prevent ACT-style collapse (99.5%+ mass on step 1, corr ≈ 0, every seed, solvable task) — the graveyard failure is an incentive pathology, not an observability one; halting pressure also rots full-depth competence 0.996 → ~0.6
 
 ## Entry template
 

--- a/scratchpad_harness.py
+++ b/scratchpad_harness.py
@@ -97,6 +97,32 @@ def affine_chain_task(K, m):
     return fn
 
 
+def variable_chain_task(K, m):
+    """Variable-length affine chain (#123): k_eff ~ U{1..K} real links, then
+    recognizable pad links (a = b = 0; real links always have a >= 1). The
+    sub-target is STATIONARY after the chain ends — r stays r_{k_eff} through
+    the pad links — so 'done' is detectable as the state no longer changing,
+    and the final answer is sub[:, -1] = r_{k_eff}. Returns (tokens, subs,
+    k_eff) so halting evals can correlate the halt step with the true length."""
+    def fn(key, batch):
+        ka, kb, kk = jax.random.split(key, 3)
+        a = jax.random.randint(ka, (batch, K), 1, m)
+        b = jax.random.randint(kb, (batch, K), 0, m)
+        k_eff = jax.random.randint(kk, (batch,), 1, K + 1)
+        live = jnp.arange(K)[None, :] < k_eff[:, None]
+        a = jnp.where(live, a, 0)
+        b = jnp.where(live, b, 0)
+        tokens = jnp.stack([a, b], axis=-1).reshape(batch, 2 * K)
+
+        def step(r, ab):
+            r_new = jnp.where(ab[:, 0] > 0, (r * ab[:, 0] + ab[:, 1]) % m, r)
+            return r_new, r_new
+        _, subs = jax.lax.scan(step, jnp.zeros(batch, jnp.int32),
+                               jnp.stack([a.T, b.T], axis=-1).astype(jnp.int32))
+        return tokens.astype(jnp.int32), subs.T, k_eff.astype(jnp.int32)
+    return fn
+
+
 class CrossBlock(nnx.Module):
     """Pre-norm cross-attention + SwiGLU: queries read a separate context. No
     positional encoding on the queries — slot identity comes from the caller's
@@ -347,6 +373,69 @@ class DenseDepthNet(nnx.Module):
         return answer_logits, step_logits
 
 
+class HaltingScratchpadNet(nnx.Module):
+    """#123: serial scratchpad + a halting head scoring 'stop after write k'.
+
+    Halting is a READOUT choice, not a compute cut: all K writes always run
+    (the per-slot grade stays on, #67), a per-step answer is read from slots
+    1..k after each write, and p = softmax(halt_logits) weights those answers
+    in the loss — so min-depth collapse is expressible but never
+    architecturally forced. halt_context is THE one variable:
+
+      "trajectory" — the halt query cross-attends slots 1..k: the decision can
+                     reread the model's own thinking, the way thinking-token
+                     models can (the issue's hypothesis).
+      "current"    — the SAME head, context = slot k alone: the decision sees
+                     only the latest state — the graveyard-ACT configuration.
+
+    Identical parameter tree either way; only the context width differs.
+    The answer readout is slots-only (#62 wiring), so answers can only come
+    from memory."""
+
+    def __init__(self, *, dim, vocab, num_slots, num_heads=4, num_encoder_layers=2,
+                 max_seq_len=64, halt_context="trajectory", rngs, dtype=jnp.float32):
+        assert halt_context in ("trajectory", "current"), f"unknown halt_context {halt_context!r}"
+        self.num_slots = num_slots
+        self.halt_context = halt_context
+        self.embed = nnx.Embed(vocab, dim, rngs=rngs, dtype=dtype)
+        self.encoder = nnx.List([
+            Block(dim, num_heads, max_seq_len, rngs, dtype) for _ in range(num_encoder_layers)
+        ])
+        self.write_block = CrossBlock(dim, num_heads, rngs, dtype)   # shared across k
+        self.slot_index = nnx.Embed(num_slots, dim, rngs=rngs, dtype=dtype)
+        self.slot_readout = nnx.Linear(dim, vocab, rngs=rngs, dtype=dtype)  # the grade head
+        self.read_block = CrossBlock(dim, num_heads, rngs, dtype)
+        self.answer_query = nnx.Param(
+            jax.nn.initializers.normal(0.02)(rngs(), (1, 1, dim), jnp.float32))
+        self.answer_head = nnx.Linear(dim, vocab, rngs=rngs, dtype=dtype)
+        self.halt_block = CrossBlock(dim, num_heads, rngs, dtype)
+        self.halt_query = nnx.Param(
+            jax.nn.initializers.normal(0.02)(rngs(), (1, 1, dim), jnp.float32))
+        self.halt_head = nnx.Linear(dim, 1, rngs=rngs, dtype=dtype)
+
+    def __call__(self, tokens):
+        h = self.embed(tokens)
+        for blk in self.encoder:
+            h = blk(h)
+        bsz = tokens.shape[0]
+        queries = jnp.broadcast_to(self.slot_index(jnp.arange(self.num_slots))[None, :, :],
+                                   (bsz, self.num_slots, h.shape[-1]))
+        aq = jnp.broadcast_to(self.answer_query[...].astype(h.dtype), (bsz, 1, h.shape[-1]))
+        hq = jnp.broadcast_to(self.halt_query[...].astype(h.dtype), (bsz, 1, h.shape[-1]))
+
+        slots, answers, halts = [], [], []
+        for k in range(self.num_slots):
+            ctx = jnp.concatenate([h] + slots, axis=1) if slots else h
+            slots.append(self.write_block(queries[:, k:k + 1], ctx))    # written once
+            bank = jnp.concatenate(slots, axis=1)                       # slots 1..k
+            answers.append(self.answer_head(self.read_block(aq, bank))[:, 0])
+            halt_ctx = bank if self.halt_context == "trajectory" else slots[-1]
+            halts.append(self.halt_head(self.halt_block(hq, halt_ctx))[:, 0, 0])
+
+        slot_logits = self.slot_readout(jnp.concatenate(slots, axis=1))  # [B, K, m]
+        return jnp.stack(answers, 1), slot_logits, jnp.stack(halts, 1)   # [B,K,m], [B,K,m], [B,K]
+
+
 def n_params(model):
     return sum(int(x.size) for x in jax.tree_util.tree_leaves(nnx.state(model, nnx.Param)))
 
@@ -533,6 +622,84 @@ def train_one_arm(arm, *, K=4, m=7, dim=64, heads=4, enc=2, steps=2500, batch=25
     }
 
 
+# #123: the halting arms run the variable-length chain. halt_traj vs
+# halt_state is the observability comparison; halt_off is the rule-4 ceiling
+# (read out at K, halting head untrained).
+HALT_ARMS = ("halt_traj", "halt_state", "halt_off")
+
+
+def train_one_halt_arm(arm, *, K=6, m=7, dim=64, heads=4, enc=2, steps=2500,
+                       batch=256, lr=2e-3, wd=0.01, seed=0, lam_slot=1.0,
+                       lam_ponder=0.2, n_pool=32768, n_test=4096):
+    assert arm in HALT_ARMS, f"unknown halt arm {arm!r}"
+    task = variable_chain_task(K, m)
+    key = jax.random.PRNGKey(seed)
+    key, dk_tr, dk_te = jax.random.split(key, 3)
+    tr_tok, tr_sub, _ = task(dk_tr, n_pool)
+    te_tok, te_sub, te_keff = task(dk_te, n_test)
+
+    model = HaltingScratchpadNet(
+        dim=dim, vocab=m, num_slots=K, num_heads=heads, num_encoder_layers=enc,
+        max_seq_len=2 * K,
+        halt_context=("current" if arm == "halt_state" else "trajectory"),
+        rngs=nnx.Rngs(seed))
+    opt = nnx.Optimizer(model, optax.adamw(lr, weight_decay=wd), wrt=nnx.Param)
+    step_frac = (jnp.arange(K, dtype=jnp.float32) + 1.0) / K   # ponder cost per halt step
+
+    def halt_losses(mdl, tok, sub):
+        answers, slot_logits, halt_logits = mdl(tok)
+        target = sub[:, -1]                                    # r_{k_eff} (stationary tail)
+        ce_k = optax.softmax_cross_entropy_with_integer_labels(
+            answers, jnp.broadcast_to(target[:, None], target.shape + (K,)))   # [B, K]
+        ce_slots = optax.softmax_cross_entropy_with_integer_labels(slot_logits, sub).mean()
+        if arm == "halt_off":
+            # Ceiling: full-depth readout, no halting pressure. The halting
+            # head's outputs are unused, so its params receive no gradient.
+            return ce_k[:, -1].mean() + lam_slot * ce_slots, (answers, halt_logits)
+        p = jax.nn.softmax(halt_logits, axis=-1)               # [B, K]
+        ce_halted = (p * ce_k).sum(-1).mean()
+        ponder = (p * step_frac[None, :]).sum(-1).mean()
+        return ce_halted + lam_slot * ce_slots + lam_ponder * ponder, (answers, halt_logits)
+
+    @nnx.jit
+    def step(mdl, op, k):
+        idx = jax.random.randint(k, (batch,), 0, tr_tok.shape[0])
+        def loss_fn(mm):
+            loss, _ = halt_losses(mm, tr_tok[idx], tr_sub[idx])
+            return loss
+        loss, grads = nnx.value_and_grad(loss_fn)(mdl)
+        op.update(mdl, grads)
+        return loss
+
+    @nnx.jit
+    def eval_all(mdl):
+        answers, slot_logits, halt_logits = mdl(te_tok)
+        target = te_sub[:, -1]
+        halt_step = halt_logits.argmax(-1)                     # [B], 0-indexed
+        halted_pred = jnp.take_along_axis(
+            answers.argmax(-1), halt_step[:, None], axis=1)[:, 0]
+        full_acc = jnp.mean(answers[:, -1].argmax(-1) == target)
+        halted_acc = jnp.mean(halted_pred == target)
+        # Pearson correlation between the chosen halt step and the true length.
+        hs = halt_step.astype(jnp.float32) + 1.0
+        ke = te_keff.astype(jnp.float32)
+        hs_c, ke_c = hs - hs.mean(), ke - ke.mean()
+        corr = (hs_c * ke_c).mean() / jnp.sqrt((hs_c**2).mean() * (ke_c**2).mean() + 1e-12)
+        p = jax.nn.softmax(halt_logits, axis=-1)
+        return full_acc, halted_acc, corr, p[:, 0].mean(), hs.mean()
+
+    for i in range(steps):
+        key, k = jax.random.split(key)
+        step(model, opt, k)
+
+    full_acc, halted_acc, corr, p1, mean_halt = eval_all(model)
+    return {
+        "full_acc": float(full_acc), "halted_acc": float(halted_acc),
+        "corr": float(corr), "p1_mass": float(p1), "mean_halt": float(mean_halt),
+        "params": n_params(model),
+    }
+
+
 def main():
     ap = argparse.ArgumentParser()
     ap.add_argument("--arms", default="serial,parallel,depthonly",
@@ -540,7 +707,8 @@ def main():
                          "finalonly (#67),annealed (#73),densedepth,"
                          "densedepth_tied (#79),overwrite,budget1,budget2,"
                          "unlimited (#63),budget1_local,budget2_local,"
-                         "unlimited_local (#116); annealed takes an"
+                         "unlimited_local (#116),halt_traj,halt_state,"
+                         "halt_off (#123); annealed takes an"
                          " optional onset and floor (#95), e.g. annealed@0.2"
                          " or annealed@0.4f0.1")
     ap.add_argument("--seeds", default="0,1,2")
@@ -561,6 +729,14 @@ def main():
         arm, anneal_kw = parse_arm_spec(spec)
         for seed in [int(s) for s in args.seeds.split(",")]:
             t0 = time.time()
+            if arm in HALT_ARMS:
+                r = train_one_halt_arm(arm, K=args.K, m=args.m,
+                                       dim=args.dim, steps=args.steps, seed=seed)
+                print(f"{spec:>16} {seed:>5} {r['params']/1e6:>8.2f}M "
+                      f"full={r['full_acc']:.4f} halted={r['halted_acc']:.4f} "
+                      f"corr={r['corr']:+.3f} p1={r['p1_mass']:.3f} "
+                      f"mean_halt={r['mean_halt']:.2f} {time.time()-t0:>7.1f}s", flush=True)
+                continue
             r = train_one_arm(arm, K=args.K, m=args.m,
                               dim=args.dim, steps=args.steps, seed=seed, **anneal_kw)
             print(f"{spec:>16} {seed:>5} {r['params']/1e6:>8.2f}M {r['cut_step']:>5} "

--- a/tests/test_scratchpad_harness.py
+++ b/tests/test_scratchpad_harness.py
@@ -434,3 +434,44 @@ def test_local_arms_share_target_with_their_full_context_twins():
     recall = np.asarray((subs[:, 0] + subs[:, -1]) % M)
     for arm in ("budget1_local", "budget2_local", "unlimited_local"):
         np.testing.assert_array_equal(np.asarray(final_target(arm, subs, M)), recall)
+
+
+def test_variable_chain_task_stationary_after_k_eff():
+    """#123: pad links are (0,0), sub-targets freeze at r_{k_eff} through the
+    pads, and the final sub IS r_{k_eff} — 'done' must be detectable as the
+    state no longer changing, or halting has nothing to track."""
+    from scratchpad_harness import variable_chain_task
+    tokens, subs, k_eff = variable_chain_task(6, M)(jax.random.PRNGKey(7), 256)
+    a = np.asarray(tokens)[:, 0::2]
+    subs, k_eff = np.asarray(subs), np.asarray(k_eff)
+    for i in range(256):
+        assert (a[i, :k_eff[i]] >= 1).all(), "real links must have a >= 1"
+        assert (a[i, k_eff[i]:] == 0).all(), "pad links must have a == 0"
+        assert (subs[i, k_eff[i] - 1:] == subs[i, k_eff[i] - 1]).all(), \
+            "sub-targets must be stationary after the chain ends"
+    assert (subs[:, -1] == subs[np.arange(256), k_eff - 1]).all()
+    assert set(np.unique(k_eff)) == set(range(1, 7)), "k_eff should span 1..K"
+
+
+def test_halt_arms_share_param_tree_and_smoke_train():
+    """#123: trajectory vs current halt context must be the SAME parameters
+    (one-variable ablation — only the halt head's context width differs), and
+    all three arms must train end-to-end at toy size with finite metrics."""
+    from scratchpad_harness import HaltingScratchpadNet, train_one_halt_arm
+
+    def shapes(net):
+        return jax.tree_util.tree_map(lambda x: x.shape, nnx.state(net, nnx.Param))
+
+    traj = HaltingScratchpadNet(dim=DIM, vocab=M, num_slots=4,
+                                halt_context="trajectory", rngs=nnx.Rngs(0))
+    curr = HaltingScratchpadNet(dim=DIM, vocab=M, num_slots=4,
+                                halt_context="current", rngs=nnx.Rngs(0))
+    assert shapes(traj) == shapes(curr), "halt arms must share one param tree"
+
+    for arm in ("halt_traj", "halt_state", "halt_off"):
+        r = train_one_halt_arm(arm, K=4, m=M, dim=DIM, steps=40,
+                               batch=64, n_pool=512, n_test=128, seed=0)
+        for key in ("full_acc", "halted_acc", "corr", "p1_mass", "mean_halt"):
+            assert np.isfinite(r[key]), f"{arm}: non-finite {key}"
+        assert 0.0 <= r["full_acc"] <= 1.0 and 0.0 <= r["halted_acc"] <= 1.0
+        assert 1.0 <= r["mean_halt"] <= 4.0, f"{arm}: halt step outside 1..K"


### PR DESCRIPTION
The #123 experiment, run to its pre-registered verdict — **bar 3, the clean negative**.

## What was asked
The graveyard says learned halting (ACT) collapses to minimum depth and reward shaping doesn't save it. Two live autopsies: the halting head **can't see** the evidence for continuing (observability — the issue's hypothesis, by analogy to thinking-token models rereading their chain of thought), or the gradient **prefers quitting** regardless (incentive). Nobody had separated them.

## How
Halting as a readout choice on the serial scratchpad (all K writes always run; collapse expressible, never forced), identical param tree, ONE variable: `halt_traj`'s halt query cross-attends slots 1..k; `halt_state`'s sees slot k alone. `halt_off` = rule-4 ceiling. First attempt failed its validity gate (ceiling 0.46 at K=6/2500) and was stopped per pre-registration; ceiling-first diagnostics found K=4/10000 solvable (0.999) and the comparison was re-pre-registered there before any arm ran.

## Result (3 seeds)

| arm | full acc | corr(halt, k_eff) | p(halt@1) |
|---|---|---|---|
| halt_off | **0.996** | — | — |
| halt_state | 0.658 | 0.05 | 0.98–1.00 |
| halt_traj | 0.577 | **0.02** | **0.995–0.999** |

Full trajectory visibility rescued nothing — indistinguishable from blind. Bonus finding: halting pressure rots the model around it (0.996 → ~0.6 full-depth), since the collapsed p trains only the step-1 readout.

**Autopsy now reads: incentive pathology.** Future halting attacks must change the payment structure, not the head's inputs. Explicit effort stays policy; #39 (rule-based halting) is untouched and arguably strengthened — 'done' IS trivially visible in the slots; it's the learned decision that won't learn.

Finding: `docs/findings/2026-07-19-trajectory-visible-halting-collapses-incentive-not-observability.md` — novel per rule 5 (the matched observability-vs-incentive separation isn't in the literature; a novel negative is exactly the moat).

Closes #123

🤖 Generated with [Claude Code](https://claude.com/claude-code)