### PR TITLE
#105: flip the trainer's model contract — live architectures stop impersonating the dead reasoner

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -225,6 +225,7 @@ experiment (the arch behind the flag):
 | **Config (single source of truth)** | `config.py` — every architecture/training constant, the dtype policy, the arch selector |
 | **Model — live** | `plan_a_model.py` (CausalRefiner), `layers.py` |
 | **Model — control/graveyard** | `model.py` (UniversalReasoner) |
+| **Model contract** | `lm_contract.py` — what the loop requires of a model (tokens + depth → predictions + auxiliary terms). Every arch implements this; the loop knows nothing else about any of them |
 | **Training loop** | `trainer.py` (loop + data pipeline; + `plan_a_trainer.py` adapter), `start_training.py` (entry), `grad_step.py`, `optimizers.py`, `schedules.py`, `validation.py` (held-out probe) |
 | **Data** | `prefill.py` (tokenize corpus → `runs/data/`), `data_loaders.py`, `tools/data_curation/` |
 | **Persistence & run state** | `checkpoint_utils.py`, `run_tracker.py`, `metrics_logger.py`, `monitor.py` |

--- a/checkpoint_utils.py
+++ b/checkpoint_utils.py
@@ -54,6 +54,44 @@ def _make_best_manager(checkpoint_path):
     )
 
 
+def restore_tolerating_legacy(read, model, model_key="model"):
+    """Restore, tolerating variables a *past* version of this model saved and the
+    current one no longer defines.
+
+    Orbax matches structure strictly, which is what we want: a checkpoint missing
+    weights the model needs must fail loudly rather than load half a network in
+    silence. But strictness also orphans a checkpoint the moment a buffer is
+    deleted — and #105 deleted the refiner's vestigial hunch buffer, which every
+    base-run checkpoint on disk still carries. So: read with the honest structure
+    first, and only if that mismatches, retry with the buffers the model itself
+    declares its old checkpoints held (`legacy_checkpoint_variables`), dropping
+    them from the result. Both attempts are strict, so nothing else slips through.
+
+    `read(model_target)` performs the actual restore and returns the item dict.
+    """
+    try:
+        return read(nnx.state(model))
+    except ValueError as mismatch:
+        legacy = model.legacy_checkpoint_variables()
+        if not legacy:
+            raise
+        target = nnx.state(model)
+        for name, leaf in legacy.items():
+            if name in target:
+                raise
+            target[name] = nnx.Variable(leaf)
+        try:
+            restored = read(target)
+        except ValueError:
+            # The legacy buffers weren't the explanation — report the real mismatch.
+            raise mismatch
+        print(f"📼 Pre-#105 checkpoint: ignoring {', '.join(legacy)} "
+              f"(vestigial, never read by this model).")
+        for name in legacy:
+            del restored[model_key][name]
+        return restored
+
+
 def save_checkpoint(mngr, step, model, optimizer, monitor, sft_active, run_id):
     """Persist the full training state (model + optimizer + monitor + step) under
     `mngr` at `step`, then block until the write lands. Shared by the
@@ -97,14 +135,17 @@ def load_or_create_checkpoint(model, optimizer, checkpoint_path, force_new_run=F
     if not force_new_run and mngr.latest_step() is not None:
         latest_step = mngr.latest_step()
         print(f"📖 Loading Orbax checkpoint from step {latest_step}...")
-        restored = mngr.restore(
-            latest_step,
-            args=ocp.args.Composite(
-                model=ocp.args.StandardRestore(nnx.state(model)),
-                optimizer=ocp.args.StandardRestore(nnx.state(optimizer)),
-                monitor_state=ocp.args.JsonRestore(),
-                step=ocp.args.JsonRestore(),
+        restored = restore_tolerating_legacy(
+            lambda model_target: mngr.restore(
+                latest_step,
+                args=ocp.args.Composite(
+                    model=ocp.args.StandardRestore(model_target),
+                    optimizer=ocp.args.StandardRestore(nnx.state(optimizer)),
+                    monitor_state=ocp.args.JsonRestore(),
+                    step=ocp.args.JsonRestore(),
+                ),
             ),
+            model,
         )
 
         nnx.update(model, restored["model"])

--- a/docs/design/plan-a.md
+++ b/docs/design/plan-a.md
@@ -39,9 +39,17 @@ Refinement loop (replaces `_reasoning_loop`) — `jax.lax.scan` over K steps, ca
 - diag per step: drift `‖z_new − z‖` (reuse temporal_drift logic).
 
 **Removed:** the 32 shared slots and slot cross-attention; the InfoNCE slot-stability
-/ diversity loss (no analogue on per-position states); `hunch_cache`, `should_refresh`,
-and the hunch gate (cross-window memory, proven dead — Plan A is within-window only);
-the slot-reading decoder cross-attention.
+/ diversity loss (no analogue on per-position states); `hunch_cache`, the hunch gate,
+and any notion of refreshing carried state (cross-window memory, proven dead — Plan A
+is within-window only); the slot-reading decoder cross-attention.
+
+Until #105 the *trainer* still required all of that, so the adapter had to fake it:
+a zero forget cost and a zero diversity loss for the schedules to multiply, and a
+never-read `hunch_cache` for the loop's bookkeeping to write into. The trainer now
+speaks a neutral contract (`lm_contract.py`) and the fakes are gone — Plan A
+implements a forward pass and nothing else. What a window means for a model that
+carries state between windows is expressed as `new_document`, a fact about the data;
+Plan A ignores it because it genuinely carries nothing.
 
 **Kept:** `RotaryAttention` with explicit causal mask (leak-correct since the scale
 fix); random-depth sampling (`sample_reasoning_depth`); `time_embed`; the
@@ -69,6 +77,38 @@ tiny-config ablation harness:
   causal depth recurrence works — the claim the hunch failed to support.
 - **Grokking watch:** these tasks show clean train→generalization transitions fast;
   depth recurrence is expected to grok where depth-1 cannot.
+
+## Why the two arches don't share block code (the decision, written down once)
+
+`layers.py` (reasoner blocks) and `plan_a_model.py` (the refiner's shared block)
+implement the same SwiGLU transformer block twice. That duplication is
+**deliberately frozen, not waiting to be shared** — and #105 is where the choice
+got recorded instead of re-litigated on sight:
+
+- The reasoner is now a *frozen control*. Its value is that a matched pair can be
+  re-run against it, and the trained v1 control checkpoint can be revived exactly
+  (#134). Refactoring its blocks — even into an identical-looking shared module —
+  risks the one property it exists to have.
+- So the rule is: the refiner's block is the one that evolves; the reasoner's is
+  touched only to keep it *runnable*, never to make it prettier.
+
+The cost of that freeze is worth stating plainly, because it is a trap for exactly
+the comparison this repo cares about. The two round the SwiGLU hidden width
+differently — reasoner up to a multiple of 256, refiner up to a multiple of 64:
+
+| `LATENT_DIM` | reasoner hidden | refiner hidden |
+|---|---|---|
+| 512 | 1536 | 1408 |
+| 960 (current) | 2560 | 2560 |
+
+They agree at 960 and disagree at 512. So "both arches at the same `LATENT_DIM`"
+is matched **by construction at some dims and only by coincidence at others** — at
+512 the reasoner carries a wider MLP for free. Any cross-arch parameter-matched
+claim must therefore quote *parameter counts*, not dim, and re-check them at the
+dim it actually ran (`trainer._param_count` prints them at launch). Note this is
+already the weaker kind of comparison — cross-model, observational, never causal
+(CLAUDE.md); the matched one-variable pair is what carries a cause, and it varies
+one knob within a single arch.
 
 ## Test gates (all green before any real-model run)
 

--- a/grad_step.py
+++ b/grad_step.py
@@ -7,35 +7,34 @@ from config import (
     ACCUMULATION_STEPS,
     PAD_TOKEN_ID,
 )
-from schedules import (
-    forget_lambda_schedule,
-    diversity_lambda_schedule,
-)
 from losses import chunked_cross_entropy_rows
 
-def compute_total_loss(ce1, ce2, out1, out2, f_lambda, d_lambda):
-    """Assembles the full training loss from both segments' outputs.
+def compute_total_loss(ce1, ce2, graded_aux):
+    """Assembles the full training loss: CE on both windows, plus whatever
+    auxiliary terms the architecture asked to have graded.
 
     Standalone (not buried in the jitted grad step) so the loss-wiring test can
-    assert every cost component actually contributes — a forget-cost term was
-    once computed and logged but never added here, and the model spent ~3900
+    assert every cost the model reports actually contributes — a forget-cost term
+    was once computed and logged but never added here, and the model spent ~3900
     opt steps not learning to forget.
 
-    Plain CE on both segments plus the two regularizers. The old refinement,
-    anchor, and ponder terms are gone: with the reasoning depth randomly sampled
-    per training step, "use the extra steps well" is enforced structurally
-    instead of through patch losses (which made copying step 1 the optimum).
+    This function knows no architecture's cost names: `graded_aux` arrives
+    already weighted from the model's own `grade_aux` (#105). Terms are added one
+    at a time in iteration order rather than summed as a group, so the arithmetic
+    an architecture's recorded trajectory was produced under is reproducible.
     """
-    return (ce1 + ce2) \
-           + d_lambda * (out1.diversity_loss + out2.diversity_loss) \
-           + f_lambda * (out1.forget_cost + out2.forget_cost)
+    total = ce1 + ce2
+    for term in graded_aux.values():
+        total = total + term
+    return total
 
 
-@nnx.jit(static_argnames=['max_steps'])
-def compute_grad_step(model, batch_tokens, step, max_steps, doc_boundary=False):
-    # A document boundary means the hunch cache holds state from an unrelated
-    # document — the model should start its slots fresh.
-    should_refresh = jnp.any(doc_boundary).squeeze()
+@nnx.jit(static_argnames=['depth'])
+def compute_grad_step(model, batch_tokens, step, depth, doc_boundary=False):
+    # Whether this batch opens a new document is a fact about the data stream;
+    # what a model does with it (start fresh, or continue from carried state) is
+    # the model's business.
+    new_document = jnp.any(doc_boundary).squeeze()
 
     def loss_fn(model):
         # Training models return pre-head states (out.hidden), not full logits, so the
@@ -46,8 +45,8 @@ def compute_grad_step(model, batch_tokens, step, max_steps, doc_boundary=False):
         seq1_in, seq1_out = batch_tokens[:, :MAX_SEQ_LEN], batch_tokens[:, 1:MAX_SEQ_LEN+1]
         seq2_in, seq2_out = batch_tokens[:, MAX_SEQ_LEN:2*MAX_SEQ_LEN], batch_tokens[:, MAX_SEQ_LEN+1:2*MAX_SEQ_LEN+1]
 
