### PR TITLE
Time machine: revive any weight in its exact training world (#44)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,10 @@ auxpy.py
 # Working plans stay local; docs/findings/ is tracked and publishable
 docs/plans/
 
+# Time-machine reconstructions (tools/timemachine.py): worktrees + cached venvs,
+# both regenerable from the run snapshot. Never commit them.
+.timemachine/
+
 # Regenerable plot outputs at repo root (plot_history.py / eval scripts).
 # The canonical, dated figures we keep live in docs/findings/.
 /depth_curve.png

--- a/run_tracker.py
+++ b/run_tracker.py
@@ -69,10 +69,16 @@ class RunTracker:
         here makes every future run revivable by construction. Best-effort: a failure
         to snapshot must never take down a training launch.
         """
+        # Every shell-out below carries a timeout: a raised error is caught, but a
+        # *hang* (wedged D-state nvidia-smi, a stuck pip) is not — without the timeout
+        # it would stall every launch. TimeoutExpired is a SubprocessError, so the
+        # existing excepts already handle it once it fires.
+
         # 1. Pinned libs — the second half of the compat surface (code is the first).
         try:
             freeze = subprocess.check_output(
-                [sys.executable, "-m", "pip", "freeze"], stderr=subprocess.DEVNULL)
+                [sys.executable, "-m", "pip", "freeze"],
+                stderr=subprocess.DEVNULL, timeout=120)
             with open(os.path.join(run_dir, "env_freeze.txt"), "wb") as f:
                 f.write(freeze)
         except (OSError, subprocess.SubprocessError) as e:
@@ -86,12 +92,16 @@ class RunTracker:
         try:
             smi = subprocess.check_output(
                 ["nvidia-smi", "--query-gpu=driver_version,name",
-                 "--format=csv,noheader"], stderr=subprocess.DEVNULL).decode().strip()
+                 "--format=csv,noheader"], stderr=subprocess.DEVNULL,
+                timeout=30).decode().strip()
             lines.append(f"gpu {smi}")
         except (OSError, subprocess.SubprocessError):
             lines.append("gpu (nvidia-smi unavailable)")
-        with open(os.path.join(run_dir, "system_snapshot.txt"), "w") as f:
-            f.write("\n".join(lines) + "\n")
+        try:
+            with open(os.path.join(run_dir, "system_snapshot.txt"), "w") as f:
+                f.write("\n".join(lines) + "\n")
+        except OSError as e:  # e.g. disk full at run creation on the near-full root fs
+            print(f"⚠️ Could not write system_snapshot.txt ({e}).")
 
         RunTracker.capture_worktree_snapshot(run_dir)
 
@@ -108,7 +118,7 @@ class RunTracker:
         """
         try:
             patch = subprocess.check_output(
-                ["git", "diff", "HEAD"], stderr=subprocess.DEVNULL)
+                ["git", "diff", "HEAD"], stderr=subprocess.DEVNULL, timeout=60)
             with open(os.path.join(run_dir, "worktree.patch"), "wb") as f:
                 f.write(patch)
         except (OSError, subprocess.SubprocessError) as e:
@@ -117,7 +127,7 @@ class RunTracker:
         try:
             untracked = subprocess.check_output(
                 ["git", "ls-files", "--others", "--exclude-standard"],
-                stderr=subprocess.DEVNULL).decode()
+                stderr=subprocess.DEVNULL, timeout=60).decode()
             with open(os.path.join(run_dir, "worktree.untracked.txt"), "w") as f:
                 f.write(untracked)
         except (OSError, subprocess.SubprocessError) as e:

--- a/run_tracker.py
+++ b/run_tracker.py
@@ -20,6 +20,7 @@ from config import (
     DATA_SEED,
     MODEL_SEED,
     TRAIN_TOKEN_BUDGET,
+    MODEL_ARCH,
 )
 from schedules import DECAY_STEPS
 
@@ -59,8 +60,76 @@ class RunTracker:
         return metadata
 
     @staticmethod
