### PR TITLE
Reasoner encoder/decoder remat ON for dim960 (#128 follow-up)

### DIFF
--- a/model.py
+++ b/model.py
@@ -36,8 +36,14 @@ class UniversalReasoner(nnx.Module):
         # The reasoning stack's memory is already bounded by the scan-level
         # jax.checkpoint in _reasoning_loop; per-block remat inside it was double
         # checkpointing (322ms -> 271ms/micro-step from dropping it alone).
-        self.encoder_stack = BlockStack(num_blocks // 2, latent_dim, num_heads=NUM_HEADS, rngs=rngs, dtype=dtype, share_weights=False, use_remat=False)
-        self.decoder_stack = BlockStack(num_blocks // 2, latent_dim, num_heads=NUM_HEADS, rngs=rngs, dtype=dtype, share_weights=False, use_remat=False)
+        # encoder/decoder remat flipped ON for dim960 (#128 follow-up): the June
+        # dim512 benchmark that turned it off predates the #129 memory work, and
+        # at dim960 the control OOM'd 1.06GiB on late depth-variant compiles with
+        # these stacks un-remat'd. The reasoning stack stays False — its scan-level
+        # jax.checkpoint in _reasoning_loop already bounds it (per-block remat
+        # inside that was measured as double-checkpointing overhead).
+        self.encoder_stack = BlockStack(num_blocks // 2, latent_dim, num_heads=NUM_HEADS, rngs=rngs, dtype=dtype, share_weights=False, use_remat=True)
+        self.decoder_stack = BlockStack(num_blocks // 2, latent_dim, num_heads=NUM_HEADS, rngs=rngs, dtype=dtype, share_weights=False, use_remat=True)
         self.reasoning_stack = BlockStack(num_blocks, latent_dim, num_heads=NUM_HEADS, rngs=rngs, dtype=dtype, share_weights=True, use_remat=False)
 
         self.meta_proj = nnx.Linear(2, latent_dim, rngs=rngs, dtype=dtype)


### PR DESCRIPTION
## What

Flips `use_remat=True` on the reasoner's encoder and decoder BlockStacks (reasoning stack stays `False` — already bounded by the scan-level `jax.checkpoint` in `_reasoning_loop`; per-block remat there was measured as double-checkpointing).

## Why

The #16 control arm (reasoner, dim960) OOM'd twice at opt step ~20 with a 1.06GiB arena shortfall when late depth-variant compiles landed on a committed pool. The June benchmark that turned this remat off was at dim512 and predates the #129 memory work — at dim960 the activation floor without it doesn't fit alongside the compile workspace.

## Evidence

Probe run last night (2026-07-19 20:06): with the flip, the control trained past opt step 60 and completed its first validation (held-out CE 8.4690 @ step 64) where both prior attempts died at ~20. It then hit a *different*, driver-side OOM (CUDA graph instantiation, 138 alive graphs) — that one is launch-config, fixed by `XLA_FLAGS=--xla_gpu_enable_command_buffer=` in the (gitignored) launch script, not a code change.

Not novel — remat necessity at larger dims is settled practice; record lives in this PR per rule 5.

Full CPU suite green locally (exit 0). BlockStack remat is training-only, so inference paths are untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)