-        out1 = model(seq1_in, max_steps=max_steps, training=True, should_refresh=should_refresh)
-        out2 = model(seq2_in, max_steps=max_steps, training=True, should_refresh=False)
+        out1 = model(seq1_in, depth=depth, training=True, new_document=new_document)
+        out2 = model(seq2_in, depth=depth, training=True, new_document=False)
 
         # Both windows are scored in ONE chunked-CE scan, stacked on the batch axis:
         # two separate calls duplicated the [vocab, dim] f32 gradient plumbing across
@@ -70,10 +69,9 @@ def compute_grad_step(model, batch_tokens, step, max_steps, doc_boundary=False):
         }
 
         opt_step = step // ACCUMULATION_STEPS
-        f_lambda = forget_lambda_schedule(opt_step)
-        d_lambda = diversity_lambda_schedule(opt_step)
+        graded_aux = model.grade_aux([out1.aux, out2.aux], opt_step)
 
-        total_loss = compute_total_loss(ce1, ce2, out1, out2, f_lambda, d_lambda)
+        total_loss = compute_total_loss(ce1, ce2, graded_aux)
 
         # No NaN masking here: a non-finite loss must surface in the train loop
         # (which skips the update and aborts on a streak), not be silently zeroed.
@@ -91,18 +89,10 @@ def compute_grad_step(model, batch_tokens, step, max_steps, doc_boundary=False):
         return total_loss, out2
 
     (loss, out), grads = nnx.value_and_grad(loss_fn, has_aux=True)(model)
-    
-    current_hunch = model.hunch_cache[...]
-    cleared_hunch = jnp.zeros_like(current_hunch)
-    
-    # After the step, carry the hunch forward UNLESS a document boundary was hit
-    carried_hunch = jax.lax.cond(
-        should_refresh,
-        lambda: jax.lax.stop_gradient(cleared_hunch),
-        lambda: jax.lax.stop_gradient(current_hunch)
-    )
-    
-    model.hunch_cache[...] = carried_hunch
+
+    # Let the model settle whatever it carries into the next step. A stateless
+    # architecture does nothing here.
+    model.end_step(new_document)
 
     sq_norms = jax.tree_util.tree_map(lambda x: jnp.sum(jnp.square(x)), grads)
     grad_norm = jnp.sqrt(sum(jax.tree_util.tree_leaves(sq_norms)))

--- a/infer_local.py
+++ b/infer_local.py
@@ -26,11 +26,11 @@ HUNCH_REFRESH_EVERY = 4
 def run_model_inference(
     model: UniversalReasoner,
     tokens: jnp.ndarray,
-    max_steps: int = MAX_STEPS_LIMIT,
-    should_refresh: bool = True,
+    depth: int = MAX_STEPS_LIMIT,
+    new_document: bool = True,
 ) -> jnp.ndarray:
     out = model(
-        tokens, max_steps=max_steps, training=False, should_refresh=should_refresh
+        tokens, depth=depth, training=False, new_document=new_document
     )
     return out.logits
 
@@ -61,7 +61,7 @@ def _temperature_truncate(logits, temperature, top_k, top_p):
 
 @partial(nnx.jit, static_argnames=['refresh', 'top_k', 'top_p'])
 def get_logits_for_token(model, padded_tks, token_idx, refresh, top_k, top_p, temperature):
-    all_logits = run_model_inference(model, padded_tks, max_steps=MAX_STEPS_LIMIT, should_refresh=refresh)
+    all_logits = run_model_inference(model, padded_tks, depth=MAX_STEPS_LIMIT, new_document=refresh)
     logits = all_logits[0, token_idx, :]
     return _temperature_truncate(logits, temperature, top_k, top_p)
 