+    def capture_environment_snapshot(run_dir):
+        """Freeze everything a revival (tools/timemachine.py) needs beyond the commit
+        SHA: the dirty working tree, the pinned Python libs, and the host it assumed.
+
+        These make a run self-describing. Until now they were written by hand (only
+        one run ever had them), so reproducibility was accidental; capturing them
+        here makes every future run revivable by construction. Best-effort: a failure
+        to snapshot must never take down a training launch.
+        """
+        # 1. Pinned libs — the second half of the compat surface (code is the first).
+        try:
+            freeze = subprocess.check_output(
+                [sys.executable, "-m", "pip", "freeze"], stderr=subprocess.DEVNULL)
+            with open(os.path.join(run_dir, "env_freeze.txt"), "wb") as f:
+                f.write(freeze)
+        except (OSError, subprocess.SubprocessError) as e:
+            print(f"⚠️ Could not capture pip freeze ({e}); libs not pinned.")
+
+        # 2. The host the venv assumed — driver/GPU/python. Not part of the compat
+        #    surface (driver is a shared passthrough) but invaluable for debugging a
+        #    failed revival. MODEL_ARCH also rides in run_metadata.json, machine-readable.
+        lines = [f"python {sys.version.split()[0]}", f"platform {sys.platform}",
+                 f"MODEL_ARCH {MODEL_ARCH}"]
+        try:
+            smi = subprocess.check_output(
+                ["nvidia-smi", "--query-gpu=driver_version,name",
+                 "--format=csv,noheader"], stderr=subprocess.DEVNULL).decode().strip()
+            lines.append(f"gpu {smi}")
+        except (OSError, subprocess.SubprocessError):
+            lines.append("gpu (nvidia-smi unavailable)")
+        with open(os.path.join(run_dir, "system_snapshot.txt"), "w") as f:
+            f.write("\n".join(lines) + "\n")
+
+        RunTracker.capture_worktree_snapshot(run_dir)
+
+    @staticmethod
+    def capture_worktree_snapshot(run_dir):
+        """Freeze the working tree so a dirty launch is reproducible.
+
+        `git_dirty` records *that* the tree diverged from HEAD; this records *how*.
+        Without it, reviving a weight (tools/timemachine.py) can only reconstruct the
+        commit, not the uncommitted edits that were actually live at launch. We save
+        the tracked-file diff as a patch the time machine re-applies onto the worktree,
+        plus the list of untracked non-ignored files (whose contents we deliberately
+        do NOT copy — bloat/surprise risk — but warn about on reconstruction).
+        """
+        try:
+            patch = subprocess.check_output(
+                ["git", "diff", "HEAD"], stderr=subprocess.DEVNULL)
+            with open(os.path.join(run_dir, "worktree.patch"), "wb") as f:
+                f.write(patch)
+        except (OSError, subprocess.SubprocessError) as e:
+            print(f"⚠️ Could not capture worktree patch ({e}); dirty state not saved.")
+
+        try:
+            untracked = subprocess.check_output(
+                ["git", "ls-files", "--others", "--exclude-standard"],
+                stderr=subprocess.DEVNULL).decode()
+            with open(os.path.join(run_dir, "worktree.untracked.txt"), "w") as f:
+                f.write(untracked)
+        except (OSError, subprocess.SubprocessError) as e:
+            print(f"⚠️ Could not list untracked files ({e}).")
+
+    @staticmethod
     def get_hyperparameters():
         return {
+            # Which arch built the param tree — the two arches are not
+            # checkpoint-compatible, so a faithful revival (tools/timemachine.py)
+            # must rebuild the same skeleton. Recorded machine-readably here.
+            "MODEL_ARCH": MODEL_ARCH,
             "LATENT_DIM": LATENT_DIM,
             "NUM_BLOCKS": NUM_BLOCKS,
             "SHARED_SLOTS": SHARED_SLOTS,
@@ -148,6 +217,7 @@ class RunTracker:
             }
             self.session_index = 0
             self.save_metadata(metadata)
+            self.capture_environment_snapshot(self.run_dir)
             print(f"📁 Created new training run folder: {self.run_dir}")
         else:
             # Resume existing run

