### PR TITLE
Tombstone the #39 raw-latent cosine-halting kill (PR #96's record)

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -109,11 +109,14 @@ the v1 leak that had to be amputated).
   gap versus the parallel-slot control. Runs on the tiny ablation harness
   (minutes), so it is a cpu-lane bet, not a real-model run.
 - **Parked refinements — gated behind the proof; adding them now confounds it:**
-  - *Convergence halting* — #39: stop refining when the latent stops moving
-    (cosine of step k vs k-1 below a threshold). This is the Deep-Equilibrium /
+  - *Convergence halting* — #39: stop refining when the state stops moving
+    (cosine of step k vs k-1 above a threshold). This is the Deep-Equilibrium /
     fixed-point family and the 2025 recurrent-depth line (Geiping et al.), NOT
     learned per-token halting (ACT, which is killed below). Not novel as a
     mechanism; worth it for adaptive compute (fewer steps on easy tokens).
+    **The raw-latent signal is dead** (see Graveyard) — #39 now carries the one
+    variant that measurement pointed at instead: the same rule on the *grade
+    logits*, which separate cleanly where the latents do not.
   - *Slot dimensionality / "vagueness"* — a wide continuous slot can hold a soft,
     under-specified idea (superposition) where a token must commit; the state
     starts vague and sharpens toward commitment — which is what convergence
@@ -174,6 +177,22 @@ its PR.
   causal decode positions, the textbook non-causal-path bug. Pre-fix "depth lowers
   CE" readings were leak bandwidth, not refinement (see the hunch-inert finding's
   pre/post contrast). Guards: both causality tests in `tests/test_model_invariants.py`.
+- **cosine halting on the serial scratchpad — raw-latent signal** (#39, 2026-07-15,
+  PR #96, closed unmerged; this line is the record): halting the write loop at the
+  first slot with cosine(s_k, s_{k−1}) > τ cannot trade writes for accuracy. On an
+  identity-tail split (oracle 3.25 writes against the fixed 4), 3 seeds: τ ∈ {0.5,
+  0.7} do save (3.30 / 3.48 writes) but cost 0.14–0.17 accuracy (≈3–4σ_pooled), and
+  every τ ≥ 0.98 holds accuracy while saving nothing (≥3.99 writes). Two crumbs
+  worth keeping. (a) Converged and computing steps overlap badly in raw-latent
+  cosine (0.59–0.65 ± 0.24 vs ≈0.01 ± 0.18); the leading *hypothesis* is that the
+  slot-index embedding keeps even frozen-value latents apart — unmeasured, and the
+  labels there also fire on coincidental residue collisions (~11% of "converged"
+  steps), so treat both distributions as indicative, not as measured cause. (b) The
+  same signal read on the **grade logits** separates cleanly (≈0.86 vs ≈−0.14) and
+  was never run as a halting rule — that is the live follow-up, #39. Note this kills
+  a *signal*, not adaptive depth: a genuinely iterated state (the refiner's depth
+  loop) never had a fixed point removed from under it the way a write-once
+  scratchpad does.
 
 ### Killed in the #10 triage (with reasons, so they stay dead)
 - **per-token halting / ACT**: collapses at small scale — documented dead-end.


### PR DESCRIPTION
## Summary
Doc-only. PR #96 ran the pre-registered #39 halting ablation and hit its KILL branch, but it cannot be merged. Rule 5 says a PR closed unmerged still owes its record, and for a non-novel result the record is the graveyard line — so the measurement lands here, then #96 gets closed as `superseded-by`.

## Why #96 can't be merged
- It refactors `ScratchpadNet.__call__` into `encode`/`write_slots`. #116 rewrote that same function underneath it (`encode_links`, `local_writer`), and the extracted methods have neither branch — resolving the conflict in #96's favour would silently make the `*_local` arms write from all tokens instead of link *k*, invalidating the #116/#118 slot-parking findings with no test failure.
- It adds `affine_chain_varlen_task`, which #123 already landed as `variable_chain_task` — and #96's version discards the sampled effective length, so per-instance halt correctness (`corr(halt step, k_eff)`) isn't measurable from it.

Rebasing costs more than rewriting the ~40 lines that would survive. The numbers, though, are three CPU runs that shouldn't be re-spent.

## What the tombstone records — and what it deliberately doesn't
**Measured (label-free, so it stands):** on the identity-tail split (oracle 3.25 writes vs the fixed 4), 3 seeds — τ ∈ {0.5, 0.7} save (3.30 / 3.48 writes) but cost 0.14–0.17 accuracy (≈3–4σ_pooled); every τ ≥ 0.98 holds accuracy and saves nothing (≥3.99 writes). No τ on the pre-registered grid satisfies the KEEP criteria.

**Downgraded to hypothesis:** #96 explained the kill by "the slot-index embedding keeps even frozen-value latents apart", resting on converged-vs-computing cosine distributions (0.59–0.65 ± 0.24 vs ≈0.01 ± 0.18). Those classes are labelled `r_k == r_{k-1}`, which also fires when a *live* affine step coincidentally returns the same residue — measured at **11.4% of "converged" steps** (20k samples, K=4, m=7). Contamination in that direction is exactly what widens the converged distribution, so the tombstone reports the numbers as indicative and marks the mechanism unmeasured. The ladder verdict is unaffected.

**Handed forward:** the pre-registered secondary — the same rule on the grade logits — separates ≈0.86 vs ≈−0.14 on the same forward pass, and was never run as a halting rule. That is the re-scoped #39, not a closed question.

Also narrows the claim: this kills a *signal*, not adaptive depth. A write-once scratchpad has no iterated state for a fixed-point detector to find; the refiner's depth loop does.

## Drive-by fix
The parked-refinement bullet described the rule backwards — "cosine of step k vs k-1 **below** a threshold". Halting fires when cosine is *high*. Corrected.

## Validation / smoke-test performed
- [x] Doc-only: single file, `docs/ROADMAP.md`, +21/−2. No code, no tests, no deps touched.
- The 11.4% contamination figure and the K=1 / `upto` edge cases cited in review were measured against #96's head in a throwaway worktree (since removed); #96's own test file passes 16/16 there.

## Risk
None — markdown only. Per the working agreement, doc-only changes need no issue and can land any time, including mid-run.

## Follow-ups (not in this PR)
1. Re-scope #39 to the grade-logit detector on `variable_chain_task`, primary metric `corr(halt step, k_eff)`; drop its stale `blocked` label.
2. Once this merges, close #96 with `superseded-by #39`.

## Checklist
- [x] Did not weaken or delete any test
- [x] Smoke-tested (n/a — doc-only)
- [x] Pinned deps unchanged
- [x] Claims backed by evidence (#96's run tables; the contamination figure re-measured)

🤖 Generated with [Claude Code](https://claude.com/claude-code)