### PR TITLE
Fix CI overfit smoke: dim 60 for the 15-head config

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -109,4 +109,6 @@ jobs:
         # labels, target off-by-ones, broken gradient flow, and dead loss terms
         # fail here in minutes. Tiny dim/blocks so it's CPU-fast; the full-scale
         # variant stays a pre-launch GPU check (tools/overfit_smoke.py defaults).
-        run: PYTHONPATH=. python tools/overfit_smoke.py --synthetic --dim 64 --blocks 2 --steps 80
+        # --dim must divide config NUM_HEADS (15 since the dim960 config, #109) with an
+        # even head_dim for RoPE: 60/15 = 4. The old --dim 64 broke on 15 heads.
+        run: PYTHONPATH=. python tools/overfit_smoke.py --synthetic --dim 60 --blocks 2 --steps 80

--- a/tools/overfit_smoke.py
+++ b/tools/overfit_smoke.py
@@ -14,7 +14,7 @@ DATA_ROOT, and --dim/--blocks shrink the model so the whole thing runs in CPU
 minutes. Wrong labels, target off-by-ones, broken gradient flow, and dead loss
 components fail at tiny scale exactly as they would at full scale:
     FORCE_F32_COMPUTE=1 JAX_PLATFORMS=cpu PYTHONPATH=. \
-        python tools/overfit_smoke.py --synthetic --dim 64 --blocks 2 --steps 80
+        python tools/overfit_smoke.py --synthetic --dim 60 --blocks 2 --steps 80
 """
 
 import os


### PR DESCRIPTION
Main's CI has been red since #109 merged: the overfit smoke passes `--dim 64` but `NUM_HEADS=15` comes from config, and 64/15 isn't integral — reshape crash. (#109's PR checks read green from a stale pre-push suite — the same watcher race we hit on #122, in the other direction.)

Fix: `--dim 60` (divides 15, head_dim 4 — even, RoPE-safe, groups derive to 3), workflow comment explaining the constraint, tool docstring updated. Verified locally: CE 11.32 → 2.65, PASS.

Unbreaks every open PR's checks, including #124.

🤖 Generated with [Claude Code](https://claude.com/claude-code)