--- a/tests/test_timemachine.py
+++ b/tests/test_timemachine.py
@@ -1,0 +1,85 @@
+"""Unit tests for the time machine's pure logic (tools/timemachine.py).
+
+The reconstruction itself (worktree, venv build, GPU eval) is validated by hand on
+the card; these pin the decisions that must never silently go wrong — above all that
+the arch resolver *refuses to guess* (a wrong arch corrupts the restore) and that the
+metric it compares against is read correctly.
+"""
+
+import os
+import json
+
+import pytest
+
+import tools.timemachine as tm
+
+
+@pytest.fixture
+def runs(tmp_path, monkeypatch):
+    """Point the module at a throwaway runs/ tree."""
+    monkeypatch.setattr(tm, "RUNS_ROOT", str(tmp_path))
+    return tmp_path
+
+
+def _make_run(runs, run_id, *, meta=None, snapshot=None, metrics=None):
+    d = runs / run_id
+    d.mkdir()
+    if meta is not None:
+        (d / "run_metadata.json").write_text(json.dumps(meta))
+    if snapshot is not None:
+        (d / "system_snapshot.txt").write_text(snapshot)
+    if metrics is not None:
+        (d / "metrics.csv").write_text(metrics)
+    return d
+
+
+def test_resolve_arch_prefers_machine_readable_metadata(runs):
+    _make_run(runs, "r", meta={"parameters": {"MODEL_ARCH": "reasoner"}})
+    assert tm.resolve_arch("r", tm.load_meta("r")) == "reasoner"
+
+
+def test_resolve_arch_reads_structured_snapshot_line(runs):
+    _make_run(runs, "r", meta={"parameters": {}}, snapshot="python 3.14\nMODEL_ARCH reasoner\n")
+    assert tm.resolve_arch("r", tm.load_meta("r")) == "reasoner"
+
+
+def test_resolve_arch_reads_legacy_arm_marker(runs):
+    _make_run(runs, "r", meta={"parameters": {}}, snapshot="arm=refiner (#16)\n")
+    assert tm.resolve_arch("r", tm.load_meta("r")) == "refiner"
+
+
+def test_resolve_arch_refuses_to_guess(runs):
+    # No metadata arch, no snapshot: must return None so the caller demands --arch
+    # rather than defaulting and rebuilding the wrong (incompatible) skeleton.
+    _make_run(runs, "r", meta={"parameters": {}})
+    assert tm.resolve_arch("r", tm.load_meta("r")) is None
+
+
+def test_recorded_val_ce_takes_last_non_empty(runs):
+    metrics = "step,val_ce\n10,5.10\n20,\n30,4.8947\n"
+    _make_run(runs, "r", meta={"parameters": {}}, metrics=metrics)
+    assert tm.recorded_val_ce("r") == pytest.approx(4.8947)
+
+
+def test_recorded_val_ce_missing_file_is_none(runs):
+    _make_run(runs, "r", meta={"parameters": {}})
+    assert tm.recorded_val_ce("r") is None
+
+
+def test_venv_key_is_deterministic_and_content_addressed(runs):
+    a = _make_run(runs, "a", meta={"parameters": {}})
+    b = _make_run(runs, "b", meta={"parameters": {}})
+    (a / "env_freeze.txt").write_text("jax==0.9.1\n")
+    (b / "env_freeze.txt").write_text("jax==0.9.1\n")
+    ka, _ = tm.venv_key("a")
+    kb, _ = tm.venv_key("b")
+    assert ka is not None and ka == kb  # identical freeze -> shared venv
+
+    (b / "env_freeze.txt").write_text("jax==0.9.2\n")
+    kb2, _ = tm.venv_key("b")
+    assert kb2 != ka  # different freeze -> different venv
+
+
+def test_venv_key_none_without_freeze(runs):
+    _make_run(runs, "r", meta={"parameters": {}})
+    assert tm.venv_key("r") == (None, None)

