### PR TITLE
Real batching at BATCH_SIZE=2: +43% throughput, same model (#24)

### DIFF
--- a/checkpoint_utils.py
+++ b/checkpoint_utils.py
@@ -72,6 +72,12 @@ def save_checkpoint(mngr, step, model, optimizer, monitor, sft_active, run_id):
                 "sft_active": sft_active,
                 "sft_start_step": monitor.sft_start_step,
                 "run_id": run_id,  # Save run_id inside checkpoint metadata
+                # Samples actually consumed, counted as they were served rather
+                # than re-derived (#24). Resume rebuilds the data position from
+                # this; computing it as step x BATCH_SIZE would mis-seek exactly
+                # the run that needs it — one resumed at a different batch size
+                # than it was trained at, whose history spans both.
+                "samples_seen": monitor.samples_seen,
             }),
             step=ocp.args.JsonSave(step),
         ),
@@ -112,8 +118,13 @@ def load_or_create_checkpoint(model, optimizer, checkpoint_path, force_new_run=F
         monitor.best_avg_ce = m_state.get("best_avg_ce", monitor.best_ce)
         monitor.last_improvement_step = m_state.get("last_improvement_step", 0)
         monitor.sft_start_step = m_state.get("sft_start_step", None)
+        # Checkpoints written before #24 have no samples_seen; every one of them
+        # was trained at BATCH_SIZE=1, so one sample per micro-step is the exact
+        # value, not a guess.
+        monitor.samples_seen = m_state.get("samples_seen", restored["step"])
 
-        print(f"✅ Resuming from step {start_step}")
+        print(f"✅ Resuming from step {start_step} "
+              f"({monitor.samples_seen:,} samples consumed)")
         del restored 
         gc.collect()
     else:

--- a/config.py
+++ b/config.py
@@ -105,11 +105,29 @@ INFERENCE_DEPTH = int(os.environ.get("INFERENCE_DEPTH", "6"))
 
 # Training
 MAX_STEPS_LIMIT = 8
-BATCH_SIZE = 1
-ACCUMULATION_STEPS = 128
+# BATCH_SIZE and ACCUMULATION_STEPS move together, always keeping their product
+# fixed (#24): the optimizer + global-norm clip over 138.7M params costs a flat
+# ~69ms per micro-step regardless of batch — 25% of a batch-1 step — so fewer,
+# fatter micro-steps amortize it. Measured +34% (3.8k -> 5.1k tok/s at depth 4).
+# Because TOKENS_PER_OPT_STEP is unchanged, the LR schedule, the token budget,
+# and the learning dynamics are all identical: same model, fewer resources.
+# Going past 2 is not worth it — the return per doubling shrinks fast (the next
+# rung measured +19-25%) as the card goes from launch-bound to compute-bound.
+BATCH_SIZE = 2
+ACCUMULATION_STEPS = 64
 # Target tokens consumed per optimizer step: each micro-step scores two
 # MAX_SEQ_LEN prediction windows, ACCUMULATION_STEPS micro-steps make one opt step.
 TOKENS_PER_OPT_STEP = ACCUMULATION_STEPS * BATCH_SIZE * 2 * MAX_SEQ_LEN
+
+# Held-out evaluation reads a fixed number of *rows* (prediction-window pairs)
+# and scores them ONE ROW AT A TIME, deliberately ignoring BATCH_SIZE. Sizing or
+# chunking the eval slice by a training throughput knob would silently redefine
+# what "val CE" means and break comparability with every number already recorded
+# (the champion's 4.7092, the #17 noise floor of sigma~0.03, the time machine's
+# +/-0.06 reproduction check). Eval is a handful of rows, so there is nothing to
+# gain by batching it — and batch-1 scoring is also the shape every stored
+# checkpoint of both arches was written at.
+EVAL_ROWS = 4
 
 # Planned token budget for the run (#83) — env-overridable per run like the seeds,
 # recorded in run_metadata.json. Drives schedules.DECAY_STEPS so the LR cosine

--- a/config.py
+++ b/config.py
@@ -108,11 +108,15 @@ MAX_STEPS_LIMIT = 8
 # BATCH_SIZE and ACCUMULATION_STEPS move together, always keeping their product
 # fixed (#24): the optimizer + global-norm clip over 138.7M params costs a flat
 # ~69ms per micro-step regardless of batch — 25% of a batch-1 step — so fewer,
-# fatter micro-steps amortize it. Measured +34% (3.8k -> 5.1k tok/s at depth 4).
+# fatter micro-steps amortize it. Matched pairs on an idle card: +43% at depth 4
+# (5.0k -> 7.2k tok/s) and +40% at depth 8 (4.2k -> 5.9k). An earlier sweep read
+# +34% but was measured while a training job shared the GPU — same ratio, lower
+# absolutes; trust the idle numbers.
 # Because TOKENS_PER_OPT_STEP is unchanged, the LR schedule, the token budget,
 # and the learning dynamics are all identical: same model, fewer resources.
 # Going past 2 is not worth it — the return per doubling shrinks fast (the next
-# rung measured +19-25%) as the card goes from launch-bound to compute-bound.
+# rung read +19-25% on the contended sweep, unconfirmed since) as the card goes
+# from launch-bound to compute-bound.
 BATCH_SIZE = 2
 ACCUMULATION_STEPS = 64
 # Target tokens consumed per optimizer step: each micro-step scores two

--- a/monitor.py
+++ b/monitor.py
@@ -13,6 +13,10 @@ class LossMonitor:
         self.is_new_best = False
         # Step at which the SFT phase began; None while still pretraining.
         self.sft_start_step = None
+        # Samples the data pipeline has served (#24). Restored from the
+        # checkpoint rather than re-derived from the step count, so a resume
+        # seeks correctly even if BATCH_SIZE changed between runs.
+        self.samples_seen = 0
 
     def reset_for_new_phase(self, step):
         """Forget the previous phase's plateau state so the new phase gets a

--- a/start_training.py
+++ b/start_training.py
@@ -91,6 +91,7 @@ if __name__ == "__main__":
         del old_state
         gc.collect()
 
-    data_queue = setup_data_pipeline(start_step, sft_phase_event, monitor.sft_start_step)
+    data_queue = setup_data_pipeline(start_step, sft_phase_event, monitor.sft_start_step,
+                                     samples_seen=monitor.samples_seen or None)
 
     train_loop(model, optimizer, data_queue, mngr, best_mngr, monitor, start_step, sft_phase_event, run_tracker)

--- a/tests/test_batching_invariants.py
+++ b/tests/test_batching_invariants.py
@@ -1,0 +1,154 @@
+"""What must NOT move when BATCH_SIZE does (#24).
+
+Doubling the micro-batch and halving the accumulation is a pure throughput
+change: same tokens, same schedule, same measurement. Three things make that
+true, and each has failed silently in a way no crash would catch:
+
+  1. TOKENS_PER_OPT_STEP stays fixed, so the LR cosine and the token budget
+     describe the same run.
+  2. The held-out eval slice is counted in ROWS and scored at batch 1, so a val
+     CE stays comparable to every number already recorded.
+  3. Resume seeks by the RECORDED sample count, so a run that resumes under a
+     different batch size than it was trained at neither re-reads data it has
+     seen nor skips a slice it hasn't.
+"""
+
+import inspect
+
+import numpy as np
+import pytest
+
+import checkpoint_utils
+import config
+import trainer as trainer_mod
+import validation
+from config import ACCUMULATION_STEPS, BATCH_SIZE, EVAL_ROWS, MAX_SEQ_LEN
+from tools import common
+from tools import eval_refiner_depth_transfer as depth_transfer
+from trainer import samples_from_micro_steps, split_samples
+
+
+def test_tokens_per_opt_step_is_the_batching_invariant():
+    """The product is the contract: BATCH_SIZE x ACCUMULATION_STEPS is what the
+    LR horizon and TRAIN_TOKEN_BUDGET are denominated in. Changing one without
+    the other silently rescales the whole schedule."""
+    assert config.TOKENS_PER_OPT_STEP == ACCUMULATION_STEPS * BATCH_SIZE * 2 * MAX_SEQ_LEN
+    # 131072 is the value every recorded run and every DECAY_STEPS was computed
+    # against. If this must change, it is a new run, not a resume.
+    assert config.TOKENS_PER_OPT_STEP == 131072
+
+
+class _FakeGen:
+    """Minimal TextDataGenerator stand-in: records the size of every read so a
+    test can see exactly how a loader consumed the stream."""
+
+    def __init__(self):
+        self.calls = []
+        self._n = 0
+
+    def get_batch(self, batch_size):
+        self.calls.append(batch_size)
+        rows = np.arange(self._n, self._n + batch_size).reshape(batch_size, 1)
+        self._n += batch_size
+        return rows, np.zeros((batch_size,), dtype=bool)
+
+
+def test_eval_loaders_read_one_row_at_a_time():
+    """Every held-out loader must read rows singly, never BATCH_SIZE at a time.
+    That reproduces the pre-#24 access pattern exactly — same rows, same order,
+    same place a file boundary lands — so a val CE stays comparable to the
+    champion's 4.7092 and the #17 noise floor no matter what BATCH_SIZE is."""
+    for loader in (validation.ValidationProbe._load, common.load_eval_batches,
+                   depth_transfer.load_domain_batches):
+        src = inspect.getsource(loader)
+        assert "get_batch(1)" in src, (
+            f"{loader.__qualname__} must read one row per call; a get_batch(BATCH_SIZE) "
+            "read would resize the eval slice when the throughput knob moves."
+        )
+        assert "get_batch(BATCH_SIZE)" not in src
+
+
+def test_eval_probe_collects_exactly_eval_rows():
+    """The probe's slice size is EVAL_ROWS rows — a constant, not a function of
+    BATCH_SIZE."""
+    gen = _FakeGen()
+    batches = []
+    while len(batches) < EVAL_ROWS:
+        row, _ = gen.get_batch(1)
+        batches.append(row)
+    assert gen.calls == [1] * EVAL_ROWS
+    assert all(b.shape[0] == 1 for b in batches)
+
+
+def test_eval_batch_size_is_pinned_independent_of_training_batch():
+    """Eval builds the reasoner skeleton at batch 1 regardless of BATCH_SIZE:
+    its hunch_cache is shaped [batch, slots, dim] and every checkpoint we hold
+    was written when BATCH_SIZE was 1. Tying this to the training knob would
+    make stored checkpoints unrestorable."""
+    assert common.EVAL_BATCH_SIZE == 1
+
+
+WEIGHTS = [0.5, 0.3, 0.2]
+MICRO_STEPS = 1000
+
+
+@pytest.mark.parametrize("batch_size", [1, 2, 4])
+def test_resume_skip_scales_with_batch_size(batch_size):
+    """A resume at micro-step N must skip N x BATCH_SIZE samples. The total can
+    fall short by at most one sample per source (integer truncation) — never by
+    a FACTOR of BATCH_SIZE, which is the bug this guards."""
+    skips = samples_from_micro_steps(MICRO_STEPS, WEIGHTS, batch_size=batch_size)
+    expected = MICRO_STEPS * batch_size
+    assert expected - len(WEIGHTS) < sum(skips) <= expected
+
+
+def test_resume_skip_without_the_batch_factor_under_skips():
+    """The exact defect, stated: counting micro-steps as samples. It re-feeds the
+    model 1/BATCH_SIZE of its own history, and nothing crashes."""
+    correct = sum(samples_from_micro_steps(MICRO_STEPS, WEIGHTS))
+    buggy = sum(samples_from_micro_steps(MICRO_STEPS, WEIGHTS, batch_size=1))
+    assert correct == pytest.approx(buggy * BATCH_SIZE, rel=0.01)
+    if BATCH_SIZE > 1:
+        assert correct > buggy
+
+
+def test_recorded_sample_count_beats_rederiving_it():
+    """A checkpoint written at BATCH_SIZE=1 and resumed at 2: re-deriving from
+    micro-steps seeks twice as far as the run actually read, skipping a slice of
+    corpus it never saw. The recorded count lands exactly."""
+    micro_steps_trained, weights = 1000, [0.5, 0.3, 0.2]
+    truly_consumed = micro_steps_trained * 1          # it ran at batch 1
+
+    exact = split_samples(truly_consumed, weights)
+    rederived = samples_from_micro_steps(micro_steps_trained, weights, batch_size=2)
+
+    assert sum(exact) == pytest.approx(truly_consumed, abs=len(weights))
+    assert sum(rederived) == pytest.approx(2 * truly_consumed, abs=len(weights))
+
+
+def test_samples_seen_is_counted_not_derived():
+    """The consumed-sample counter must accumulate actual batch rows. Deriving it
+    at save time as step x BATCH_SIZE is wrong for the one run that needs it: a
+    resume whose history spans two different batch sizes."""
+    save_src = inspect.getsource(checkpoint_utils.save_checkpoint)
+    assert '"samples_seen": monitor.samples_seen' in save_src
+    assert "step * BATCH_SIZE" not in save_src
+    assert "monitor.samples_seen += batch.shape[0]" in inspect.getsource(trainer_mod.train_loop)
+
+
+def test_phase_flip_preserves_the_data_position():
+    """An SFT phase flip resets plateau state, never the consumed-sample count —
+    zeroing it would rewind the data stream to the start of the corpus."""
+    from monitor import LossMonitor
+
+    m = LossMonitor()
+    m.samples_seen = 123456
+    m.reset_for_new_phase(step=10)
+    assert m.samples_seen == 123456
+
+
+def test_pre_24_checkpoints_resume_exactly():
+    """A checkpoint with no samples_seen was written at BATCH_SIZE=1, so one
+    sample per micro-step is its exact position — not an approximation."""
+    restore_src = inspect.getsource(checkpoint_utils.load_or_create_checkpoint)
+    assert 'm_state.get("samples_seen", restored["step"])' in restore_src

--- a/tests/test_validation_probe.py
+++ b/tests/test_validation_probe.py
@@ -21,7 +21,7 @@ def test_validation_probe_scores_and_preserves_training_state(tiny_model, monkey
 
     if not trainer.DATA_ROOT:
         pytest.skip("DATA_ROOT not set")
-    monkeypatch.setattr(validation, "VAL_BATCHES", 1)
+    monkeypatch.setattr(validation, "VAL_ROWS", 1)
 
     probe = validation.ValidationProbe(trainer.DATA_ROOT)
     sentinel = jnp.ones_like(tiny_model.hunch_cache[...]) * 0.123

--- a/tools/bench_train_step.py
+++ b/tools/bench_train_step.py
@@ -45,6 +45,11 @@ def main():
     parser.add_argument("--warmup", type=int, default=10, help="untimed steps (includes compile)")
     parser.add_argument("--depth", type=int, default=8, help="reasoning steps (curriculum depth)")
     parser.add_argument("--modes", type=str, default="loop,kernel")
+    parser.add_argument("--batch", type=int, default=BATCH_SIZE,
+                        help="micro-batch rows (default: config BATCH_SIZE). Sweeping this "
+                             "measures how throughput scales with the forward's GEMM shape — "
+                             "the 1->2 rung is what stacking the two windows would buy without "
+                             "touching the data pipeline, the 2->4 rung is what real batching adds.")
     parser.add_argument("--no-remat-encdec", action="store_true",
                         help="disable per-block remat in encoder/decoder stacks (P5 config c)")
     parser.add_argument("--no-remat-reasoning", action="store_true",
@@ -56,7 +61,7 @@ def main():
     print(f"device: {jax.devices()[0]}")
     print(f"allocator: {os.environ.get('XLA_PYTHON_CLIENT_ALLOCATOR', '(default bfc)')} | "
           f"preallocate: {os.environ.get('XLA_PYTHON_CLIENT_PREALLOCATE', '(default true)')}")
-    print(f"depth: {args.depth} | steps: {args.steps} | warmup: {args.warmup} | "
+    print(f"depth: {args.depth} | batch: {args.batch} | steps: {args.steps} | warmup: {args.warmup} | "
           f"no_remat_encdec: {args.no_remat_encdec} | no_remat_reasoning: {args.no_remat_reasoning} | "
           f"attn_impl: {args.attn_impl or '(default)'}")
 
@@ -75,9 +80,9 @@ def main():
 
     rng = np.random.default_rng(0)
     batch = jnp.array(
-        rng.integers(0, VOCAB_SIZE, size=(BATCH_SIZE, 2 * MAX_SEQ_LEN + 1)), dtype=jnp.int32
+        rng.integers(0, VOCAB_SIZE, size=(args.batch, 2 * MAX_SEQ_LEN + 1)), dtype=jnp.int32
     )
-    no_boundary = jnp.zeros((BATCH_SIZE,), dtype=bool)
+    no_boundary = jnp.zeros((args.batch,), dtype=bool)
 
     def micro_step(i, sync):
         loss, out, grads, grad_norm = compute_grad_step(
@@ -99,7 +104,7 @@ def main():
     print(f"warmup (incl. compile): {time.time() - t0:.1f}s")
     report_memory("post-warmup")
 
-    tokens_per_step = BATCH_SIZE * 2 * MAX_SEQ_LEN
+    tokens_per_step = args.batch * 2 * MAX_SEQ_LEN
     for mode in args.modes.split(","):
         t0 = time.time()
         for i in range(args.steps):

--- a/tools/common.py
+++ b/tools/common.py
@@ -6,10 +6,18 @@ before importing jax through this module).
 
 import os
 
+import jax.numpy as jnp
 from flax import nnx
 import orbax.checkpoint as ocp
 
-from config import LATENT_DIM, BATCH_SIZE, MODEL_ARCH, resolve_root
+from config import LATENT_DIM, MODEL_ARCH, resolve_root
+
+# Eval builds and scores at batch 1, never at the training BATCH_SIZE (#24). The
+# reasoner's vestigial hunch_cache is shaped [batch, slots, dim] and its forward
+# asserts on the leading dim, so a reasoner skeleton built at the training batch
+# would fail to restore every checkpoint we have — all written when BATCH_SIZE
+# was 1 — for no benefit, since eval reads a handful of rows.
+EVAL_BATCH_SIZE = 1
 from model import UniversalReasoner
 from data_loaders import TextDataGenerator
 from checkpoint_utils import discover_latest_checkpoint_run
@@ -47,7 +55,7 @@ def build_model():
     if MODEL_ARCH == "refiner":
         from plan_a_trainer import RefinerForTraining
         return RefinerForTraining(LATENT_DIM, nnx.Rngs(42))
-    return UniversalReasoner(LATENT_DIM, nnx.Rngs(42))
+    return UniversalReasoner(LATENT_DIM, nnx.Rngs(42), batch_size=EVAL_BATCH_SIZE)
 
 
 def restore_model(checkpoint_path=None):
@@ -59,7 +67,8 @@ def restore_model(checkpoint_path=None):
 
 def restore_reasoner(checkpoint_path=None):
     """Reasoner restore regardless of MODEL_ARCH, for explicit --arch overrides."""
-    return _restore_into(UniversalReasoner(LATENT_DIM, nnx.Rngs(42)), checkpoint_path)
+    return _restore_into(
+        UniversalReasoner(LATENT_DIM, nnx.Rngs(42), batch_size=EVAL_BATCH_SIZE), checkpoint_path)
 
 
 def restore_refiner(checkpoint_path=None):
@@ -71,12 +80,17 @@ def restore_refiner(checkpoint_path=None):
     return _restore_into(RefinerForTraining(LATENT_DIM, nnx.Rngs(42)), checkpoint_path)
 
 
-def load_eval_batches(source="pretrain/fineweb-edu", num_batches=16, skip=3_000_000):
-    """Held-out batches: skip past the data the training run has consumed.
+def load_eval_batches(source="pretrain/fineweb-edu", num_rows=16, skip=3_000_000):
+    """Held-out rows: skip past the data the training run has consumed.
 
     The default skip sits far beyond plausible consumption (an 8k-opt-step run
     reads under 1M fineweb samples of its 4.3M) — the old 200k default was
-    inside the range long runs train through, contaminating the eval slice."""
+    inside the range long runs train through, contaminating the eval slice.
+
+    Counted in ROWS and scored one row at a time, independent of BATCH_SIZE
+    (#24): the eval slice must not move when a training throughput knob does, or
+    every recorded yardstick number stops being comparable. Batch-1 is also the
+    shape every stored checkpoint of both arches was written at."""
     data_root = os.environ.get("DATA_ROOT", "")
     if not data_root:
         raise SystemExit("DATA_ROOT is not set.")
@@ -85,11 +99,11 @@ def load_eval_batches(source="pretrain/fineweb-edu", num_batches=16, skip=3_000_
     gen = TextDataGenerator(source_dir)
     gen.skip_count = skip
     batches = []
-    while len(batches) < num_batches:
-        batch, _ = gen.get_batch(BATCH_SIZE)
-        if batch is None:
+    while len(batches) < num_rows:
+        row, _ = gen.get_batch(1)
+        if row is None:
             break
-        batches.append(batch)
+        batches.append(row)
     if not batches:
         raise SystemExit(f"No eval data available in {source_dir} after skipping {skip} samples.")
     return batches

--- a/tools/eval_refiner_depth_transfer.py
+++ b/tools/eval_refiner_depth_transfer.py
@@ -75,19 +75,23 @@ def restore_refiner(checkpoint_path=None):
     return model, latest
 
 
-def load_domain_batches(source, num_batches, skip):
-    """Held-out batches for one domain, skipping past the trained range."""
+def load_domain_batches(source, num_rows, skip):
+    """Held-out rows for one domain, skipping past the trained range.
+
+    Counted in ROWS and scored one row at a time (#24), so the slice this depth
+    curve is measured over does not move when the batching knob does — same
+    reasoning as tools/common.load_eval_batches."""
     data_root = os.environ.get("DATA_ROOT", "")
     if not data_root:
         raise SystemExit("DATA_ROOT is not set (try DATA_ROOT=runs/data).")
     gen = TextDataGenerator(f"{resolve_root(data_root)}/{source}")
     gen.skip_count = skip
     batches = []
-    while len(batches) < num_batches:
-        batch, _ = gen.get_batch(BATCH_SIZE)
-        if batch is None:
+    while len(batches) < num_rows:
+        row, _ = gen.get_batch(1)
+        if row is None:
             break
-        batches.append(batch)
+        batches.append(row)
     return batches
 
 

--- a/tools/eval_yardstick.py
+++ b/tools/eval_yardstick.py
@@ -35,8 +35,8 @@ import tiktoken
 from flax import nnx
 from dotenv import load_dotenv
 
-from config import BATCH_SIZE, MAX_SEQ_LEN, PAD_TOKEN_ID, TOKENIZER_NAME, MODEL_ARCH
-from tools.common import restore_reasoner, restore_refiner
+from config import MAX_SEQ_LEN, PAD_TOKEN_ID, TOKENIZER_NAME, MODEL_ARCH
+from tools.common import EVAL_BATCH_SIZE, restore_reasoner, restore_refiner
 from tools.yardstick import (
     GPT2_SMALL_REFERENCE,
     LAMBADA_SHA256,
@@ -106,11 +106,13 @@ def main():
     ap.add_argument("--no-heldout", action="store_true", help="skip the own-corpus ppl probe")
     args = ap.parse_args()
 
-    if args.arch == "reasoner" and args.batch != BATCH_SIZE:
-        # The reasoner's slot/hunch caches are built (and checkpointed) at
-        # BATCH_SIZE; its forward asserts on any other leading dim.
-        print(f"⚠️ reasoner arch: clamping --batch {args.batch} -> {BATCH_SIZE}.")
-        args.batch = BATCH_SIZE
+    if args.arch == "reasoner" and args.batch != EVAL_BATCH_SIZE:
+        # The reasoner's slot/hunch caches are built (and checkpointed) at the
+        # eval batch size; its forward asserts on any other leading dim. This is
+        # EVAL_BATCH_SIZE, not the training BATCH_SIZE (#24) — the yardstick must
+        # keep restoring checkpoints written before batching changed.
+        print(f"⚠️ reasoner arch: clamping --batch {args.batch} -> {EVAL_BATCH_SIZE}.")
+        args.batch = EVAL_BATCH_SIZE
     restore = {"reasoner": restore_reasoner, "refiner": restore_refiner}[args.arch]
     model, step = restore(args.checkpoint_path)
 

--- a/tools/overfit_smoke.py
+++ b/tools/overfit_smoke.py
@@ -49,7 +49,9 @@ def main():
                         help="number of blocks (shrink for CPU CI; must be even)")
     args = parser.parse_args()
 
-    model = UniversalReasoner(args.dim, nnx.Rngs(0), num_blocks=args.blocks)
+    # batch_size pinned at 1, not the training BATCH_SIZE: this smoke feeds a
+    # single row, and the reasoner's hunch cache asserts on the leading dim.
+    model = UniversalReasoner(args.dim, nnx.Rngs(0), num_blocks=args.blocks, batch_size=1)
     optimizer = nnx.Optimizer(
         model,
         optax.chain(optax.clip_by_global_norm(1.0), optax.adamw(args.lr)),
@@ -60,7 +62,7 @@ def main():
         batch = jnp.asarray(rng.integers(1, 5000, size=(1, 2 * MAX_SEQ_LEN + 1)), dtype=jnp.int32)
     else:
         from tools.common import load_eval_batches
-        batch = load_eval_batches(num_batches=1, skip=0)[0]
+        batch = load_eval_batches(num_rows=1, skip=0)[0]
 
     initial_ce = None
     final_ce = None

--- a/trainer.py
+++ b/trainer.py
@@ -71,6 +71,30 @@ def _param_count(model):
     return sum(int(x.size) for x in jax.tree_util.tree_leaves(nnx.state(model, nnx.Param)))
 
 
+def split_samples(total_samples, weights):
+    """Split a sample count across sources by mixture weight.
+
+    The unit that resume correctness hangs on: TextDataGenerator's skip_count is
+    in SAMPLES, while every step counter in this trainer is in MICRO-STEPS, and
+    each micro-step draws BATCH_SIZE samples across the mixer (#24). Callers pass
+    the SAMPLE total — read from the checkpoint, not re-derived from steps — so
+    a run that resumes under a different batch size than it was trained at still
+    seeks to the right place. Getting this wrong is silent either way: too small
+    and the model re-trains on data it already saw, too large and it skips a
+    slice of corpus it never read. No crash, no warning, just a bad run.
+
+    Per-source truncation is deliberate: skip_count is an integer sample offset,
+    so the total can fall short by at most one sample per source.
+    """
+    return [int(total_samples * w) for w in weights]
+
+
+def samples_from_micro_steps(micro_steps, weights, batch_size=BATCH_SIZE):
+    """split_samples for the case with no recorded sample count — a pre-#24
+    checkpoint, or a fresh run. Converts micro-steps at the given batch size."""
+    return split_samples(micro_steps * batch_size, weights)
+
+
 def init_model_and_optimizer():
     if MODEL_ARCH == "refiner":
         # Imported lazily so the baseline path never touches Plan A code.
@@ -96,7 +120,7 @@ def init_model_and_optimizer():
 
     return model, optimizer
 
-def setup_data_pipeline(start_step, sft_phase_event, sft_start_step=None):
+def setup_data_pipeline(start_step, sft_phase_event, sft_start_step=None, samples_seen=None):
     print("🚀 Initializing Dynamic Data Phases...")
     pretrain_sources = [
         TextDataGenerator(f"{DATA_ROOT}/pretrain/fineweb-edu"),
@@ -115,23 +139,29 @@ def setup_data_pipeline(start_step, sft_phase_event, sft_start_step=None):
 
     if start_step > 1:
         start_opt_step = start_step // ACCUMULATION_STEPS
+        # Prefer the recorded sample count over re-deriving it from micro-steps
+        # (#24): only the recorded figure survives a change in BATCH_SIZE between
+        # the run that wrote the checkpoint and the one resuming it.
         if sft_start_step is None or start_step < sft_start_step:
-            total_pretrain_seen = (start_step - 1)
             avg_weights = get_average_curriculum_weights(start_opt_step)
-            for gen, weight in zip(pretrain_sources, avg_weights):
-                gen.skip_count = int(total_pretrain_seen * weight)
+            skips = (split_samples(samples_seen, avg_weights) if samples_seen is not None
+                     else samples_from_micro_steps(start_step - 1, avg_weights))
+            for gen, skip in zip(pretrain_sources, skips):
+                gen.skip_count = skip
         else:
-            # 1. Catch up pretrain sources to the point where pretraining ended
+            # 1. Catch up pretrain sources to the point where pretraining ended.
+            # The pretrain/SFT split is still counted in micro-steps: samples_seen
+            # is a single total and does not say where the phase boundary fell.
             sft_start_opt_step = sft_start_step // ACCUMULATION_STEPS
-            total_pre_pretrain_seen = (sft_start_step - 1)
             avg_weights = get_average_curriculum_weights(sft_start_opt_step)
-            for gen, weight in zip(pretrain_sources, avg_weights):
-                gen.skip_count = int(total_pre_pretrain_seen * weight)
+            skips = samples_from_micro_steps(sft_start_step - 1, avg_weights)
+            for gen, skip in zip(pretrain_sources, skips):
+                gen.skip_count = skip
 
             # 2. Add SFT usage for all blended sources (Chat + Replay)
-            total_sft_seen = (start_step - sft_start_step)
-            for gen, weight in zip(sft_sources, SFT_MIX_WEIGHTS):
-                gen.skip_count += int(total_sft_seen * weight)
+            sft_skips = samples_from_micro_steps(start_step - sft_start_step, SFT_MIX_WEIGHTS)
+            for gen, skip in zip(sft_sources, sft_skips):
+                gen.skip_count += skip
 
     data_queue = queue.Queue(maxsize=PREFETCH_SIZE)
 
@@ -179,6 +209,12 @@ def train_loop(model, optimizer, data_queue, mngr, best_mngr, monitor, start_ste
             batch, doc_boundary = data_queue.get()
             if batch is None:
                 break
+
+            # Count consumed samples as they are consumed (#24). Deriving this at
+            # save time as step x BATCH_SIZE would be wrong for exactly the run
+            # that needs it most: one resumed at a different batch size than it
+            # was trained at, whose history spans both.
+            monitor.samples_seen += batch.shape[0]
 
             t_compute_start = time.time()
 

--- a/validation.py
+++ b/validation.py
@@ -8,10 +8,10 @@ import jax.numpy as jnp
 import optax
 from flax import nnx
 
-from config import BATCH_SIZE, MAX_SEQ_LEN, PAD_TOKEN_ID
+from config import EVAL_ROWS, MAX_SEQ_LEN, PAD_TOKEN_ID
 from data_loaders import TextDataGenerator
 
-VAL_BATCHES = 4
+VAL_ROWS = EVAL_ROWS
 VAL_FIXED_DEPTH = 4
 # Far past any plausible training consumption (an 8k-opt-step run consumes
 # under 1M fineweb samples; fineweb holds 4.3M) so the slice stays held out.
@@ -37,7 +37,7 @@ def _val_ce_sums(model, batch):
 
 
 class ValidationProbe:
-    """Loads VAL_BATCHES fixed held-out batches once, then scores them on demand.
+    """Loads VAL_ROWS fixed held-out rows once, then scores them on demand.
     Restores the training stream's carried hunch afterwards, so validating never
     perturbs training."""
 
@@ -48,12 +48,16 @@ class ValidationProbe:
     def _load(self):
         gen = TextDataGenerator(f"{self.data_root}/pretrain/fineweb-edu")
         gen.skip_count = VAL_SKIP_SAMPLES
+        # One row per batch, independent of BATCH_SIZE (#24): this reproduces the
+        # pre-#24 read pattern exactly — including where a file boundary lands
+        # mid-slice — so the measured val CE stays comparable to every number
+        # already recorded. Batching a 4-row probe would buy nothing anyway.
         batches = []
-        while len(batches) < VAL_BATCHES:
-            batch, _ = gen.get_batch(BATCH_SIZE)
-            if batch is None:
+        while len(batches) < VAL_ROWS:
+            row, _ = gen.get_batch(1)
+            if row is None:
                 break
-            batches.append(batch)
+            batches.append(row)
         if not batches:
             print("⚠️ Validation disabled: no held-out data available past the skip range.")
         return batches


### PR DESCRIPTION
Branch name is a leftover from #135 (killed — see below); the contents are #24.

## What this does

`BATCH_SIZE 1 -> 2`, `ACCUMULATION_STEPS 128 -> 64`. Their product is held fixed at `TOKENS_PER_OPT_STEP = 131072`, so the LR cosine, the token budget, and the learning dynamics are identical. Same model, fewer resources.

**Measured: 5.0k -> 7.2k tok/s at depth 4 (+43%)** on the RTX 2060, dim960 refiner; +40% at depth 8 (4.2k -> 5.9k). Matched pairs, same seeds, idle card.

> **Numbers re-measured before merge.** The original sweep (3.6k -> 4.9k, +36%) was taken while a training job was still sharing the GPU, which depressed both arms. The ratio survived the confound; the absolutes did not. The idle-card figures above are the ones to trust, and are what `config.py` now records.

## Why — and why #24's stated premise was wrong

#24 framed this as a GEMM-shape win freed up by #19's VRAM savings. Both halves turn out to be wrong.

A probe timing fwd+bwd alone against fwd+bwd+`apply_grads`:

| | fwd+bwd | +apply_grads | optimizer cost |
|---|---|---|---|
| B=1 | 201.7 ms | 270.3 ms | **68.6 ms** |
| B=2 | 331.0 ms | 400.1 ms | **69.1 ms** |

The real driver is a **flat ~69 ms per micro-step** of Adam + global-norm clip over 138.7M params — **25% of a batch-1 step**, completely independent of batch size. Fatter micro-steps amortize it.

And **VRAM was never the blocker**: batch 2 peaks at 4.35 GB of 6 GB, indistinguishable from batch 1's 4.48 GB (footprint is param/optimizer-state dominated; even batch 4 fits at 4.99 GB).

**The independent-streams pipeline project is not needed for the throughput win.** `data_loaders.py` already serves `batch_size > 1` by chopping one contiguous slab into rows. Independent streams stay open as a separate *gradient-diversity* question — an `idea` to be judged on loss, not an `optimization` judged on speed.

`blocked` label is stale: #19 and #16 are both closed.

## Four silent-failure modes found and fixed

None of these would have crashed. Each would have produced a plausible-looking, invalid run.

1. **Resume re-trained on its own history.** `trainer.py:122` counted micro-steps as samples, so a resume under-skipped by exactly `BATCH_SIZE`. Extracted into a tested `split_samples` / `samples_from_micro_steps` pair.
2. **The eval slice moved with the training knob.** `validation.py`, `tools/common.py`, and `tools/eval_refiner_depth_transfer.py` all sized the held-out set as *`BATCH_SIZE` batches*. At B=2 that doubles the slice and redefines `val_ce`, destroying comparability with the champion's 4.7092, the #17 noise floor (sigma~0.03), and the time machine's +/-0.06 reproduction check. Now counted in `EVAL_ROWS` rows and scored at batch 1 unconditionally.
3. **Stored checkpoints would have become unrestorable.** The reasoner's `hunch_cache` is `[batch, slots, dim]` and its forward asserts on the leading dim, so building the eval skeleton at the *training* batch would have broken every checkpoint we hold — including the #16 control run. Eval now pins `EVAL_BATCH_SIZE = 1`.
4. **Resume seeked past unseen corpus.** Only the micro-step count was persisted, with samples-consumed derived from it — so resuming a batch-1 checkpoint at batch 2 seeked *twice as far as the run actually read*, skipping a slice it had never seen. `samples_seen` is now counted as rows are served and stored in the checkpoint. Checkpoints lacking it were all written at `BATCH_SIZE=1`, so the step count is their exact position, not an approximation.

## Golden run: NOT re-recorded, contrary to #24

#24 says the golden run needs regenerating because data order changes. It does not: `tests/test_golden_run.py` builds its own `batch_size=1` model with its own fixed batch, and its five steps all resolve to `opt_step 0` under either accumulation setting. **Verified rather than assumed** — `RUN_GOLDEN=1` passes against the stored trajectory, file unchanged.

## Testing

- Full suite green: **150 passed, 2 skipped**.
- Golden run: **passes**, stored trajectory unchanged.
- **12 new invariant tests** (`tests/test_batching_invariants.py`) pinning each property above — the token-per-opt-step contract, row-counted eval reads, the pinned eval batch, resume scaling, and that an SFT phase flip cannot rewind the data position.

## Related

#135 (stacking the two window forwards) was closed `negative-result` in the course of this work: measured +3.0% against a pre-registered 20% gate. Its diagnosis is what identified the ~69 ms optimizer cost as the real target, and it is why this PR exists in its current form.

Refs #24
