### PR TITLE
#146: ruff gate in CI — fix the 22 pre-existing errors and hold the line

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,12 +28,42 @@ on:
 #                         committed golden went stale once already, pre-#50)
 #   overfit smoke (CPU) — end-to-end training-path smoke at tiny scale: the
 #                         real grad step must collapse CE on one batch
+#   lint (ruff)         — errors and bugs only, never formatting (see the ruff
+#                         config in pyproject.toml). Its job is to catch the
+#                         class of defect that costs a run: an unused import
+#                         masking a rename, a shadowed name, an f-string that
+#                         silently prints nothing. Needs no jax, so it finishes
+#                         in seconds and fails fast ahead of the slow jobs.
 # CPU-only throughout (FORCE_F32_COMPUTE via tests/conftest.py or explicit env)
 # so CI runs while the GPU trains; the real f16 path stays RUN_TESTS_ON_GPU=1.
 
 # Each job carries the draft guard (an `if` on the job, since a workflow can't
 # be conditioned as a whole); push events have no PR payload, so they pass.
 jobs:
+  lint:
+    name: lint (ruff)
+    if: ${{ github.event_name == 'push' || !github.event.pull_request.draft }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.14"
+
+      - name: Install ruff
+        # The pin comes from requirements.txt so there is one version to bump, but
+        # only that line is installed — the rest of the file pulls jax, which this
+        # job has no use for. Pinned at all because an unpinned linter turns
+        # "upstream shipped a new rule" into a red build on an unrelated PR.
+        run: pip install "$(grep '^ruff==' requirements.txt)"
+
+      - name: Ruff
+        # Rule selection lives in pyproject.toml, so local `ruff check .` and CI
+        # are the same check — no flags to keep in sync in two places.
+        run: ruff check .
+
   test:
     name: pytest (CPU)
     if: ${{ github.event_name == 'push' || !github.event.pull_request.draft }}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -232,7 +232,7 @@ experiment (the arch behind the flag):
 | **Proof instrument** | `ablation_harness.py` — tiny toy-task depth ablations (parity / cumsum / state-tracking) at the *exact* arch we'd ship |
 | **Diagnostics & smokes** | `tools/` — `eval_depth_curve.py`, `overfit_smoke.py`, `smoke_refiner_gpu.py`, `vram_headroom_smoke.py`, `dump_transcripts.py`, … |
 | **Inference / plots** | `infer_local.py`, `plot_history.py` |
-| **Tests** | `tests/` — three tier folders, `core/` · `apparatus/` · `expensive/`, and the folder is the declaration (`tests/README.md`; a test file dropped straight into `tests/` fails collection). CPU by default (`FORCE_F32_COMPUTE`) so they run while the GPU trains; `RUN_TESTS_ON_GPU=1` for the real f16 path. CI runs core + apparatus on every push/PR to `main`. |
+| **Tests** | `tests/` — three tier folders, `core/` · `apparatus/` · `expensive/`, and the folder is the declaration (`tests/README.md`; a test file dropped straight into `tests/` fails collection). CPU by default (`FORCE_F32_COMPUTE`) so they run while the GPU trains; `RUN_TESTS_ON_GPU=1` for the real f16 path. CI runs core + apparatus on every push/PR to `main`, plus `ruff check .` as its own status (errors and bugs only, config in `pyproject.toml` — run it locally before pushing). |
 
 Hardware reality: one **RTX 2060 (6GB, Turing)** — no bf16 tensor cores, so **f16
 compute is the permanent policy** (`config.py`); the GPU lane is serial. Tokenizer is

--- a/tests/apparatus/test_timemachine.py
+++ b/tests/apparatus/test_timemachine.py
@@ -6,7 +6,6 @@ the arch resolver *refuses to guess* (a wrong arch corrupts the restore) and tha
 metric it compares against is read correctly.
 """
 
-import os
 import json
 
 import pytest

--- a/tests/core/test_chunked_attention.py
+++ b/tests/core/test_chunked_attention.py
@@ -25,7 +25,10 @@ def _stock(q, k, v, pad_cols):
 
 def _rand_qkv(seed, s):
     rng = np.random.default_rng(seed)
-    mk = lambda: jnp.asarray(rng.normal(size=(B, s, H, D)), jnp.float32)
+    def mk():
+        return jnp.asarray(rng.normal(size=(B, s, H, D)), jnp.float32)
+
+    # Drawn in this order from one generator, so q, k, v are distinct.
     q, k, v = mk(), mk(), mk()
     pad_cols = jnp.where(jnp.arange(s) < s - 3, 0.0, -1e9)[None, :].astype(jnp.float32)
     pad_cols = jnp.broadcast_to(pad_cols, (B, s))
@@ -105,7 +108,9 @@ def test_chunked_attention_f16_parity_gpu():
     CPU CI skips this — the CPU lane forces f32 (see conftest)."""
     s, block_q = 160, 128
     rng = np.random.default_rng(23)
-    mk = lambda: jnp.asarray(rng.normal(size=(B, s, H, D)), jnp.float16)
+    def mk():
+        return jnp.asarray(rng.normal(size=(B, s, H, D)), jnp.float16)
+
     q, k, v = mk(), mk(), mk()
     pad_cols = jnp.broadcast_to(
         jnp.where(jnp.arange(s) < s - 5, 0.0, -1e9)[None, :].astype(jnp.float32), (B, s))

--- a/tests/core/test_neutral_contract.py
+++ b/tests/core/test_neutral_contract.py
@@ -13,7 +13,6 @@ The second is the one that matters; the first is what stops the seam from being
 re-opened one convenient attribute at a time.
 """
 
-import io
 import pathlib
 import tokenize
 

--- a/tests/core/test_plan_a_integration.py
+++ b/tests/core/test_plan_a_integration.py
@@ -18,7 +18,7 @@ import pytest
 from flax import nnx
 
 from checkpoint_utils import restore_tolerating_legacy
-from config import MAX_SEQ_LEN, PAD_TOKEN_ID
+from config import MAX_SEQ_LEN
 from grad_step import compute_grad_step, apply_grads
 from plan_a_trainer import RefinerForTraining
 

--- a/tests/core/test_rolling_checkpoint.py
+++ b/tests/core/test_rolling_checkpoint.py
@@ -15,7 +15,6 @@ import jax.numpy as jnp
 import numpy as np
 import orbax.checkpoint as ocp
 
-import checkpoint_utils
 from checkpoint_utils import (
     BEST_SUBDIR,
     CHECKPOINT_ITEMS,

--- a/tools/bf16_mu_smoke.py
+++ b/tools/bf16_mu_smoke.py
@@ -104,7 +104,7 @@ def main():
     gap = np.mean(np.abs(np.array(bf16_losses[half:]) - np.array(f32_losses[half:])))
     rel = gap / np.mean(np.array(f32_losses[half:]))
 
-    print(f"\nstep   f32_mu    bf16_mu")
+    print("\nstep   f32_mu    bf16_mu")
     for s in range(0, args.steps, max(1, args.steps // 10)):
         print(f"{s:4d}  {f32_losses[s]:7.4f}   {bf16_losses[s]:7.4f}")
     print(f"{args.steps-1:4d}  {f32_losses[-1]:7.4f}   {bf16_losses[-1]:7.4f}")

--- a/tools/common.py
+++ b/tools/common.py
@@ -6,11 +6,13 @@ before importing jax through this module).
 
 import os
 
-import jax.numpy as jnp
 from flax import nnx
 import orbax.checkpoint as ocp
 
+from checkpoint_utils import discover_latest_checkpoint_run, restore_tolerating_legacy
 from config import LATENT_DIM, MODEL_ARCH, resolve_root
+from data_loaders import TextDataGenerator
+from model import UniversalReasoner
 
 # Eval builds and scores at batch 1, never at the training BATCH_SIZE (#24). The
 # reasoner's hunch_cache is shaped [batch, slots, dim] and its forward asserts on
@@ -18,9 +20,6 @@ from config import LATENT_DIM, MODEL_ARCH, resolve_root
 # to restore every checkpoint we have — all written when BATCH_SIZE was 1 — for
 # no benefit, since eval reads a handful of rows.
 EVAL_BATCH_SIZE = 1
-from model import UniversalReasoner
-from data_loaders import TextDataGenerator
-from checkpoint_utils import discover_latest_checkpoint_run, restore_tolerating_legacy
 
 
 def _restore_into(model, checkpoint_path):

--- a/tools/depth_playground.py
+++ b/tools/depth_playground.py
@@ -32,9 +32,11 @@ from dotenv import load_dotenv
 
 load_dotenv()
 
-from config import MAX_SEQ_LEN, PAD_TOKEN_ID, TOKENIZER_NAME
-from infer_local import _temperature_truncate
-from tools.common import restore_refiner
+# E402 below is deliberate: these are repo-local modules, reachable only after the
+# sys.path insert above puts the repo root on the path.
+from config import MAX_SEQ_LEN, PAD_TOKEN_ID, TOKENIZER_NAME  # noqa: E402
+from infer_local import _temperature_truncate  # noqa: E402
+from tools.common import restore_refiner  # noqa: E402
 
 
 def generate_at_depth(model, enc, prompt, depth, *, max_new_tokens, temperature,

--- a/tools/dump_transcripts.py
+++ b/tools/dump_transcripts.py
@@ -12,17 +12,20 @@ import os
 
 os.environ.setdefault("XLA_PYTHON_CLIENT_MEM_FRACTION", "0.5")
 
-import argparse
-import datetime
+# Everything below is deliberately imported after the env block above: these reach
+# jax (via tools.common), and the memory-fraction var has no effect once jax is
+# imported. Hoisting them would silently undo the arena cap — hence the noqas.
+import argparse  # noqa: E402
+import datetime  # noqa: E402
 
-import tiktoken
-from dotenv import load_dotenv
+import tiktoken  # noqa: E402
+from dotenv import load_dotenv  # noqa: E402
 
 load_dotenv()
 
-from checkpoint_utils import discover_latest_checkpoint_run
-from config import TOKENIZER_NAME
-from tools.common import restore_model
+from checkpoint_utils import discover_latest_checkpoint_run  # noqa: E402
+from config import TOKENIZER_NAME  # noqa: E402
+from tools.common import restore_model  # noqa: E402
 
 PROMPTS = [
     "The water cycle begins when",

--- a/tools/eval_depth_curve.py
+++ b/tools/eval_depth_curve.py
@@ -29,7 +29,10 @@ from config import MAX_SEQ_LEN, MAX_STEPS_LIMIT, MODEL_ARCH, PAD_TOKEN_ID
 
 load_dotenv()
 
-from tools.common import restore_model, load_eval_batches
+# E402 below is deliberate: tools.common imports jax, and the memory-fraction env
+# var set above has no effect once jax is imported. Hoisting this would silently
+# undo the arena cap.
+from tools.common import restore_model, load_eval_batches  # noqa: E402
 
 
 @nnx.jit(static_argnames=["depth"])

--- a/tools/eval_refiner_depth_transfer.py
+++ b/tools/eval_refiner_depth_transfer.py
@@ -30,7 +30,7 @@ import optax
 from flax import nnx
 import orbax.checkpoint as ocp
 
-from config import LATENT_DIM, MAX_SEQ_LEN, PAD_TOKEN_ID, BATCH_SIZE, resolve_root
+from config import LATENT_DIM, MAX_SEQ_LEN, PAD_TOKEN_ID, resolve_root
 from plan_a_trainer import RefinerForTraining
 from data_loaders import TextDataGenerator
 from checkpoint_utils import discover_latest_checkpoint_run

--- a/tools/smoke_refiner_gpu.py
+++ b/tools/smoke_refiner_gpu.py
@@ -75,9 +75,9 @@ def main():
     print(f"— depth {MAX_STEPS_LIMIT} (worst case) with optimizer resident —")
     for s in range(1, 4):
         loss, _, grads, gnorm = compute_grad_step(model, batch, jnp.array(s), MAX_STEPS_LIMIT)
-        l, g = float(loss), float(gnorm)
-        ok = math.isfinite(l) and math.isfinite(g) and g > 0
-        print(f"  step {s}: loss={l:.4f}  grad_norm={g:.4f}  {'OK' if ok else '✗ NON-FINITE/ZERO'}")
+        loss_f, grad_f = float(loss), float(gnorm)
+        ok = math.isfinite(loss_f) and math.isfinite(grad_f) and grad_f > 0
+        print(f"  step {s}: loss={loss_f:.4f}  grad_norm={grad_f:.4f}  {'OK' if ok else '✗ NON-FINITE/ZERO'}")
         assert ok, f"depth {MAX_STEPS_LIMIT} step {s} non-finite/zero in f16"
         worst_dense = max(worst_dense, read_zero_fracs(grads))
         apply_grads(optimizer, grads, model)

--- a/tools/timemachine.py
+++ b/tools/timemachine.py
@@ -114,7 +114,7 @@ def ensure_worktree(run_id, commit):
 
     untracked = os.path.join(run_dir(run_id), "worktree.untracked.txt")
     if os.path.exists(untracked):
-        n = len([l for l in open(untracked) if l.strip()])
+        n = len([line for line in open(untracked) if line.strip()])
         if n:
             print(f"  note: {n} untracked non-ignored files existed at launch "
                   f"(not restored; see {os.path.relpath(untracked, REPO_ROOT)})")
@@ -336,7 +336,7 @@ def fork(run_id, new_name, build_venv=True, arch_override=None):
         if os.path.exists(s):
             shutil.copy2(s, os.path.join(dst_dir, f))
 
-    print(f"\nResume the fork inside its reconstructed world:")
+    print("\nResume the fork inside its reconstructed world:")
     print(f"  cd {world['worktree']}")
     print(f"  PYTHONPATH=. MODEL_ARCH={world['arch']} DATA_ROOT=$DATA_ROOT \\")
     print(f"    {world['python']} start_training.py --checkpoint-path {dst_ckpt}")


### PR DESCRIPTION
Closes #146. Prerequisite for #143 — landing this first keeps the package-move diff pure renames, with ruff already guarding the new tree.

## What was missing

`pyproject.toml` has configured ruff for a while (`select = ["E4", "E7", "E9", "F", "W6"]` — errors and bugs, never formatting). Nothing ran it, so 22 errors had accumulated. This clears them and adds a separate named **`lint (ruff)`** status, matching #45's one-status-per-load-bearing-check convention.

The job needs no jax, so it finishes in seconds and fails fast ahead of the ~10-minute suites.

## The part that needed judgment

Ten E402s (`module level import not at top of file`), and **seven of them are load-bearing**. `tools/` scripts do this:

```python
os.environ.setdefault("XLA_PYTHON_CLIENT_MEM_FRACTION", "0.5")   # must precede jax
import argparse
from tools.common import restore_model      # ← reaches jax
```

The env var has no effect once jax is imported, so hoisting those imports to satisfy the linter would silently undo the GPU arena cap — a real regression dressed as a lint fix. Same for `tools/depth_playground.py`, where the imports are only reachable after its `sys.path.insert`.

Those carry `# noqa: E402` **with the reason stated at the site**, deliberately not a blanket per-file ignore — a per-file ignore would also hide the next *accidental* E402 in the same file.

`tools/common.py` was the genuine offender: three imports sitting below a constant for no reason. Fixed properly by moving them up.

## The rest

| rule | count | fix |
|---|---|---|
| F401 | 6 | deleted — each verified genuinely unused first, including a bare `import checkpoint_utils` that looked like it might be an import canary and wasn't |
| F541 | 2 | dropped the `f` prefix |
| E741 | 2 | `l` → `loss_f`/`grad_f`, `l` → `line` |
| E731 | 2 | `mk = lambda: ...` → `def mk()` |

One of the F401s (`io` in `tests/core/test_neutral_contract.py`) was mine, from #105 an hour ago — which is a fair argument for the gate existing.

## Verification

- `ruff check .` → **All checks passed!**
- The pin is read from `requirements.txt`'s existing `ruff==0.15.16` (`pip install "$(grep '^ruff==' requirements.txt)"`), so there's one version to bump and no second copy to drift. Verified the extraction resolves.
- Every edited `tools/` module still imports cleanly (`tools.common`, `dump_transcripts`, `depth_playground`, `eval_depth_curve`, `smoke_refiner_gpu`, `timemachine`) — the import-order changes are the risky part, so they were checked directly rather than assumed.
- Tests touching the edited files: 31 passed, 1 skipped (the GPU-only f16 parity case).
- CLAUDE.md's test row now names the lint status, so `ruff check .` before pushing is discoverable.

## Record

Not novel — tooling. Per CLAUDE.md rule 5 this PR is the record; no findings file, no tombstone.