--- a/tools/timemachine.py
+++ b/tools/timemachine.py
@@ -1,0 +1,401 @@
+"""Time machine — revive any stored weight in the exact world that trained it.
+
+New code is not compatible with old weights: param-tree renames, config drift, and
+orbax/flax checkpoint-format changes all break a naive `load`. So reviving a weight
+means reconstructing the *world* that made it, not just pointing new code at an old
+checkpoint. This tool rebuilds that world — the model/config code at the training
+commit, the uncommitted edits that were live at launch, and the pinned Python libs —
+then aims it at the SAME weights on disk and lets you fork a new training lineage or
+run inference.
+
+Why worktree + venv, not Docker: the compatibility surface is exactly (code, libs).
+CUDA userspace is pinned *inside* `env_freeze.txt` (the `nvidia-cu12` wheels) and the
+driver is a shared host passthrough — so a git worktree at the commit plus a venv
+built from the freeze reproduces the whole surface. Docker would only wrap that in an
+OS/driver jail on top, for 5-8GB an image on a tight SSD. The snapshot is structured
+so a `build-image` step could wrap it later if that jail is ever wanted; see
+docs/plans/timemachine.md.
+
+The load-bearing fact: `runs/` is gitignored, so a worktree checked out at any old
+commit shares the *same* `runs/<id>/checkpoints` on disk. The time machine reverts
+code; the weights folder never moves. "Same folder" is free.
+
+Usage:
+    python tools/timemachine.py list
+    python tools/timemachine.py reconstruct <run-id> [--for infer|train] [--no-venv]
+    python tools/timemachine.py fork <run-id> <new-name> [--no-venv]
+"""
+
+import os
+import sys
+import csv
+import json
+import shutil
+import hashlib
+import argparse
+import subprocess
+
+REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+TM_ROOT = os.path.join(REPO_ROOT, ".timemachine")
+RUNS_ROOT = os.path.join(REPO_ROOT, "runs")
+
+
+# --- reading a run's snapshot ------------------------------------------------
+
+def run_dir(run_id):
+    return os.path.join(RUNS_ROOT, run_id)
+
+
+def load_meta(run_id):
+    path = os.path.join(run_dir(run_id), "run_metadata.json")
+    if not os.path.exists(path):
+        raise SystemExit(f"No run_metadata.json for {run_id} (looked in {path}).")
+    with open(path) as f:
+        return json.load(f)
+
+
+def resolve_arch(run_id, meta):
+    """Which arch built the checkpoint's param tree, or None if unknowable.
+
+    The two arches are not checkpoint-compatible, so guessing wrong rebuilds the
+    WRONG skeleton and the restore corrupts silently. We therefore never default:
+    prefer the machine-readable record (run_metadata parameters, or the
+    system_snapshot line for runs after that capture landed), fall back to the
+    older free-text 'arm=<x>', and otherwise return None so the caller demands an
+    explicit --arch rather than gambling on the project default."""
+    arch = meta.get("parameters", {}).get("MODEL_ARCH")
+    if arch:
+        return arch
+    snap = os.path.join(run_dir(run_id), "system_snapshot.txt")
+    if os.path.exists(snap):
+        text = open(snap).read()
+        for marker in ("MODEL_ARCH ", "arm="):  # new structured line, then legacy
+            if marker in text:
+                return text.split(marker, 1)[1].split()[0].strip("();,")
+    return None
+
+
+def has_file(run_id, name):
+    p = os.path.join(run_dir(run_id), name)
+    return os.path.exists(p) and os.path.getsize(p) > 0
+
+
+# --- reconstructing the world ------------------------------------------------
+
+def ensure_worktree(run_id, commit):
+    """A detached worktree at `commit` with the run's dirty edits re-applied.
+    Idempotent: an existing worktree is reused (patch applied only once, tracked
+    by a sentinel so a re-run never double-applies)."""
+    wt = os.path.join(TM_ROOT, "wt", run_id)
+    applied = os.path.join(wt, ".tm_applied")
+    if os.path.exists(applied):
+        print(f"  worktree reused: {os.path.relpath(wt, REPO_ROOT)}")
+        return wt
+
+    os.makedirs(os.path.dirname(wt), exist_ok=True)
+    if not os.path.exists(wt):
+        subprocess.run(["git", "worktree", "add", "--detach", wt, commit],
+                       cwd=REPO_ROOT, check=True)
+
+    patch = os.path.join(run_dir(run_id), "worktree.patch")
+    if has_file(run_id, "worktree.patch"):
+        # --3way falls back to a merge if context drifted; a clean run applies flat.
+        subprocess.run(["git", "apply", "--3way", patch], cwd=wt, check=True)
+        print(f"  applied worktree.patch ({os.path.getsize(patch)} bytes)")
+    else:
+        print("  no worktree.patch — reconstructed to the commit only "
+              "(pre-snapshot run; dirty edits at launch are not recoverable)")
+
+    untracked = os.path.join(run_dir(run_id), "worktree.untracked.txt")
+    if os.path.exists(untracked):
+        n = len([l for l in open(untracked) if l.strip()])
+        if n:
+            print(f"  note: {n} untracked non-ignored files existed at launch "
+                  f"(not restored; see {os.path.relpath(untracked, REPO_ROOT)})")
+
+    open(applied, "w").close()
+    return wt
+
+
+def venv_key(run_id):
+    """A venv is shared by every lineage with a byte-identical env_freeze.txt."""
+    freeze = os.path.join(run_dir(run_id), "env_freeze.txt")
+    if not os.path.exists(freeze):
+        return None, None
+    digest = hashlib.sha256(open(freeze, "rb").read()).hexdigest()[:16]
+    return digest, freeze
+
+
+def ensure_venv(run_id, build=True):
+    """A venv matching the run's pinned freeze, cached by its hash. Building
+    installs ~5GB of wheels (incl. the vendored CUDA libs) and needs the network,
+    so it is the slow step — but it happens once per distinct environment."""
+    digest, freeze = venv_key(run_id)
+    if digest is None:
+        print("  no env_freeze.txt — cannot pin libs (using the caller's venv)")
+        return None
+    venv = os.path.join(TM_ROOT, "venvs", digest)
+    py = os.path.join(venv, "bin", "python")
+    if os.path.exists(py):
+        print(f"  venv reused: .timemachine/venvs/{digest}")
+        return venv
+    if not build:
+        print(f"  venv NOT built (--no-venv): would install {freeze} -> "
+              f".timemachine/venvs/{digest}")
+        return venv
+    print(f"  building venv .timemachine/venvs/{digest} from {os.path.basename(freeze)} "
+          f"(installs ~5GB, one-off)...")
+    os.makedirs(os.path.dirname(venv), exist_ok=True)
+    subprocess.run([sys.executable, "-m", "venv", venv], check=True)
+    subprocess.run([py, "-m", "pip", "install", "--upgrade", "pip"], check=True)
+    subprocess.run([py, "-m", "pip", "install", "-r", freeze], check=True)
+    return venv
+
+
+def reconstruct(run_id, for_mode="infer", build_venv=True, arch_override=None):
+    meta = load_meta(run_id)
+    commit = meta.get("git_commit", "unknown")
+    arch = arch_override or resolve_arch(run_id, meta)
+    if commit in (None, "unknown"):
+        raise SystemExit(f"{run_id} has no recorded commit — cannot reconstruct.")
+    if arch is None:
+        raise SystemExit(
+            f"{run_id} does not record its MODEL_ARCH (a pre-capture run), and the "
+            f"two arches are not checkpoint-compatible. Re-run with --arch "
+            f"refiner|reasoner to say which skeleton to rebuild.")
+
+    print(f"Reconstructing world for {run_id}  (commit {commit[:10]}, arch {arch})")
+    wt = ensure_worktree(run_id, commit)
+    venv = ensure_venv(run_id, build=build_venv)
+    ckpt = os.path.join(run_dir(run_id), "checkpoints")
+    py = os.path.join(venv, "bin", "python") if venv else sys.executable
+
+    print(f"\nWORLD READY: {run_id}")
+    print(f"  worktree : {wt}")
+    print(f"  venv     : {venv or '(caller venv — libs NOT pinned)'}")
+    print(f"  weights  : {ckpt}")
+    print(f"  arch     : {arch}")
+    _print_commands(wt, py, ckpt, arch, run_id, for_mode)
+    return {"worktree": wt, "python": py, "checkpoints": ckpt, "arch": arch}
+
+
+def _print_commands(wt, py, ckpt, arch, run_id, for_mode):
+    if for_mode == "eval":
+        return  # evaluate() prints its own eval command + verdict
+    print("\nRun inside the reconstructed world:")
+    if for_mode == "infer":
+        print(f"  cd {wt}")
+        print(f"  PYTHONPATH=. MODEL_ARCH={arch} DATA_ROOT=$DATA_ROOT \\")
+        print(f"    {py} tools/depth_playground.py --arch {arch} \\")
+        print(f"    --checkpoint-path {ckpt} --prompt 'The capital of France is'")
+        print("  (older worktrees may not have depth_playground's --arch flag; "
+              "fall back to that commit's infer_local.py)")
+    else:
+        print(f"  # fork a NEW lineage (original {run_id} preserved):")
+        print(f"  python tools/timemachine.py fork {run_id} <new-name>")
+        print("  # ...on the 6GB card, also export the run's memory knobs "
+              "(XLA_PYTHON_CLIENT_MEM_FRACTION, CHUNKED_ATTENTION, etc.) from its "
+              "launch env / system_snapshot.txt, or it will OOM.")
+
+
+# --- closing the loop: reproduce the metric (#44 DoD) ------------------------
+
+def recorded_val_ce(run_id):
+    """The run's own last held-out val CE (metrics.csv) — the number a faithful
+    revival must reproduce. Held-out CE is what the #17 noise floor is stated in
+    (2σ = 0.06 nats), so it is the natural apples-to-apples target."""
+    path = os.path.join(run_dir(run_id), "metrics.csv")
+    if not os.path.exists(path):
+        return None
+    last = None
+    with open(path) as f:
+        for row in csv.DictReader(f):
+            v = row.get("val_ce", "")
+            if v not in ("", "nan", None):
+                try:
+                    last = float(v)
+                except ValueError:
+                    pass
+    return last
+
+
+def evaluate(run_id, arch_override=None, build_venv=True, limit=None,
+             tolerance=0.06, cpu=False, dry_run=False):
+    """#44's definition of done: from the snapshot alone, rebuild the world, run
+    that run's own yardstick (tools/eval_yardstick.py at its commit) on its weights,
+    and confirm the held-out val CE reproduces the recorded value within the noise
+    floor. A faithful time machine closes this loop; a broken one won't."""
+    world = reconstruct(run_id, for_mode="eval", build_venv=build_venv,
+                        arch_override=arch_override)
+    wt, py, ckpt, arch = (world["worktree"], world["python"],
+                          world["checkpoints"], world["arch"])
+
+    yard = os.path.join(wt, "tools", "eval_yardstick.py")
+    if not os.path.exists(yard):
+        raise SystemExit(
+            f"tools/eval_yardstick.py does not exist at {run_id}'s commit — that "
+            f"run predates the yardstick (#48); the metric loop can't be closed for it.")
+
+    expect = recorded_val_ce(run_id)
+    out_json = os.path.join(TM_ROOT, "eval", f"{run_id}.json")
+    os.makedirs(os.path.dirname(out_json), exist_ok=True)
+
+    cmd = [py, "tools/eval_yardstick.py", "--arch", arch,
+           "--checkpoint-path", ckpt, "--json-out", out_json]
+    if limit:
+        cmd += ["--limit", str(limit)]
+
+    env = os.environ.copy()
+    env["PYTHONPATH"] = wt
+    env["MODEL_ARCH"] = arch
+    if cpu:  # CPU XLA can't lower the f16 matmuls; note the fidelity caveat below.
+        env["FORCE_F32_COMPUTE"] = "1"
+
+    print(f"\nClosing the metric loop for {run_id}:")
+    print(f"  recorded held-out val CE : {expect if expect is not None else '(none in metrics.csv)'}")
+    print(f"  tolerance (2σ, #17)      : ±{tolerance}")
+    print(f"  eval command             : (cwd {os.path.relpath(wt, REPO_ROOT)}) "
+          + " ".join(os.path.relpath(c, REPO_ROOT) if c.startswith(REPO_ROOT) else c for c in cmd))
+    if dry_run:
+        print("  --dry-run: not executing (wiring check only).")
+        return
+    if cpu:
+        print("  ⚠️ --cpu uses the f32 path — numbers drift slightly from the f16 "
+              "training path; the authoritative check runs on the GPU (f16).")
+
+    subprocess.run(cmd, cwd=wt, env=env, check=True)
+    with open(out_json) as f:
+        row = json.load(f)
+    measured = (row.get("heldout") or {}).get("val_ce")
+    if measured is None:
+        raise SystemExit("Yardstick produced no held-out val CE (DATA_ROOT unset?) "
+                         "— cannot compare. See the JSON at " + out_json)
+
+    print(f"\n  measured held-out val CE : {measured:.4f}")
+    if expect is None:
+        print("  verdict: no recorded metric to compare against — measured value logged only.")
+        return
+    delta = abs(measured - expect)
+    ok = delta <= tolerance
+    print(f"  |measured - recorded|    : {delta:.4f}  "
+          f"({'≤' if ok else '>'} {tolerance})")
+    print(f"  VERDICT: {'✅ REPRODUCED (within noise floor)' if ok else '❌ DRIFTED — reconstruction is not faithful'}")
+    return ok
+
+
+# --- forking a lineage -------------------------------------------------------
+
+def fork(run_id, new_name, build_venv=True, arch_override=None):
+    """Branch a new training lineage off an old checkpoint. The original run is
+    left untouched: we copy its checkpoints into a fresh run dir and resume there,
+    so continued training extends the fork, not the ancestor."""
+    src_ckpt = os.path.join(run_dir(run_id), "checkpoints")
+    if not os.path.isdir(src_ckpt):
+        raise SystemExit(f"{run_id} has no checkpoints/ to fork from.")
+
+    dst_dir = run_dir(new_name)
+    dst_ckpt = os.path.join(dst_dir, "checkpoints")
+    if os.path.exists(dst_dir):
+        raise SystemExit(f"{dst_dir} already exists — pick another fork name.")
+
+    world = reconstruct(run_id, for_mode="train", build_venv=build_venv,
+                        arch_override=arch_override)
+
+    os.makedirs(dst_dir, exist_ok=True)
+    print(f"\nForking checkpoints {run_id} -> {new_name} (copying, original preserved)...")
+    shutil.copytree(src_ckpt, dst_ckpt)
+    # Carry the snapshot forward so the fork is itself revivable.
+    for f in ("run_metadata.json", "env_freeze.txt", "system_snapshot.txt",
+              "worktree.patch", "worktree.untracked.txt"):
+        s = os.path.join(run_dir(run_id), f)
+        if os.path.exists(s):
+            shutil.copy2(s, os.path.join(dst_dir, f))
+
+    print(f"\nResume the fork inside its reconstructed world:")
+    print(f"  cd {world['worktree']}")
+    print(f"  PYTHONPATH=. MODEL_ARCH={world['arch']} DATA_ROOT=$DATA_ROOT \\")
+    print(f"    {world['python']} start_training.py --checkpoint-path {dst_ckpt}")
+    print("  (add the run's GPU memory knobs before launching on the 2060.)")
+
+
+# --- listing -----------------------------------------------------------------
+
+def list_runs():
+    if not os.path.isdir(RUNS_ROOT):
+        raise SystemExit("No runs/ directory.")
+    rows = []
+    for name in sorted(os.listdir(RUNS_ROOT)):
+        if not name.startswith("run_"):
+            continue
+        if not os.path.exists(os.path.join(RUNS_ROOT, name, "run_metadata.json")):
+            continue
+        try:
+            meta = load_meta(name)
+        except SystemExit:
+            continue
+        rows.append((
+            name,
+            (meta.get("git_commit") or "unknown")[:10],
+            resolve_arch(name, meta) or "UNKNOWN",
+            "patch" if has_file(name, "worktree.patch") else "commit-only",
+            "freeze" if has_file(name, "env_freeze.txt") else "NO-freeze",
+            "ckpt" if os.path.isdir(os.path.join(RUNS_ROOT, name, "checkpoints")) else "NO-ckpt",
+        ))
+    if not rows:
+        print("No runs found under runs/.")
+        return
+    w = max(len(r[0]) for r in rows)
+    print(f"{'run-id':<{w}}  commit      arch      fidelity     libs       weights")
+    for r in rows:
+        print(f"{r[0]:<{w}}  {r[1]:<10}  {r[2]:<8}  {r[3]:<11}  {r[4]:<9}  {r[5]}")
+
+
+def main():
+    p = argparse.ArgumentParser(description="revive a stored weight in its training world")
+    sub = p.add_subparsers(dest="cmd", required=True)
+
+    sub.add_parser("list", help="what's revivable and at what fidelity")
+
+    r = sub.add_parser("reconstruct", help="rebuild a run's world; print the run command")
+    r.add_argument("run_id")
+    r.add_argument("--for", dest="for_mode", choices=["infer", "train"], default="infer")
+    r.add_argument("--no-venv", action="store_true", help="skip the ~5GB venv build (dry)")
+    r.add_argument("--arch", choices=["refiner", "reasoner"], default=None,
+                   help="override arch for pre-capture runs that don't record it")
+
+    f = sub.add_parser("fork", help="branch a new training lineage off an old checkpoint")
+    f.add_argument("run_id")
+    f.add_argument("new_name")
+    f.add_argument("--no-venv", action="store_true")
+    f.add_argument("--arch", choices=["refiner", "reasoner"], default=None,
+                   help="override arch for pre-capture runs that don't record it")
+
+    e = sub.add_parser("eval", help="close the loop: reproduce a run's metric within the noise floor (#44 DoD)")
+    e.add_argument("run_id")
+    e.add_argument("--arch", choices=["refiner", "reasoner"], default=None,
+                   help="override arch for pre-capture runs that don't record it")
+    e.add_argument("--no-venv", action="store_true")
+    e.add_argument("--limit", type=int, default=None, help="LAMBADA sample cap (speed)")
+    e.add_argument("--tolerance", type=float, default=0.06,
+                   help="max |measured-recorded| held-out val CE; default 2σ from #17")
+    e.add_argument("--cpu", action="store_true", help="f32 CPU path (slow, drifts from f16)")
+    e.add_argument("--dry-run", action="store_true", help="print the wiring, don't execute")
+
+    args = p.parse_args()
+    if args.cmd == "list":
+        list_runs()
+    elif args.cmd == "reconstruct":
+        reconstruct(args.run_id, args.for_mode, build_venv=not args.no_venv,
+                    arch_override=args.arch)
+    elif args.cmd == "fork":
+        fork(args.run_id, args.new_name, build_venv=not args.no_venv,
+             arch_override=args.arch)
+    elif args.cmd == "eval":
+        ok = evaluate(args.run_id, arch_override=args.arch, build_venv=not args.no_venv,
+                      limit=args.limit, tolerance=args.tolerance, cpu=args.cpu,
+                      dry_run=args.dry_run)
+        sys.exit(0 if ok or ok is None else 1)
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/timemachine.py
+++ b/tools/timemachine.py
@@ -96,6 +96,12 @@ def ensure_worktree(run_id, commit):
     if not os.path.exists(wt):
         subprocess.run(["git", "worktree", "add", "--detach", wt, commit],
                        cwd=REPO_ROOT, check=True)