@@ -86,14 +86,14 @@ def generate_text(model, enc, prompt, max_new_tokens=256, temperature=0.5, top_k
         if valid_len >= MAX_SEQ_LEN:
             break
 
-        should_refresh = (i % HUNCH_REFRESH_EVERY == 0)
+        new_document = (i % HUNCH_REFRESH_EVERY == 0)
 
         # temperature=0 means greedy argmax below; pass 1.0 so the jitted
         # truncation step is a no-op scale rather than a division by zero.
         effective_temperature = temperature if temperature > 0.0 else 1.0
         logits = get_logits_for_token(
             model, input_ids, valid_len - 1,
-            refresh=should_refresh, top_k=top_k, top_p=top_p,
+            refresh=new_document, top_k=top_k, top_p=top_p,
             temperature=effective_temperature,
         )
 

--- a/layers.py
+++ b/layers.py
@@ -2,7 +2,6 @@ import jax
 import jax.numpy as jnp
 import optax
 from flax import nnx, struct
-from typing import Dict, Any
 
 from config import MAX_SEQ_LEN, MAX_STEPS_LIMIT, SHARED_SLOTS, NUM_GROUPS, COMPUTE_DTYPE
 from rope import rope_tables, apply_rope
@@ -12,18 +11,6 @@ class ScanStepOutput:
     shared_state: jnp.ndarray
     forget_val: jnp.ndarray
     step_div: jnp.ndarray
-
-@struct.dataclass
-class ReasonerOutput:
-    logits: jnp.ndarray
-    forget_cost: float
-    diversity_loss: float
-    diag: Dict[str, Any]
-    final_shared: jnp.ndarray
-    # Pre-head states [b, s, d], set instead of `logits` when training: the loss
-    # projects the LM head per-chunk (chunked CE, #19) to avoid the full
-    # [b, s, vocab] f32 logit peak. None at inference, where `logits` is filled.
-    hidden: jnp.ndarray = None
 
 class RotaryAttention(nnx.Module):
     def __init__(self, num_heads, in_features, num_groups=4, rngs=None):
@@ -121,6 +108,11 @@ class StandardReasoningBlock(nnx.Module):
         self.norm1 = nnx.RMSNorm(latent_dim, epsilon=1e-6, rngs=rngs, dtype=dtype)
         self.norm2 = nnx.RMSNorm(latent_dim, epsilon=1e-6, rngs=rngs, dtype=dtype)
 
+        # Rounded up to a multiple of 256 here; the refiner's block rounds to 64,
+        # so the two arches' MLPs differ at some dims and agree at others (512:
+        # 1536 vs 1408; 960: both 2560). That divergence is frozen on purpose —
+        # see "Why the two arches don't share block code" in docs/design/plan-a.md
+        # before matching a pair on LATENT_DIM rather than on parameter count.
         hidden_dim = int(256 * ((latent_dim * 8 / 3 + 255) // 256))
         self.gate_proj = nnx.Linear(latent_dim, hidden_dim, rngs=rngs, dtype=COMPUTE_DTYPE)
         self.up_proj = nnx.Linear(latent_dim, hidden_dim, rngs=rngs, dtype=COMPUTE_DTYPE)

--- a/lm_contract.py
+++ b/lm_contract.py
@@ -1,0 +1,86 @@
+"""What the training loop requires of a model — and nothing more.
+
+The loop speaks plain language-model: *here are tokens and a depth; give me
+predictions (or pre-head states for the chunked loss), plus any auxiliary terms
+you want graded.* Every architecture implements this; none of them has to wear
+another architecture's costume.
+
+The four hooks below all default to the stateless, no-extra-objective case, so a
+plain LM implements `__call__` and stops. An architecture that carries state
+between windows, or that has its own regularizers, overrides exactly the hooks
+it needs — and the shared loop stays free of its bookkeeping (#105).
+"""
+
+from contextlib import contextmanager
+from typing import Any, Dict
+
+import jax.numpy as jnp
+from flax import nnx, struct
+
+
+@struct.dataclass
+class LMOutput:
+    """One forward pass. Exactly one of `logits` / `hidden` is filled.
+
+    `hidden` (pre-head states, [b, s, d]) is what training returns: the loss
+    projects the LM head chunk-by-chunk (#19) so the full [b, s, vocab] f32
+    logit tensor is never materialized. Inference fills `logits` instead.
+    """
+
+    logits: jnp.ndarray = None
+    hidden: jnp.ndarray = None
+    # Unweighted auxiliary objectives, by name. The trainer never interprets
+    # these — it hands them back to grade_aux() and adds whatever comes out.
+    # A model with no extra objectives leaves this empty; it does NOT report
+    # zeros to keep a schedule company.
+    aux: Dict[str, jnp.ndarray] = struct.field(default_factory=dict)
+    # Telemetry. Read by the metrics logger, never differentiated.
+    diag: Dict[str, Any] = struct.field(default_factory=dict)
+
+
+class LanguageModel(nnx.Module):
+    """Base class carrying the neutral defaults. Subclass and override as needed."""
+
+    def __call__(self, tokens, depth, training=False, new_document=True) -> LMOutput:
+        """Score `tokens` using `depth` units of compute.
+
+        `new_document` says whether this window starts a fresh document — a fact
+        about the data stream, which a model carrying state across windows needs
+        and a stateless one can ignore.
+        """
+        raise NotImplementedError
+
+    def grade_aux(self, window_aux, opt_step):
+        """Weight this step's auxiliary terms into named scalars for the loss.
+
+        `window_aux` is the list of per-window `LMOutput.aux` dicts, in window
+        order. Returns {name: weighted scalar}; the trainer adds the values to
+        the cross-entropy in iteration order. Any schedule the weights follow
+        belongs here, in the architecture that owns the objective.
+        """
+        return {}
+
+    def reset_state(self):
+        """Drop whatever is carried between windows. Default: nothing is carried."""
+
+    def end_step(self, new_document):
+        """Settle carried state at the end of a training step. Default: no-op."""
+
+    @contextmanager
+    def isolated_state(self):
+        """Forward passes inside leave the carried training state untouched, so
+        an eval probe can never perturb the run measuring it. Default: there is
+        nothing to protect."""
+        yield
+
+    def legacy_checkpoint_variables(self):
+        """Variables that *past* versions of this model saved and this one no
+        longer defines, as {name: zeros_like_leaf}.
+
+        Restoring is a strict structural match, so a checkpoint written before a
+        buffer was removed cannot be read by a model that lacks it. Declaring
+        the buffer here lets checkpoint_utils match the on-disk shape and then
+        discard the value — without weakening the check that catches a
+        checkpoint genuinely missing weights the model needs.
+        """
+        return {}

--- a/metrics_logger.py
+++ b/metrics_logger.py
@@ -4,12 +4,21 @@ import fsspec
 import jax.numpy as jnp
 
 
+def _fmt(diags, key, places):
+    """A reported metric, or an empty cell if this architecture doesn't measure it."""
+    return f"{diags[key]:.{places}f}" if key in diags else ""
+
+
 class MetricsLogger:
     def __init__(self, history_file, start_opt_step=None):
         self.history_file = history_file
+        # Telemetry this logger knows how to write. A model reports the subset it
+        # actually measures (#105) — an architecture without a forget gate simply
+        # omits those keys, and their columns stay empty instead of being filled
+        # with zeros that look like measurements.
         self.diag_keys = [
             'temporal_drift', 'forget_density',
-            'diversity_loss', 'tau',
+            'forget_cost', 'diversity_loss', 'tau',
             'out_entropy', 'logz_mean', 'max_abs_logit',
         ]
         # Full set of fields for CSV
@@ -52,8 +61,9 @@ class MetricsLogger:
             print(f"⚠️ Could not trim replayed rows from {self.history_file}: {e}")
 
     def extract_diags(self, diag, jnp_mean_fn):
-        """Extracts and formats diagnostics from the model step using a provided mean function."""
-        return {k: float(jnp_mean_fn(diag.get(k, 0))) for k in self.diag_keys}
+        """Reduces the diagnostics this model reported to plain floats. Keys the
+        model did not report are absent, not zero."""
+        return {k: float(jnp_mean_fn(diag[k])) for k in self.diag_keys if k in diag}
 
     def log(self, step, ce, loss, out, compute_time,
             grad_norm_avg=None, seg1_ce=None, depth_avg=None, val_ce=None,
@@ -98,14 +108,14 @@ class MetricsLogger:
                 "seg1_ce": f"{seg1_ce:.4f}" if seg1_ce is not None else "",
                 "grad_norm_avg": f"{grad_norm_avg:.4f}" if grad_norm_avg is not None else "",
                 "zero_frac_dense_max": f"{zero_frac_dense_max:.6f}" if zero_frac_dense_max is not None else "",
-                "avg_forget_cost": f"{out.forget_cost:.4f}",
-                "diversity_loss": f"{out.diversity_loss:.6f}",
-                "temporal_drift": f"{diag_dict.get('temporal_drift', 0):.6f}",
-                "forget_density": f"{diag_dict.get('forget_density', 0):.6f}",
-                "tau": f"{diag_dict.get('tau', 0):.6f}",
-                "out_entropy": f"{diag_dict.get('out_entropy', 0):.4f}",
-                "logz_mean": f"{diag_dict.get('logz_mean', 0):.4f}",
-                "max_abs_logit": f"{diag_dict.get('max_abs_logit', 0):.2f}",
+                "avg_forget_cost": _fmt(diag_dict, "forget_cost", 4),
+                "diversity_loss": _fmt(diag_dict, "diversity_loss", 6),
+                "temporal_drift": _fmt(diag_dict, "temporal_drift", 6),
+                "forget_density": _fmt(diag_dict, "forget_density", 6),
+                "tau": _fmt(diag_dict, "tau", 6),
+                "out_entropy": _fmt(diag_dict, "out_entropy", 4),
+                "logz_mean": _fmt(diag_dict, "logz_mean", 4),
+                "max_abs_logit": _fmt(diag_dict, "max_abs_logit", 2),
                 "depth_avg": f"{depth_avg:.4f}" if depth_avg is not None else "",
                 "val_ce": f"{val_ce:.4f}" if val_ce is not None else "",
             }

--- a/model.py
+++ b/model.py
@@ -1,3 +1,5 @@
+from contextlib import contextmanager
+
 import jax
 import jax.numpy as jnp
 from flax import nnx
@@ -15,11 +17,12 @@ from config import (
 from layers import (
     BlockStack,
     ScanStepOutput,
-    ReasonerOutput,
     calculate_slot_stability_loss,
 )
+from lm_contract import LMOutput, LanguageModel
+from schedules import diversity_lambda_schedule, forget_lambda_schedule
 
-class UniversalReasoner(nnx.Module):
+class UniversalReasoner(LanguageModel):
     def __init__(self, latent_dim, rngs, num_blocks=NUM_BLOCKS, dtype=jnp.float32, use_forget=True, batch_size=BATCH_SIZE):
         self.latent_dim = latent_dim
         self.embed = nnx.Embed(VOCAB_SIZE, latent_dim, dtype=dtype, rngs=rngs)
@@ -89,7 +92,7 @@ class UniversalReasoner(nnx.Module):
         z_seq = self.encoder_stack(z_seq_base, mask=pad_bias, q_pos=seq_pos, kv_pos=seq_pos, is_causal=True, training=training)
         return z_seq, pad_mask, seq_pos
 
-    def _reasoning_loop(self, z_seq, pad_mask, seq_pos, max_steps, batch_size, z_shared, training=False):
+    def _reasoning_loop(self, z_seq, pad_mask, seq_pos, depth, batch_size, z_shared, training=False):
         # Fixed base positions for slot KV keys in the cross-attention context.
         # These stay constant across iterations — slots always appear at the same
         # position as memory keys. Only query positions advance with the iteration.
@@ -97,15 +100,15 @@ class UniversalReasoner(nnx.Module):
         shared_kv_pos = jnp.concatenate([seq_pos, base_shared_pos])
 
         # Precompute per-step slot query positions at trace time (Python loop).
-        # max_steps is a static_argname so this evaluates to a concrete constant array.
+        # depth is a static_argname so this evaluates to a concrete constant array.
         # XLA sees static integer constants rather than a dynamic gather/arithmetic,
         # which significantly reduces compilation time.
         all_step_shared_pos = jnp.array([
             list(range(MAX_SEQ_LEN + i * SHARED_SLOTS, MAX_SEQ_LEN + (i + 1) * SHARED_SLOTS))
-            for i in range(max_steps)
-        ])  # [max_steps, SHARED_SLOTS]
+            for i in range(depth)
+        ])  # [depth, SHARED_SLOTS]
 
-        all_time_embeds = self.time_embed(jnp.arange(max_steps))
+        all_time_embeds = self.time_embed(jnp.arange(depth))
 
         pad_part = (pad_mask.astype(jnp.float32) - 1.0) * 1e9
         slot_part = jnp.zeros((batch_size, SHARED_SLOTS), dtype=jnp.float32)
@@ -176,7 +179,7 @@ class UniversalReasoner(nnx.Module):
         return final_shared, all_outputs
 
 
-    def __call__(self, tokens, max_steps=MAX_STEPS_LIMIT, training=False, should_refresh=True):
+    def __call__(self, tokens, depth=MAX_STEPS_LIMIT, training=False, new_document=True):
         batch_size = tokens.shape[0]
         assert batch_size == self.hunch_cache[...].shape[0], (
             f"Batch size {batch_size} does not match the hunch cache built for batch "
@@ -201,7 +204,7 @@ class UniversalReasoner(nnx.Module):
             gate = jax.nn.sigmoid(self.hunch_gate(gate_in))
             return gate * current_hunch + (1.0 - gate) * z_shared_base
         
-        z_shared = jax.lax.cond(should_refresh, get_fresh, get_carried)
+        z_shared = jax.lax.cond(new_document, get_fresh, get_carried)
 
         # Decoder slots use negative positions, which index into the tail of the
         # extended RoPE cache — distinct from all query/key positions in the
@@ -215,7 +218,7 @@ class UniversalReasoner(nnx.Module):
         decoder_bias = decoder_bias[:, None, None, :]
 
         final_shared, all_outputs = self._reasoning_loop(
-            z_seq, pad_mask, seq_pos, max_steps, batch_size, z_shared, training=training
+            z_seq, pad_mask, seq_pos, depth, batch_size, z_shared, training=training
         )
 
         # Causality: the decoder reads the slots this window STARTED with (fresh,
@@ -258,7 +261,7 @@ class UniversalReasoner(nnx.Module):
         # Undefined for a 1-step trajectory (no transitions): report 0, not the NaN
         # that jnp.mean over an empty diff produces.
         states = all_outputs.shared_state
-        if max_steps > 1:
+        if depth > 1:
             diffs = states[1:] - states[:-1]
             temporal_drift = jnp.mean(jnp.sqrt(jnp.sum(jnp.square(diffs), axis=-1) + 1e-8))
         else:
@@ -268,16 +271,60 @@ class UniversalReasoner(nnx.Module):
             'temporal_drift': temporal_drift,
             'forget_density': jnp.mean(all_outputs.forget_val),
             'tau': jax.nn.softplus(self.raw_tau[...]) + 1e-4,
+            # The two costs are reported twice on purpose: in `aux` to be graded
+            # into the loss, and here to be logged. The logger reads telemetry
+            # only, so it never needs to know an architecture's cost names.
+            'forget_cost': total_f_cost,
+            'diversity_loss': total_div_cost,
         }
 
         # Carry the final slot state forward as the next segment's hunch.
         self.hunch_cache[...] = final_shared
 
-        return ReasonerOutput(
+        return LMOutput(
             logits=logits,
             hidden=hidden,
-            forget_cost=total_f_cost,
-            diversity_loss=total_div_cost,
+            aux={'diversity': total_div_cost, 'forget': total_f_cost},
             diag=diag,
-            final_shared=final_shared,
         )
+
+    # --- The contract's optional hooks: this architecture's own bookkeeping,
+    # which used to live in the shared training loop (#105). ---
+
+    def grade_aux(self, window_aux, opt_step):
+        """Both regularizers, summed over windows and weighted by their schedules.
+
+        Summed *before* scaling, and returned in this order, because that is the
+        expression the loop has always evaluated — the golden-run trajectory is
+        recorded against `d_lambda * (d1 + d2) + f_lambda * (f1 + f2)` added to
+        the CE in that sequence, and f32 addition does not reassociate for free.
+        """
+        def over_windows(key):
+            return sum(aux[key] for aux in window_aux)
+
+        return {
+            'diversity': diversity_lambda_schedule(opt_step) * over_windows('diversity'),
+            'forget': forget_lambda_schedule(opt_step) * over_windows('forget'),
+        }
+
+    def reset_state(self):
+        self.hunch_cache[...] = jnp.zeros_like(self.hunch_cache[...])
+
+    def end_step(self, new_document):
+        # Carry the hunch into the next step UNLESS this step crossed a document
+        # boundary. stop_gradient either way: the hunch is state, not a path for
+        # gradient to flow back into a previous step.
+        current = self.hunch_cache[...]
+        self.hunch_cache[...] = jax.lax.cond(
+            new_document,
+            lambda: jax.lax.stop_gradient(jnp.zeros_like(current)),
+            lambda: jax.lax.stop_gradient(current),
+        )
+
+    @contextmanager
+    def isolated_state(self):
+        saved_hunch = self.hunch_cache[...]
+        try:
+            yield
+        finally:
+            self.hunch_cache[...] = saved_hunch

--- a/plan_a_model.py
+++ b/plan_a_model.py
@@ -88,6 +88,9 @@ class Block(nnx.Module):
         self.attn = CausalAttention(dim, num_heads, max_pos, rngs, dtype, chunked=chunked_attention)
         self.norm1 = nnx.RMSNorm(dim, epsilon=1e-6, rngs=rngs, dtype=dtype)
         self.norm2 = nnx.RMSNorm(dim, epsilon=1e-6, rngs=rngs, dtype=dtype)
+        # Multiple of 64; the reasoner's block (layers.py) rounds to 256, so the
+        # two arches' MLPs are not the same width at every dim. Frozen on purpose —
+        # see "Why the two arches don't share block code" in docs/design/plan-a.md.
         hidden = ((int(8 * dim / 3) + 63) // 64) * 64
         self.gate_proj = nnx.Linear(dim, hidden, rngs=rngs, dtype=dtype)
         self.up_proj = nnx.Linear(dim, hidden, rngs=rngs, dtype=dtype)

--- a/plan_a_trainer.py
+++ b/plan_a_trainer.py
@@ -2,25 +2,23 @@
 
 `plan_a_model.CausalRefiner` is kept deliberately pure and config-free so the same
 architecture runs at toy scale in the ablation harness and at real scale here. This
-module is the thin seam that lets the existing production trainer drive it: it wraps
-the refiner in the exact interface UniversalReasoner exposes — `__call__(tokens,
-max_steps, training, should_refresh) -> ReasonerOutput` plus a `hunch_cache` buffer —
-so the grad step, validation probe, and Orbax checkpoint plumbing work unchanged.
+module is the thin seam that wires it to production config and to the trainer's
+neutral model contract (`lm_contract.LanguageModel`).
 
-Plan A has no cross-window state, no forget gate, and no slot-diversity term, so the
-machinery the trainer threads through degrades to honest no-ops:
-  - forget_cost and diversity_loss are exactly zero, so their loss schedules
-    (forget_lambda, diversity_lambda) multiply zero and contribute nothing;
-  - the two training windows are independent (no carried state), so should_refresh
-    is ignored — each window is a standalone causal LM prediction;
-  - hunch_cache is a vestigial zero buffer, never read in the forward, kept only so
-    the trainer's `model.hunch_cache[...]` bookkeeping writes stay valid.
-`max_steps` maps to the refinement depth (sampled per step in training, fixed at
+Plan A is a plain causal LM as far as the training loop is concerned: each window
+is scored independently, there is no state carried between them, and there are no
+auxiliary objectives. So it implements `__call__` and nothing else — the contract's
+defaults (no carried state, no graded extras) are already the truth here. Before
+#105 this same fact had to be expressed as *impersonation*: a zero forget-cost and
+a zero diversity loss for schedules to multiply, a never-read hunch buffer for the
+trainer's bookkeeping to write into, and placeholder zeros for the reasoner's
+diagnostics. All of it is gone.
+
+`depth` maps to the refinement depth (sampled per step in training, fixed at
 inference) — the one dial Plan A actually uses.
 """
 
 import jax.numpy as jnp
-from flax import nnx
 
 from config import (
     VOCAB_SIZE,
@@ -34,12 +32,12 @@ from config import (
     CHUNKED_ATTENTION,
     TIME_SIGNAL,
 )
-from layers import ReasonerOutput
+from lm_contract import LMOutput, LanguageModel
 from plan_a_model import CausalRefiner
 
 
-class RefinerForTraining(nnx.Module):
-    """CausalRefiner in the UniversalReasoner-shaped interface the trainer expects.
+class RefinerForTraining(LanguageModel):
+    """CausalRefiner behind the trainer's neutral contract.
 
     Config constants are the defaults; every architecture knob is overridable so the
     integration test can build a tiny instance without monkeypatching config.
@@ -50,39 +48,37 @@ class RefinerForTraining(nnx.Module):
                  max_seq_len=MAX_SEQ_LEN, pad_token_id=PAD_TOKEN_ID, dtype=COMPUTE_DTYPE,
                  chunked_attention=CHUNKED_ATTENTION, time_signal=TIME_SIGNAL):
         self.pad_token_id = pad_token_id
+        self.latent_dim = latent_dim
         self.refiner = CausalRefiner(
             dim=latent_dim, vocab_size=vocab_size, num_heads=num_heads,
             num_encoder_layers=encoder_layers, max_depth=max_depth,
             max_seq_len=max_seq_len, dtype=dtype, rngs=rngs,
             chunked_attention=chunked_attention, time_signal=time_signal,
         )
-        # Vestigial: written by the trainer's hunch bookkeeping, never read here.
-        # Kept tiny ([1, 1, dim]) since it carries no information.
-        self.hunch_cache = nnx.Variable(jnp.zeros((1, 1, latent_dim)))
 
-    def __call__(self, tokens, max_steps=INFERENCE_DEPTH, training=False, should_refresh=True):
-        # training / should_refresh are part of the baseline interface and have no
-        # effect here (no dropout, no carried state) — accepted and ignored.
+    def __call__(self, tokens, depth=INFERENCE_DEPTH, training=False, new_document=True):
+        # training selects pre-head states vs logits. new_document is part of the
+        # contract for models that carry state across windows; Plan A carries none,
+        # so each window is a standalone causal LM prediction either way.
         # The default depth is the serving knee (INFERENCE_DEPTH, the 2026-06-19
         # dense-sweep plateau), NOT MAX_STEPS_LIMIT: callers that don't say a depth
         # get the cheapest setting the evidence says is equivalent. Training always
         # passes its sampled depth explicitly.
         pad_mask = tokens != self.pad_token_id
-        zero = jnp.array(0.0)
-        diag = {"temporal_drift": zero, "forget_density": zero, "tau": zero}
         if training:
             # Return pre-head states; the loss does the chunked LM-head projection
             # (#19), avoiding the full [b, s, vocab] f32 logit peak.
-            hidden = self.refiner(tokens, depth=max_steps, pad_mask=pad_mask, return_hidden=True)
-            return ReasonerOutput(
-                logits=None, hidden=hidden, forget_cost=zero, diversity_loss=zero,
-                diag=diag, final_shared=None,
-            )
-        logits = self.refiner(tokens, depth=max_steps, pad_mask=pad_mask)
-        return ReasonerOutput(
-            logits=logits, forget_cost=zero, diversity_loss=zero,
-            diag=diag, final_shared=None,
-        )
+            hidden = self.refiner(tokens, depth=depth, pad_mask=pad_mask, return_hidden=True)
+            return LMOutput(hidden=hidden)
+        return LMOutput(logits=self.refiner(tokens, depth=depth, pad_mask=pad_mask))
+
+    def legacy_checkpoint_variables(self):
+        # Every refiner checkpoint written before #105 carries the vestigial
+        # [1, 1, dim] hunch buffer the old trainer wrote into. It never held
+        # information — the forward never read it — so restore matches its shape
+        # and drops the value. Removing this entry orphans the champion base-run
+        # weights (and the runs the #134 time machine revives).
+        return {"hunch_cache": jnp.zeros((1, 1, self.latent_dim))}
 
     @property
     def embed(self):

--- a/plot_history.py
+++ b/plot_history.py
@@ -125,10 +125,15 @@ def plot_training_history(log_path=None):
                         'ce': float(row.get('ce', 0)),
                         # old CSVs called the first segment's CE "first_ce"
                         'seg1_ce': float(row.get('seg1_ce') or row.get('first_ce') or 0),
-                        'diversity': float(row.get('diversity_loss', 0)),
-                        'forget_cost': float(row.get('avg_forget_cost', 0)),
-                        'grad_norm': float(row.get('grad_norm_avg', 0)),
-                        'temporal_drift': float(row.get('temporal_drift', 0)),
+                        # Arch-optional (#105): a model that has no forget gate or
+                        # slot-diversity term leaves these cells empty rather than
+                        # writing zeros, so read them the sparse way — `float('')`
+                        # would raise, and the ValueError below would silently drop
+                        # every row of the run.
+                        'diversity': float(row.get('diversity_loss') or 0),
+                        'forget_cost': float(row.get('avg_forget_cost') or 0),
+                        'grad_norm': float(row.get('grad_norm_avg') or 0),
+                        'temporal_drift': float(row.get('temporal_drift') or 0),
                         # old CSVs logged mean_halt_step where new ones log sampled depth
                         'depth_avg': float(row.get('depth_avg') or row.get('mean_halt_step') or 0),
                         # sparse: only written every VAL_EVERY_OPT_STEPS, 0 means absent

--- a/tests/apparatus/test_logit_telemetry.py
+++ b/tests/apparatus/test_logit_telemetry.py
@@ -73,7 +73,7 @@ def test_grad_step_surfaces_stats_in_diag():
     model = UniversalReasoner(LATENT_DIM, nnx.Rngs(5), batch_size=1)
     rng = np.random.default_rng(11)
     batch = jnp.asarray(rng.integers(1, 5000, size=(1, 2 * MAX_SEQ_LEN + 1)), dtype=jnp.int32)
-    _, out, _, _ = compute_grad_step(model, batch, step=0, max_steps=1)
+    _, out, _, _ = compute_grad_step(model, batch, step=0, depth=1)
 
     vocab = model.embed.embedding[...].shape[0]
     entropy = float(out.diag['out_entropy'])

--- a/tests/core/test_checkpoint_roundtrip.py
+++ b/tests/core/test_checkpoint_roundtrip.py
@@ -16,7 +16,7 @@ from model import UniversalReasoner
 
 def test_save_restore_roundtrip_preserves_forward(tmp_path, tiny_model, token_batch):
     tokens = jnp.asarray(token_batch)
-    reference = np.asarray(tiny_model(tokens, max_steps=2, training=False, should_refresh=True).logits)
+    reference = np.asarray(tiny_model(tokens, depth=2, training=False, new_document=True).logits)
 
     mngr = ocp.CheckpointManager(
         tmp_path / "checkpoints",
@@ -32,5 +32,5 @@ def test_save_restore_roundtrip_preserves_forward(tmp_path, tiny_model, token_ba
     )
     nnx.update(other, restored["model"])
 
-    roundtripped = np.asarray(other(tokens, max_steps=2, training=False, should_refresh=True).logits)
+    roundtripped = np.asarray(other(tokens, depth=2, training=False, new_document=True).logits)
     np.testing.assert_array_equal(reference, roundtripped)

--- a/tests/core/test_init_loss.py
+++ b/tests/core/test_init_loss.py
@@ -16,7 +16,7 @@ from config import VOCAB_SIZE
 
 
 def test_untrained_model_scores_near_uniform_guessing(tiny_model, token_batch):
-    out = tiny_model(jnp.asarray(token_batch), max_steps=2, training=False, should_refresh=True)
+    out = tiny_model(jnp.asarray(token_batch), depth=2, training=False, new_document=True)
     targets = np.roll(token_batch, -1, axis=1)[:, :-1]
     ce = float(jnp.mean(
         optax.softmax_cross_entropy_with_integer_labels(

--- a/tests/core/test_loss_wiring.py
+++ b/tests/core/test_loss_wiring.py
@@ -1,58 +1,104 @@
 """Guards against the forget-cost incident: a loss component that is computed
 and logged but never added to the total loss (commit e516132 fixed ~3900 opt
-steps of training where the model never learned to forget). Every cost the
-model reports must provably influence the total loss."""
+steps of training where the model never learned to forget). Every cost a model
+reports must provably influence the total loss.
+
+Post-#105 that wiring runs through the neutral contract — the model reports raw
+terms in `LMOutput.aux`, weights them in its own `grade_aux`, and
+`compute_total_loss` adds back whatever it gets — so the guard is generic over
+architectures: it asks each arch which terms it reports and checks those, rather
+than naming forget and diversity. A new architecture with a new regularizer is
+covered the day it ships, and an arch that reports nothing has nothing to lose.
+"""
 
 import os
 os.environ.setdefault("JAX_PLATFORMS", "cpu")
 
-from types import SimpleNamespace
-
 import jax.numpy as jnp
+import pytest
 
 from grad_step import compute_total_loss
 from schedules import sample_reasoning_depth
 from config import MAX_STEPS_LIMIT
 
-
-def _out(diversity=1.0, forget=1.0):
-    return SimpleNamespace(
-        diversity_loss=jnp.array(diversity),
-        forget_cost=jnp.array(forget),
-    )
+# Any step past warmup, so no schedule is legitimately sitting at zero.
+GRADING_STEP = 1000
 
 
-def _total(out1, out2, ce1=2.0, ce2=3.0, f_lambda=0.1, d_lambda=0.1):
-    return float(compute_total_loss(
-        jnp.array(ce1), jnp.array(ce2), out1, out2, f_lambda, d_lambda
-    ))
+def _total(graded_aux, ce1=2.0, ce2=3.0):
+    return float(compute_total_loss(jnp.array(ce1), jnp.array(ce2), graded_aux))
 
 
-def test_every_cost_component_is_wired():
-    base = _total(_out(), _out())
-    # Doubling any single component must change the total loss.
-    assert _total(_out(forget=2.0), _out()) != base, "forget cost (segment 1) is not wired into the loss"
-    assert _total(_out(), _out(forget=2.0)) != base, "forget cost (segment 2) is not wired into the loss"
-    assert _total(_out(diversity=2.0), _out()) != base, "diversity loss is not wired into the loss"
-    assert _total(_out(), _out(), ce1=4.0) != base, "ce1 is not wired into the loss"
-    assert _total(_out(), _out(), ce2=4.0) != base, "ce2 is not wired into the loss"
+def test_every_graded_term_reaches_the_total():
+    base = _total({"a": jnp.array(1.0), "b": jnp.array(1.0)})
+    assert _total({"a": jnp.array(2.0), "b": jnp.array(1.0)}) != base, "term 'a' is not added"
+    assert _total({"a": jnp.array(1.0), "b": jnp.array(2.0)}) != base, "term 'b' is not added"
+    assert _total({}, ce1=4.0) != _total({}), "ce1 is not wired into the loss"
+    assert _total({}, ce2=4.0) != _total({}), "ce2 is not wired into the loss"
 
 
-def test_zero_lambda_disables_exactly_its_component():
-    # With a lambda of zero, the corresponding component must stop mattering.
-    assert _total(_out(forget=1.0), _out(), f_lambda=0.0) == _total(_out(forget=99.0), _out(), f_lambda=0.0)
-    assert _total(_out(diversity=1.0), _out(), d_lambda=0.0) == _total(_out(diversity=99.0), _out(), d_lambda=0.0)
+def test_no_aux_means_plain_cross_entropy():
+    # A model with no auxiliary objectives must pay exactly the CE — not the CE
+    # plus a zero term it was obliged to invent (#105).
+    assert _total({}) == pytest.approx(5.0)
 
 
-def test_both_segments_weigh_equally():
-    # No anchor/refinement asymmetry: raising either segment's CE by the same
+def test_both_windows_weigh_equally():
+    # No anchor/refinement asymmetry: raising either window's CE by the same
     # amount must change the loss by the same amount.
-    out1, out2 = _out(), _out()
-    base = _total(out1, out2, ce1=2.0, ce2=2.0)
-    via_ce1 = _total(out1, out2, ce1=3.0, ce2=2.0)
-    via_ce2 = _total(out1, out2, ce1=2.0, ce2=3.0)
+    base = _total({}, ce1=2.0, ce2=2.0)
+    via_ce1 = _total({}, ce1=3.0, ce2=2.0)
+    via_ce2 = _total({}, ce1=2.0, ce2=3.0)
     assert abs(via_ce1 - via_ce2) < 1e-6
     assert abs((via_ce1 - base) - 1.0) < 1e-6
+
+
+def _graded(model, window_aux):
+    return {k: float(v) for k, v in model.grade_aux(window_aux, GRADING_STEP).items()}
+
+
+def test_each_reported_aux_term_survives_grading(tiny_model, token_batch):
+    """Whatever the arch puts in `aux`, its own grade_aux must carry through to a
+    graded term that responds to it — in BOTH windows. This is the forget-cost
+    incident's actual shape: a cost computed, reported, and then dropped on the
+    floor between the model and the loss."""
+    reported = tiny_model(jnp.asarray(token_batch), depth=2, training=False).aux
+    if not reported:
+        pytest.skip("this architecture reports no auxiliary objectives")
+
+    ones = {k: jnp.array(1.0) for k in reported}
+    base = _graded(tiny_model, [ones, ones])
+
+    for key in reported:
+        for window in (0, 1):
+            bumped = [dict(ones), dict(ones)]
+            bumped[window][key] = jnp.array(2.0)
+            after = _graded(tiny_model, bumped)
+            assert after != base, (
+                f"reported aux term '{key}' does not reach the loss from window {window}"
+            )
+
+
+def test_grading_scales_with_the_reported_cost(tiny_model, token_batch):
+    """A graded term must be driven by the cost it is named for and nothing else:
+    doubling one reported term moves its own graded value and leaves the others
+    alone. Catches a schedule wired to the wrong key."""
+    reported = tiny_model(jnp.asarray(token_batch), depth=2, training=False).aux
+    if not reported:
+        pytest.skip("this architecture reports no auxiliary objectives")
+
+    ones = {k: jnp.array(1.0) for k in reported}
+    base = _graded(tiny_model, [ones, ones])
+
+    for key in reported:
+        bumped = dict(ones, **{key: jnp.array(2.0)})
+        after = _graded(tiny_model, [bumped, ones])
+        assert after[key] != base[key], f"'{key}' grading ignores its own reported cost"
+        for other in reported:
+            if other != key:
+                assert after[other] == base[other], (
+                    f"bumping '{key}' moved the graded '{other}' term — crossed wiring"
+                )
 
 
 def test_depth_sampling_is_deterministic_and_covers_range():

--- a/tests/core/test_model_invariants.py
+++ b/tests/core/test_model_invariants.py
@@ -15,8 +15,8 @@ import numpy as np
 from config import PAD_TOKEN_ID
 
 
-def _logits(model, tokens_np, max_steps=2):
-    out = model(jnp.asarray(tokens_np), max_steps=max_steps, training=False, should_refresh=True)
+def _logits(model, tokens_np, depth=2):
+    out = model(jnp.asarray(tokens_np), depth=depth, training=False, new_document=True)
     return np.asarray(out.logits, dtype=np.float32)
 
 
@@ -52,8 +52,8 @@ def test_causality_holds_with_carried_hunch(tiny_model, token_batch):
     window_a = (token_batch + 17) % 5000 + 1
 
     def run(tokens_b):
-        tiny_model(jnp.asarray(window_a), max_steps=2, training=False, should_refresh=True)
-        out = tiny_model(jnp.asarray(tokens_b), max_steps=2, training=False, should_refresh=False)
+        tiny_model(jnp.asarray(window_a), depth=2, training=False, new_document=True)
+        out = tiny_model(jnp.asarray(tokens_b), depth=2, training=False, new_document=False)
         return np.asarray(out.logits, dtype=np.float32)[:, :40]
 
     perturbed = token_batch.copy()

--- a/tests/core/test_neutral_contract.py
+++ b/tests/core/test_neutral_contract.py
@@ -1,0 +1,123 @@
+"""The training loop speaks plain LM, and keeps speaking it (#105).
+
+Before this, the loop's idea of "a model" was the shape of the original reasoner:
+it did hunch bookkeeping, scheduled a forget cost and a diversity loss, and sent a
+refresh signal — so every live architecture had to wear that costume, and Plan A
+was integrated by dressing up as the arch we had already proved inert.
+
+Two things keep the inversion from quietly rotting back:
+  1. the shared loop names no architecture's machinery, and
+  2. both architectures really do train through the same call.
+
+The second is the one that matters; the first is what stops the seam from being
+re-opened one convenient attribute at a time.
+"""
+
+import io
+import pathlib
+import tokenize
+
+import jax.numpy as jnp
+import numpy as np
+import pytest
+from flax import nnx
+
+from config import LATENT_DIM, MAX_SEQ_LEN
+from grad_step import compute_grad_step
+from lm_contract import LanguageModel
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[2]
+
+# Modules that drive training and must stay architecture-blind. metrics_logger is
+# deliberately NOT here: a CSV column named `avg_forget_cost` is telemetry with a
+# stable name that historical runs and plot_history still read, not the loop doing
+# an architecture's bookkeeping.
+SHARED_LOOP = ("trainer.py", "grad_step.py", "validation.py")
+
+# Vocabulary belonging to one specific architecture. If the loop mentions any of
+# it in *code*, some model's internals have leaked back into the shared path.
+ARCH_VOCABULARY = ("hunch", "forget", "diversity", "temporal_drift", "slot", "refresh")
+
+
+def _code_without_comments_or_strings(path):
+    """Source with comments and string literals stripped, so prose about the past
+    (the forget-cost incident is worth explaining) doesn't trip the scan."""
+    kept = []
+    with open(path, "rb") as f:
+        for tok in tokenize.tokenize(f.readline):
+            if tok.type not in (tokenize.COMMENT, tokenize.STRING):
+                kept.append(tok.string)
+    return " ".join(kept)
+
+
+@pytest.mark.parametrize("module", SHARED_LOOP)
+def test_shared_loop_names_no_architecture_internals(module):
+    code = _code_without_comments_or_strings(REPO_ROOT / module).lower()
+    leaked = [word for word in ARCH_VOCABULARY if word in code]
+    assert not leaked, (
+        f"{module} mentions {leaked} in code — the shared loop is doing one "
+        f"architecture's bookkeeping again. Move it behind an lm_contract hook."
+    )
+
+
+def test_the_leak_scan_can_actually_detect_a_leak():
+    """The scan above is only worth having if it fails when it should. model.py is
+    the reasoner itself, so its code is full of this vocabulary — if stripping
+    comments and strings ever swallowed the whole file, the guard would pass
+    vacuously and notice nothing."""
+    code = _code_without_comments_or_strings(REPO_ROOT / "model.py").lower()
+    found = [word for word in ARCH_VOCABULARY if word in code]
+    assert "hunch" in found and "forget" in found, (
+        f"the scan found only {found} in model.py — it is no longer reading real code"
+    )
+
+
+def test_contract_defaults_describe_a_plain_stateless_lm():
+    """A new architecture must be able to implement `__call__` and stop. If these
+    defaults ever stop being no-ops, every future model inherits a chore."""
+
+    class Minimal(LanguageModel):
+        def __call__(self, tokens, depth, training=False, new_document=True):
+            raise AssertionError("not called")
+
+    m = Minimal()
+    assert m.grade_aux([{}, {}], 0) == {}
+    assert m.legacy_checkpoint_variables() == {}
+    m.reset_state()
+    m.end_step(True)
+    with m.isolated_state():
+        pass
+
+
+def _tiny_refiner():
+    from plan_a_trainer import RefinerForTraining
+
+    return RefinerForTraining(
+        128, nnx.Rngs(0), vocab_size=37, num_heads=4,
+        encoder_layers=2, max_depth=8, max_seq_len=MAX_SEQ_LEN,
+    )
+
+
+def _reasoner():
+    from model import UniversalReasoner
+
+    return UniversalReasoner(LATENT_DIM, nnx.Rngs(5), batch_size=1)
+
+
+@pytest.mark.parametrize("build", [_tiny_refiner, _reasoner], ids=["refiner", "reasoner"])
+def test_both_arches_train_through_the_identical_call(build):
+    """The same `compute_grad_step` invocation — no arch branch, no adapter
+    shim — drives a model that carries state and grades two regularizers, and one
+    that does neither."""
+    model = build()
+    rng = np.random.default_rng(11)
+    batch = jnp.asarray(rng.integers(1, 37, size=(1, 2 * MAX_SEQ_LEN + 1)), dtype=jnp.int32)
+
+    loss, out, grads, grad_norm = compute_grad_step(
+        model, batch, step=0, depth=2, doc_boundary=True)
+
+    assert np.isfinite(float(loss)) and np.isfinite(float(grad_norm))
+    assert float(grad_norm) > 0.0, "no gradient flowed"
+    assert out.logits is None, "training must return pre-head states, not logits"
+    # Whatever the arch reported got graded and added; nothing else was required.
+    assert isinstance(out.aux, dict)

--- a/tests/core/test_plan_a_integration.py
+++ b/tests/core/test_plan_a_integration.py
@@ -1,9 +1,10 @@
 """Plan A wired into the production trainer (plan_a_trainer.RefinerForTraining).
 
 test_plan_a.py proves the pure CausalRefiner; this proves the *integration* — that
-the adapter drives the real grad step, that the no-op regularizers stay zero, and
-that the refiner's param tree survives the Orbax round-trip the trainer uses. These
-are the failure modes a config flag flip would otherwise hit only mid-run on the GPU.
+the adapter drives the real grad step, that it speaks the trainer's neutral contract
+without carrying any of the reasoner's machinery (#105), and that the refiner's param
+tree survives the Orbax round-trip the trainer uses. These are the failure modes a
+config flag flip would otherwise hit only mid-run on the GPU.
 
 Runs on CPU in f32 like the rest of the suite. Windows are sliced at MAX_SEQ_LEN, so
 the batch must be 2*MAX_SEQ_LEN+1 wide; dims are kept tiny otherwise.
@@ -16,6 +17,7 @@ import orbax.checkpoint as ocp
 import pytest
 from flax import nnx
 
+from checkpoint_utils import restore_tolerating_legacy
 from config import MAX_SEQ_LEN, PAD_TOKEN_ID
 from grad_step import compute_grad_step, apply_grads
 from plan_a_trainer import RefinerForTraining
@@ -37,25 +39,47 @@ def _fixed_batch(seed=3):
     return jnp.asarray(tokens.astype(np.int32))
 
 
-def test_adapter_interface_and_zero_regularizers():
-    """The adapter returns the ReasonerOutput the trainer consumes, with the
-    hunch/forget/diversity terms as exact zeros (so their schedules add nothing)."""
+def test_adapter_speaks_the_neutral_contract():
+    """The adapter returns the LMOutput the trainer consumes — and nothing else.
+
+    #105 turned the contract around: the refiner no longer impersonates the
+    reasoner. It reports no auxiliary objectives (an empty dict, not zeros for a
+    schedule to multiply) and allocates no state buffer for the trainer to write
+    into. Both are asserted here because both used to exist purely as costume.
+    """
     m = _tiny_adapter()
     tokens = _fixed_batch()[:, :MAX_SEQ_LEN]
-    out = m(tokens, max_steps=4, training=True, should_refresh=True)
+    out = m(tokens, depth=4, training=True, new_document=True)
 
     # Training returns pre-head states (logits=None); the loss does the chunked
     # LM-head projection (#19). Inference still returns full logits (checked below).
     assert out.logits is None
     assert out.hidden.shape == (1, MAX_SEQ_LEN, DIM)
     assert np.isfinite(np.asarray(out.hidden)).all()
-    infer_out = m(tokens, max_steps=4, training=False, should_refresh=True)
+    infer_out = m(tokens, depth=4, training=False, new_document=True)
     assert infer_out.logits.shape == (1, MAX_SEQ_LEN, VOCAB)
     assert np.isfinite(np.asarray(infer_out.logits)).all()
-    assert float(out.forget_cost) == 0.0
-    assert float(out.diversity_loss) == 0.0
-    # Vestigial buffer exists for the trainer's bookkeeping writes.
-    assert m.hunch_cache[...].shape == (1, 1, DIM)
+
+    assert out.aux == {}, "the refiner has no auxiliary objectives to grade"
+    assert m.grade_aux([out.aux, out.aux], 1000) == {}
+    assert not hasattr(m, "hunch_cache"), "no vestigial state buffer"
+    # The contract's state hooks are inert here, and must stay callable anyway —
+    # the shared loop calls them without asking which architecture it has.
+    m.reset_state()
+    m.end_step(True)
+    with m.isolated_state():
+        pass
+
+
+def test_stateless_forward_ignores_document_boundaries():
+    """Plan A carries nothing between windows, so `new_document` cannot change a
+    prediction. If this ever fails, the refiner grew cross-window state and the
+    trainer's window sequencing has to be revisited."""
+    m = _tiny_adapter()
+    tokens = _fixed_batch()[:, :MAX_SEQ_LEN]
+    fresh = np.asarray(m(tokens, depth=3, training=False, new_document=True).logits)
+    continued = np.asarray(m(tokens, depth=3, training=False, new_document=False).logits)
+    np.testing.assert_array_equal(fresh, continued)
 
 
 def test_grad_step_runs_and_reduces_loss():
@@ -88,7 +112,7 @@ def test_checkpoint_roundtrip_preserves_forward(tmp_path):
     layout before a real run trusts a resume."""
     m = _tiny_adapter(seed=0)
     tokens = _fixed_batch()[:, :MAX_SEQ_LEN]
-    reference = np.asarray(m(tokens, max_steps=2, training=False, should_refresh=True).logits)
+    reference = np.asarray(m(tokens, depth=2, training=False, new_document=True).logits)
 
     mngr = ocp.CheckpointManager(
         tmp_path / "checkpoints",
@@ -104,8 +128,66 @@ def test_checkpoint_roundtrip_preserves_forward(tmp_path):
     )
     nnx.update(other, restored["model"])
 
-    roundtripped = np.asarray(other(tokens, max_steps=2, training=False, should_refresh=True).logits)
+    roundtripped = np.asarray(other(tokens, depth=2, training=False, new_document=True).logits)
     np.testing.assert_array_equal(reference, roundtripped)
+
+
+def test_pre_105_checkpoint_still_restores(tmp_path):
+    """Every refiner checkpoint on disk — including the champion base run and the
+    worlds the #134 time machine revives — was written while the adapter still
+    carried the vestigial `hunch_cache`. Dropping the buffer must not orphan them:
+    restore matches the legacy shape, discards it, and reproduces the forward.
+    """
+    m = _tiny_adapter(seed=0)
+    tokens = _fixed_batch()[:, :MAX_SEQ_LEN]
+    reference = np.asarray(m(tokens, depth=2, training=False).logits)
+
+    # A pre-#105 save: the real state plus the buffer the old trainer wrote into.
+    legacy_state = nnx.state(m)
+    legacy_state["hunch_cache"] = nnx.Variable(jnp.zeros((1, 1, DIM)))
+
+    mngr = ocp.CheckpointManager(
+        tmp_path / "checkpoints", item_names=("model",),
+        options=ocp.CheckpointManagerOptions(max_to_keep=1, create=True),
+    )
+    mngr.save(0, args=ocp.args.Composite(model=ocp.args.StandardSave(legacy_state)))
+    mngr.wait_until_finished()
+
+    other = _tiny_adapter(seed=99)  # different init, must be overwritten by restore
+    restored = restore_tolerating_legacy(
+        lambda target: mngr.restore(
+            0, args=ocp.args.Composite(model=ocp.args.StandardRestore(target))),
+        other,
+    )
+    assert "hunch_cache" not in restored["model"], "legacy buffer leaked into the model"
+    nnx.update(other, restored["model"])
+
+    np.testing.assert_array_equal(
+        reference, np.asarray(other(tokens, depth=2, training=False).logits))
+
+
+def test_restore_still_fails_loudly_on_genuinely_missing_weights(tmp_path):
+    """The legacy tolerance must not become a blanket 'load whatever fits'. A
+    checkpoint that lacks weights the model needs is a real error — silently
+    keeping freshly-initialized values there is how a resume quietly restarts
+    from noise."""
+    complete = _tiny_adapter(seed=0)
+    truncated = nnx.state(complete)
+    del truncated["refiner"]["embed"]
+
+    mngr = ocp.CheckpointManager(
+        tmp_path / "checkpoints", item_names=("model",),
+        options=ocp.CheckpointManagerOptions(max_to_keep=1, create=True),
+    )
+    mngr.save(0, args=ocp.args.Composite(model=ocp.args.StandardSave(truncated)))
+    mngr.wait_until_finished()
+
+    with pytest.raises(ValueError):
+        restore_tolerating_legacy(
+            lambda target: mngr.restore(
+                0, args=ocp.args.Composite(model=ocp.args.StandardRestore(target))),
+            _tiny_adapter(seed=99),
+        )
 
 
 def test_adapter_honors_time_signal():

--- a/tests/core/test_rolling_checkpoint.py
+++ b/tests/core/test_rolling_checkpoint.py
@@ -135,8 +135,8 @@ def test_save_checkpoint_schema_matches_loader(tmp_path, tiny_model):
     assert start_step == 43, "resume must continue at saved step + 1"
 
     tokens = jnp.asarray(np.full((1, 16), 5, dtype=np.int32))
-    ref = np.asarray(tiny_model(tokens, max_steps=2, training=False, should_refresh=True).logits)
-    got = np.asarray(fresh(tokens, max_steps=2, training=False, should_refresh=True).logits)
+    ref = np.asarray(tiny_model(tokens, depth=2, training=False, new_document=True).logits)
+    got = np.asarray(fresh(tokens, depth=2, training=False, new_document=True).logits)
     np.testing.assert_array_equal(ref, got)
 
 

--- a/tests/core/test_step_determinism.py
+++ b/tests/core/test_step_determinism.py
@@ -19,7 +19,7 @@ def _one_step():
     model = UniversalReasoner(LATENT_DIM, nnx.Rngs(5), batch_size=1)
     rng = np.random.default_rng(11)
     batch = jnp.asarray(rng.integers(1, 5000, size=(1, 2 * MAX_SEQ_LEN + 1)), dtype=jnp.int32)
-    loss, out, grads, grad_norm = compute_grad_step(model, batch, step=0, max_steps=1)
+    loss, out, grads, grad_norm = compute_grad_step(model, batch, step=0, depth=1)
     return float(loss), float(grad_norm)
 
 

--- a/tests/expensive/test_golden_run.py
+++ b/tests/expensive/test_golden_run.py
@@ -42,7 +42,7 @@ def test_grad_steps_match_golden_trajectory():
 
     losses = []
     for step, depth in enumerate(DEPTHS):
-        loss, out, grads, grad_norm = compute_grad_step(model, batch, step, max_steps=depth)
+        loss, out, grads, grad_norm = compute_grad_step(model, batch, step, depth=depth)
         apply_grads(optimizer, grads, model)
         losses.append(float(loss))
 

--- a/tools/common.py
+++ b/tools/common.py
@@ -13,14 +13,14 @@ import orbax.checkpoint as ocp
 from config import LATENT_DIM, MODEL_ARCH, resolve_root
 
 # Eval builds and scores at batch 1, never at the training BATCH_SIZE (#24). The
-# reasoner's vestigial hunch_cache is shaped [batch, slots, dim] and its forward
-# asserts on the leading dim, so a reasoner skeleton built at the training batch
-# would fail to restore every checkpoint we have — all written when BATCH_SIZE
-# was 1 — for no benefit, since eval reads a handful of rows.
+# reasoner's hunch_cache is shaped [batch, slots, dim] and its forward asserts on
+# the leading dim, so a reasoner skeleton built at the training batch would fail
+# to restore every checkpoint we have — all written when BATCH_SIZE was 1 — for
+# no benefit, since eval reads a handful of rows.
 EVAL_BATCH_SIZE = 1
 from model import UniversalReasoner
 from data_loaders import TextDataGenerator
-from checkpoint_utils import discover_latest_checkpoint_run
+from checkpoint_utils import discover_latest_checkpoint_run, restore_tolerating_legacy
 
 
 def _restore_into(model, checkpoint_path):
@@ -40,9 +40,12 @@ def _restore_into(model, checkpoint_path):
     if latest is None:
         raise SystemExit(f"No checkpoint found under {checkpoint_path}")
     print(f"📖 Restoring model weights from step {latest} ({checkpoint_path})")
-    restored = mngr.restore(
-        latest,
-        args=ocp.args.Composite(model=ocp.args.StandardRestore(nnx.state(model))),
+    restored = restore_tolerating_legacy(
+        lambda model_target: mngr.restore(
+            latest,
+            args=ocp.args.Composite(model=ocp.args.StandardRestore(model_target)),
+        ),
+        model,
     )
     nnx.update(model, restored["model"])
     return model, latest

--- a/tools/depth_playground.py
+++ b/tools/depth_playground.py
@@ -52,7 +52,7 @@ def generate_at_depth(model, enc, prompt, depth, *, max_new_tokens, temperature,
     for _ in range(max_new_tokens):
         if valid_len >= MAX_SEQ_LEN:
             break
-        out = model(input_ids, max_steps=depth, training=False)
+        out = model(input_ids, depth=depth, training=False)
         logits = out.logits[0, valid_len - 1, :]
         logits = _temperature_truncate(
             logits, temperature if temperature > 0.0 else 1.0, top_k, top_p)

--- a/tools/eval_depth_curve.py
+++ b/tools/eval_depth_curve.py
@@ -20,7 +20,6 @@ os.environ.setdefault("XLA_PYTHON_CLIENT_MEM_FRACTION", "0.5")
 
 import argparse
 
-import jax.numpy as jnp
 import numpy as np
 import optax
 from flax import nnx
@@ -33,10 +32,10 @@ load_dotenv()
 from tools.common import restore_model, load_eval_batches
 
 
-@nnx.jit(static_argnames=["max_steps"])
-def prime_hunch(model, window1, max_steps):
+@nnx.jit(static_argnames=["depth"])
+def prime_hunch(model, window1, depth):
     """Run the reasoning loop over window 1; its output lands in the hunch cache."""
-    model(window1, max_steps=max_steps, training=False, should_refresh=True)
+    model(window1, depth=depth, training=False, new_document=True)
 
 
 @nnx.jit(static_argnames=["use_hunch"])
@@ -45,7 +44,7 @@ def score_window2(model, tokens, use_hunch):
     (the decoder reads the slots the window started with), so run depth 1."""
     seq_in = tokens[:, MAX_SEQ_LEN:2 * MAX_SEQ_LEN]
     seq_out = tokens[:, MAX_SEQ_LEN + 1:2 * MAX_SEQ_LEN + 1]
-    out = model(seq_in, max_steps=1, training=False, should_refresh=not use_hunch)
+    out = model(seq_in, depth=1, training=False, new_document=not use_hunch)
     mask = seq_out != PAD_TOKEN_ID
     token_ce = optax.softmax_cross_entropy_with_integer_labels(logits=out.logits, labels=seq_out)
     return token_ce, mask
@@ -61,8 +60,8 @@ def main():
 
     if MODEL_ARCH == "refiner":
         raise SystemExit(
-            "eval_depth_curve probes the reasoner's cross-window hunch; the refiner has none "
-            "(its hunch_cache is a vestigial zero buffer). Use tools/eval_refiner_depth_transfer.py instead."
+            "eval_depth_curve probes the reasoner's cross-window hunch; the refiner carries "
+            "no state between windows at all. Use tools/eval_refiner_depth_transfer.py instead."
         )
 
     model, ckpt_step = restore_model(args.checkpoint_path)
@@ -83,7 +82,7 @@ def main():
         window1 = batch[:, :MAX_SEQ_LEN]
         hard_mask = None
         for cond in conditions:
-            model.hunch_cache[...] = jnp.zeros_like(model.hunch_cache[...])
+            model.reset_state()
             if cond == "fresh":
                 token_ce, mask = score_window2(model, batch, use_hunch=False)
             else:

--- a/tools/eval_refiner_depth_finetune.py
+++ b/tools/eval_refiner_depth_finetune.py
@@ -101,7 +101,7 @@ def train_eval(model, train, test, depth, steps, batch, lr, seed):
         idx = jax.random.randint(key, (batch,), 0, tr_in.shape[0])
         inp, tgt, mask = tr_in[idx], tr_tgt[idx], tr_mask[idx]
         def loss_fn(m):
-            logits = m(inp, max_steps=depth, training=True).logits
+            logits = m(inp, depth=depth, training=True).logits
             ce = optax.softmax_cross_entropy_with_integer_labels(logits=logits, labels=tgt)
             return jnp.sum(ce * mask) / jnp.sum(mask)
         loss, grads = nnx.value_and_grad(loss_fn)(model)
@@ -112,7 +112,7 @@ def train_eval(model, train, test, depth, steps, batch, lr, seed):
     def eval_chunk(model, inp, tgt, mask, depth):
         # Chunked: the full test pool's logits ([n_test*seq, VOCAB_SIZE]) would be tens of
         # GB; score batch-sized chunks and accumulate masked sums instead.
-        logits = model(inp, max_steps=depth, training=False).logits
+        logits = model(inp, depth=depth, training=False).logits
         correct = jnp.sum((logits.argmax(-1) == tgt) * mask)
         ce = jnp.sum(optax.softmax_cross_entropy_with_integer_labels(logits=logits, labels=tgt) * mask)
         return correct, ce, jnp.sum(mask)

--- a/tools/eval_refiner_depth_transfer.py
+++ b/tools/eval_refiner_depth_transfer.py
@@ -101,8 +101,8 @@ def _ce_sums(model, batch, depth):
     mirrors validation._val_ce_sums, but depth is the swept argument here."""
     seq1_in, seq1_out = batch[:, :MAX_SEQ_LEN], batch[:, 1:MAX_SEQ_LEN + 1]
     seq2_in, seq2_out = batch[:, MAX_SEQ_LEN:2 * MAX_SEQ_LEN], batch[:, MAX_SEQ_LEN + 1:2 * MAX_SEQ_LEN + 1]
-    out1 = model(seq1_in, max_steps=depth, training=False)
-    out2 = model(seq2_in, max_steps=depth, training=False)
+    out1 = model(seq1_in, depth=depth, training=False)
+    out2 = model(seq2_in, depth=depth, training=False)
     total, count = jnp.array(0.0), jnp.array(0)
     for logits, targets in ((out1.logits, seq1_out), (out2.logits, seq2_out)):
         mask = targets != PAD_TOKEN_ID

--- a/tools/eval_yardstick.py
+++ b/tools/eval_yardstick.py
@@ -59,15 +59,15 @@ DEFAULT_DEPTH = 4
 
 @nnx.jit(static_argnames=["depth"])
 def _forward_logits(model, tokens, depth):
-    return model(tokens, max_steps=depth, training=False, should_refresh=True).logits
+    return model(tokens, depth=depth, training=False, new_document=True).logits
 
 
 def make_logits_fn(model, depth):
     """Adapt a restored model to the yardstick's numpy-causal interface.
 
-    Every batch starts from fresh cross-window state (the hunch cache is
-    vestigial-zero for the refiner and refreshed by should_refresh=True for the
-    reasoner), so LAMBADA examples stay independent."""
+    Every batch is scored as a fresh document (new_document=True), so a model
+    that carries cross-window state starts clean and LAMBADA examples stay
+    independent. A stateless model carries nothing to begin with."""
     def logits_fn(tokens):
         return np.asarray(_forward_logits(model, jnp.asarray(tokens), depth=depth))
     return logits_fn

--- a/tools/overfit_smoke.py
+++ b/tools/overfit_smoke.py
@@ -68,7 +68,7 @@ def main():
     final_ce = None
     for step in range(args.steps):
         loss, out, grads, grad_norm = compute_grad_step(
-            model, batch, step, max_steps=args.depth, doc_boundary=False
+            model, batch, step, depth=args.depth, doc_boundary=False
         )
         apply_grads(optimizer, grads, model)
         ce = float(out.diag["token_loss"])

--- a/trainer.py
+++ b/trainer.py
@@ -229,13 +229,14 @@ def train_loop(model, optimizer, data_queue, mngr, best_mngr, monitor, start_ste
 
             if not (math.isfinite(current_loss) and math.isfinite(current_grad_norm)):
                 # Divergence must be loud and must not poison the optimizer state
-                # or the carried hunch (which the grad step already overwrote).
+                # or any state the model carries (which the grad step already
+                # overwrote).
                 nonfinite_streak += 1
                 print(
                     f"⚠️ Non-finite loss/grad at micro-step {step} "
                     f"(loss={current_loss}, grad_norm={current_grad_norm}, streak={nonfinite_streak}) — skipping update."
                 )
-                model.hunch_cache[...] = jnp.zeros_like(model.hunch_cache[...])
+                model.reset_state()
                 if nonfinite_streak >= MAX_NONFINITE_STREAK:
                     raise RuntimeError(
                         f"Training diverged: {MAX_NONFINITE_STREAK} consecutive non-finite micro-steps "

--- a/validation.py
+++ b/validation.py
@@ -21,11 +21,11 @@ VAL_SKIP_SAMPLES = 3_000_000
 @nnx.jit
 def _val_ce_sums(model, batch):
     """Masked CE sums over both windows, mirroring the training segment structure
-    (window 1 fresh, window 2 on the carried hunch) at a fixed depth."""
+    (window 1 opens the document, window 2 continues it) at a fixed depth."""
     seq1_in, seq1_out = batch[:, :MAX_SEQ_LEN], batch[:, 1:MAX_SEQ_LEN + 1]
     seq2_in, seq2_out = batch[:, MAX_SEQ_LEN:2 * MAX_SEQ_LEN], batch[:, MAX_SEQ_LEN + 1:2 * MAX_SEQ_LEN + 1]
-    out1 = model(seq1_in, max_steps=VAL_FIXED_DEPTH, training=False, should_refresh=True)
-    out2 = model(seq2_in, max_steps=VAL_FIXED_DEPTH, training=False, should_refresh=False)
+    out1 = model(seq1_in, depth=VAL_FIXED_DEPTH, training=False, new_document=True)
+    out2 = model(seq2_in, depth=VAL_FIXED_DEPTH, training=False, new_document=False)
     total = jnp.array(0.0)
     count = jnp.array(0)
     for logits, targets in ((out1.logits, seq1_out), (out2.logits, seq2_out)):
@@ -38,8 +38,8 @@ def _val_ce_sums(model, batch):
 
 class ValidationProbe:
     """Loads VAL_ROWS fixed held-out rows once, then scores them on demand.
-    Restores the training stream's carried hunch afterwards, so validating never
-    perturbs training."""
+    Runs inside the model's `isolated_state`, so whatever the training stream
+    carries is restored afterwards and validating never perturbs training."""
 
     def __init__(self, data_root):
         self.data_root = data_root
@@ -67,12 +67,13 @@ class ValidationProbe:
             self._batches = self._load()
         if not self._batches:
             return None
-        saved_hunch = model.hunch_cache[...]
         total, count = 0.0, 0
-        for batch in self._batches:
-            model.hunch_cache[...] = jnp.zeros_like(saved_hunch)
-            ce_sum, ce_count = _val_ce_sums(model, batch)
-            total += float(ce_sum)
-            count += int(ce_count)
-        model.hunch_cache[...] = saved_hunch
+        with model.isolated_state():
+            for batch in self._batches:
+                # Every probe row is scored from a clean slate, so the measurement
+                # is a property of the weights and not of the row order.
+                model.reset_state()
+                ce_sum, ce_count = _val_ce_sums(model, batch)
+                total += float(ce_sum)
+                count += int(ce_count)
         return total / max(count, 1)


### PR DESCRIPTION
Closes #105.

## The inversion

The training loop's idea of "a model" was the shape of the original reasoner: a hunch memory to do bookkeeping on, a forget cost and a diversity loss to schedule, a refresh signal to send. Plan A — the live bet — was integrated by wearing that costume, and the costume was the *only* reason several of its pieces existed.

`lm_contract.py` now states what the loop actually needs:

> tokens and a depth in → predictions (or pre-head states for the chunked CE), plus a dict of auxiliary terms you want graded.

Everything else is an optional hook whose default is a no-op, so a plain LM implements `__call__` and stops:

| hook | default | reasoner's override |
|---|---|---|
| `grade_aux(window_aux, opt_step)` | `{}` | its two lambda schedules |
| `reset_state()` | no-op | zero the hunch |
| `end_step(new_document)` | no-op | carry-or-clear + `stop_gradient` |
| `isolated_state()` | yields | save/restore the hunch |
| `legacy_checkpoint_variables()` | `{}` | (refiner: the dropped buffer) |

`ReasonerOutput` → `LMOutput` (`logits`/`hidden`/`aux`/`diag`); `final_shared` is gone (nothing read it). `should_refresh` → `new_document`, `max_steps` → `depth` — both were the reasoner's vocabulary for facts the loop legitimately knows.

## Acceptance

**No vestigial fields.** The refiner reports `aux == {}` — not zeros for a schedule to multiply — has no `hunch_cache`, and no longer fabricates `temporal_drift`/`forget_density`/`tau` zeros for the CSV. Metrics a model doesn't measure now leave empty cells instead of zeros that look like measurements.

**Trainer contains no reasoner-specific bookkeeping.** `trainer.py`, `grad_step.py`, `validation.py` contain zero architecture vocabulary in code (`test_neutral_contract.py` scans for it with comments and strings stripped, and asserts the scan can still detect a real leak so it can't pass vacuously). Both arches drive the identical `compute_grad_step` call, parametrized in the same test.

`metrics_logger.py` is deliberately excluded from that scan: a CSV column named `avg_forget_cost` is telemetry with a stable name that historical runs and `plot_history` still read, not the loop doing an architecture's bookkeeping.

**Golden story: preserved, and stronger than the guard requires.** The trajectory is **bit-identical to `main`** — all five losses, byte for byte — verified by running the same script on a clean `origin/main` worktree on this machine:

| step | stored golden | main | this branch |
|---|---|---|---|
| 0 | 22.739139556884766 | 22.739139556884766 | 22.739139556884766 |
| 1 | 20.838632583618164 | 20.838632583618164 | 20.838632583618164 |
| 2 | 18.524885177612305 | 18.5248**87084960938** | 18.5248**87084960938** |
| 3 | 17.145214080810547 | 17.14521**598815918** | 17.14521**598815918** |
| 4 | 14.599569320678711 | 14.599569320678711 | 14.599569320678711 |

Steps 2–3 sit ~1e-7 relative off the *stored file* — **on `main` too**, identically. That drift is pre-existing (the file was recorded under a different XLA/CPU than this box), unrelated to this PR, and inside the guard's `rtol=1e-6`. `RUN_GOLDEN=1` passes; the golden file is untouched and was **not** re-recorded.

This is why `compute_total_loss` adds graded terms one at a time in iteration order, and why the reasoner sums each cost across windows *before* scaling: `λ·(d1+d2) + λ·(f1+f2)` added to the CE in that sequence is the expression the loop has always evaluated, and f32 addition does not reassociate for free.

## The one thing that isn't just interface surgery

Dropping the refiner's `hunch_cache` changes its saved *variable* tree (params are untouched), and Orbax matches structure strictly — so every refiner checkpoint on disk, **the champion base run included**, would have been orphaned. Verified as a real failure mode before fixing it, not assumed.

`restore_tolerating_legacy` reads with the honest structure first and only on mismatch retries with the buffers the model itself declares its old checkpoints held. Both attempts stay strict, so a checkpoint genuinely *missing* weights still fails loudly rather than half-loading a network — the direction `partial_restore=True` gets silently wrong, which is why it isn't used. Two tests pin both directions.

## Verification

- `pytest tests/core tests/apparatus` green; `RUN_GOLDEN=1 pytest tests/expensive` green.
- New: `tests/core/test_neutral_contract.py` (7) — leak scan + its own detector check, no-op defaults, both arches through one call.
- `test_loss_wiring.py` rewritten to be **generic over architectures**: it asks each arch which terms it reports and checks those reach the loss from both windows, instead of naming forget and diversity. The forget-cost incident's shape is now guarded for arches that don't exist yet.
- `test_plan_a_integration.py`: asserts the absence of the costume, plus the two legacy-checkpoint cases.
- Fixed en route: blank CSV cells would have hit `float('')` in `plot_history`, whose `except ValueError: continue` would have silently dropped *every row* of a refiner run.

## Also in scope (issue's "good moment to")

The per-arch block duplication decision is now written down once — `docs/design/plan-a.md`, "Why the two arches don't share block code" — with pointer comments at both width computations. The decision is **deliberately frozen, not pending**: the reasoner is a frozen control whose value is exact revivability (#134), so the refiner's block evolves and the reasoner's is touched only to stay runnable.

Its cost, stated plainly because it's a trap for this repo's core comparison: the two round the SwiGLU hidden width differently (256 vs 64), so they **agree at `LATENT_DIM=960` and differ at 512** (1536 vs 1408). "Same dim" is matched by construction at some dims and by coincidence at others — cross-arch claims must quote parameter counts, not dim.

## Record

Not novel — an interface refactor, no research result. Per CLAUDE.md rule 5 this PR is the record; no `docs/findings/` entry, and no ROADMAP tombstone since nothing was killed.

Sequenced before #143, which needed this settled to know whether `model.py` moves into the tree or leaves it. It stays: the reasoner is a first-class implementer of the contract now, not a legacy shape everything else imitates.