+    else:
+        # Worktree exists but the sentinel doesn't — a prior run died mid-setup,
+        # leaving a possibly half-patched tree. Reset it clean before re-applying so
+        # the patch lands on the pristine commit, not on top of a partial apply.
+        subprocess.run(["git", "reset", "--hard", commit], cwd=wt, check=True)
+        subprocess.run(["git", "clean", "-fd"], cwd=wt, check=True)
 
     patch = os.path.join(run_dir(run_id), "worktree.patch")
     if has_file(run_id, "worktree.patch"):
@@ -200,23 +206,35 @@ def _print_commands(wt, py, ckpt, arch, run_id, for_mode):
 
 # --- closing the loop: reproduce the metric (#44 DoD) ------------------------
 
-def recorded_val_ce(run_id):
-    """The run's own last held-out val CE (metrics.csv) — the number a faithful
-    revival must reproduce. Held-out CE is what the #17 noise floor is stated in
-    (2σ = 0.06 nats), so it is the natural apples-to-apples target."""
+def recorded_val_ce(run_id, step=None):
+    """The run's own held-out val CE (metrics.csv) — the number a faithful revival
+    must reproduce. Held-out CE is what the #17 noise floor is stated in (2σ = 0.06
+    nats), so it is the natural apples-to-apples target.
+
+    The yardstick scores whatever checkpoint is on disk, whose step need not be the
+    last *logged* row (val cadence and checkpoint cadence can differ). Pass `step`
+    (from the yardstick's reported checkpoint step) to compare like-for-like; we fall
+    back to the last logged CE only when no row matches."""
     path = os.path.join(run_dir(run_id), "metrics.csv")
     if not os.path.exists(path):
         return None
-    last = None
+    last = matched = None
     with open(path) as f:
         for row in csv.DictReader(f):
             v = row.get("val_ce", "")
-            if v not in ("", "nan", None):
+            if v in ("", "nan", None):
+                continue
+            try:
+                last = float(v)
+            except ValueError:
+                continue
+            if step is not None:
                 try:
-                    last = float(v)
+                    if int(float(row.get("step", "nan"))) == int(step):
+                        matched = last
                 except ValueError:
                     pass
-    return last
+    return matched if matched is not None else last
 
 
 def evaluate(run_id, arch_override=None, build_venv=True, limit=None,
@@ -271,10 +289,17 @@ def evaluate(run_id, arch_override=None, build_venv=True, limit=None,
         raise SystemExit("Yardstick produced no held-out val CE (DATA_ROOT unset?) "
                          "— cannot compare. See the JSON at " + out_json)
 
+    # Compare against the CE logged for the exact checkpoint step the yardstick scored.
+    step = (row.get("checkpoint") or {}).get("step")
+    expect = recorded_val_ce(run_id, step=step) if step is not None else expect
+
     print(f"\n  measured held-out val CE : {measured:.4f}")
     if expect is None:
-        print("  verdict: no recorded metric to compare against — measured value logged only.")
-        return
+        # A DoD gate that can't find the recorded metric must not exit success —
+        # otherwise an un-checkable run reads as "reproduced". Distinct code 2.
+        print("  verdict: NO recorded metric to compare against — cannot verify "
+              "(measured value logged above).")
+        raise SystemExit(2)
     delta = abs(measured - expect)
     ok = delta <= tolerance
     print(f"  |measured - recorded|    : {delta:.4f}  "


### PR DESCRIPTION
## What & why

Codifies the capability #44 asks for — **resume training or run inference on any stored weight after the code has moved on** — via **worktree + venv**, not Docker.

The compat surface is only **(code at the commit, pinned libs)**: JAX vendors its own CUDA inside `env_freeze.txt` and the driver is a shared host passthrough, so a `git worktree` at the training commit + a venv from the freeze reproduces the whole surface. `runs/` is gitignored, so the worktree shares the *same* weights on disk. The snapshot is structured so a `build-image` step could wrap it in Docker later, if that OS/driver jail is ever wanted (see `docs/plans/issue-44-retarget.md`, local).

**Note:** the issue's original "Shape" specified Docker; the mechanism decision (worktree+venv, Docker demoted to optional) was made with @MatthewLacerda2 this session. A retargeted #44 body is drafted locally for him to apply.

## What's here

- **`run_tracker.py`** — every new run now auto-captures its full reconstruction snapshot: `env_freeze.txt`, a structured `system_snapshot.txt` (incl. machine-readable `MODEL_ARCH`), the dirty-tree `worktree.patch`, and the untracked-file list. These were written *by hand* only once before — reproducibility was accidental. Best-effort: a snapshot failure never takes down a launch.
- **`tools/timemachine.py`** — `list` / `reconstruct` / `fork` / `eval`. The arch resolver **refuses to guess** (the two arches aren't checkpoint-compatible); it demands `--arch` for pre-capture runs rather than silently rebuilding the wrong skeleton. `eval` closes #44's DoD: rebuild the world, run that run's own `eval_yardstick.py` at its commit, confirm held-out val CE reproduces within the #17 noise floor (2σ=0.06).
- **`tests/test_timemachine.py`** — pins the arch-refusal, metric-read, and venv-hash logic (8 tests, green).

## Validated vs. not

- ✅ CPU: patch round-trips, worktree builds at the right commit, arch refusal/override, fork guards, metric parsing + verdict math, golden + determinism suites unaffected.
- ⏳ **GPU-gated (not done):** the first *real* reconstruction (venv build, old-code import, checkpoint restore, run) and the DoD eval reproducing the metric. **Nothing here has executed on the card yet.**

## Why this does NOT close #44

`Refs #44`, not `Closes #44`. By #44's own DoD the reproduce-the-metric eval must actually pass, and that's GPU-gated. Closing on unrun code would be a false win. #44 closes when the GPU eval verdict lands.