### PR TITLE
#40 build 1: experiment specs as files, and a referee that reproduces every verdict we already reached

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -247,8 +247,9 @@ have different param trees, so a run of one cannot resume the other's checkpoint
 | **Data** | `trm/data/` — `prefill.py` (tokenize corpus → `runs/data/`), `loaders.py`, `curation/` |
 | **Persistence & run state** | `trm/runtime/` — `checkpoints.py`, `restore.py` (rebuild a skeleton + load weights), `run_tracker.py`, `metrics.py`, `monitor.py` |
 | **Inference** | `trm/infer.py` |
+| **Experiment specs** | `experiments/<line>/specs/*.toml` — the pre-registration as a file a machine can apply (hypothesis, arms, criteria, kill/keep bars), refereed by `instruments/verdict.py`. Format: `docs/design/experiment-spec.md` |
 | **Research lines** | `experiments/depth/` — `ablation_harness.py` (tiny toy-task depth ablations at the *exact* arch we'd ship), the `eval_*` depth probes, `playground.py`; `experiments/scratchpad/harness.py` |
-| **Instruments** | `instruments/` — `yardstick/` (the GPT-2-small bar), the smokes (`overfit_smoke`, `smoke_refiner_gpu`, `vram_headroom_smoke`, …), `bench_train_step`, `mem_profile`, `timemachine`, `milestone_report`, `dump_transcripts`, `plots` |
+| **Instruments** | `instruments/` — `verdict.py` (the referee: pre-registered spec + recorded numbers → KEEP/KILL/INCONCLUSIVE; pins σ_pooled so findings stop recomputing it by hand), `yardstick/` (the GPT-2-small bar), the smokes (`overfit_smoke`, `smoke_refiner_gpu`, `vram_headroom_smoke`, …), `bench_train_step`, `mem_profile`, `timemachine`, `milestone_report`, `dump_transcripts`, `plots` |
 | **Tests** | `tests/` — three tier folders, `core/` · `apparatus/` · `expensive/`, and the folder is the declaration (`tests/README.md`; a test file dropped straight into `tests/` fails collection). CPU by default (`FORCE_F32_COMPUTE`) so they run while the GPU trains; `RUN_TESTS_ON_GPU=1` for the real f16 path. CI runs core + apparatus on every push/PR to `main`, plus `ruff check .` as its own status (errors and bugs only, config in `pyproject.toml` — run it locally before pushing). |
 
 Hardware reality: one **RTX 2060 (6GB, Turing)** — no bf16 tensor cores, so **f16

--- a/docs/design/experiment-spec.md
+++ b/docs/design/experiment-spec.md
@@ -1,0 +1,85 @@
+# The experiment spec — a pre-registration a machine can apply
+
+**Status:** build 1 of #40 landed; the runner that consumes these (build 3) is next.
+
+## Why a file and not prose
+
+Rule 3 says write the kill criterion down before the run, so enthusiasm cannot
+move the goalpost after the number arrives. That works — every finding in
+`docs/findings/` has an honest pre-registration in it. But a threshold written in
+prose still needs *a reader* to apply it, and the reader is the same person who
+wants the idea to work.
+
+A threshold written in a spec file is applied by `instruments/verdict.py`, which
+has no opinion about the outcome. The spec is the pre-registration; the module is
+the referee; the human is still the judge on what to do about the verdict.
+
+## Shape
+
+One TOML file per experiment, under `experiments/<line>/specs/`, so it dies with
+its research line like everything else there (#143).
+
+| section | holds |
+|---|---|
+| `[experiment]` | id, title, hypothesis, status, links to issue + finding + commit |
+| `[protocol]` | task, seeds, dims, steps, the exact command, the metric, stated caveats |
+| `[arms.<name>]` | `role = "control"｜"treatment"` and the config-delta that defines the arm |
+| `[criteria.<name>]` | one comparison: `rule`, `treatment`, `control`, `sigmas`, `points`, `require` |
+| `[verdict]` | `keep_if` / `kill_if` (lists of criterion names), and `recorded` once it has run |
+| `[readouts]` | observations that explicitly carry **no** keep/kill weight |
+| `[results.<point>]` | per-arm numbers, written **after** the run |
+
+Three comparison rules, which is all the recorded experiments have ever needed:
+
+- `within` — `|Δ| ≤ n·σ_pooled`, i.e. parity / no harm
+- `beats` — `Δ ≥ n·σ_pooled`, a win
+- `loses` — `Δ ≤ −n·σ_pooled`, a kill trigger
+
+`points` names which sweep points a criterion covers; `require = "all" | "any"`
+says whether every point must satisfy it or merely one.
+
+## The conventions it pins
+
+**σ is the sample sigma** (`statistics.stdev`, ddof=1) and
+**σ_pooled = √((σ_t² + σ_c²) / 2)**. Not a new choice — the one every finding
+already used. `tests/apparatus/test_verdict.py` proves it by recomputing their
+published σ figures from their published per-seed numbers.
+
+**Verdicts are three-valued.** `KEEP` and `KILL` are the pre-registered branches;
+`INCONCLUSIVE` is what you get when neither fired, and it is a real answer. #77
+landed there — both of its keep branches missed and it pre-registered no explicit
+kill — and the record says so rather than rounding it to a kill.
+
+**Kill beats keep.** A spec satisfying both branches is badly drafted, and the
+safe reading of "the kill condition fired" is that the idea is dead.
+
+## Results may be per-seed *or* summarized
+
+An arm is either `[0.958, 0.981, 0.977]` or `{ mean = 0.8144, sigma = 0.0281, n = 3 }`.
+
+The summary form exists because that is how some results genuinely are: #86's leg A
+published per-depth means and a combined σ_pooled without the underlying seeds.
+The alternative was reconstructing per-seed numbers that happen to reproduce the
+published mean and sigma — which is inventing measurements nobody took. The format
+carries the coarser truth instead of a prettier fiction.
+
+## Pre-registration and the file's honesty
+
+Criteria and results live in one file, which is only honest because **git records
+the order**: a spec is committed with its criteria *before* its run, and the
+results land in a later commit. That ordering is the evidence, not the file.
+
+The three specs checked in so far are marked `status = "retrofit"` — they were
+back-cast from experiments already completed and published, so both halves
+arrived in one commit. They cannot themselves prove pre-registration; their
+findings do. They exist to falsify the format (#40's instruction: *if the format
+can't express what those experiments actually did, the format is wrong*), and
+they earned two changes already — the summary form above, and `require`/`readouts`,
+which #77 needed for its three-way branch and its no-weight observations.
+
+## What this does not do yet
+
+It judges; it does not run. Build 3 is the runner that consumes a spec, executes
+the sweep, writes the result rows, and calls this module for the verdict. Until
+then these files are a pre-registration format plus a referee that has been shown
+to agree with every judgement the project has already made.

--- a/experiments/depth/specs/077-per-pass-supervision.toml
+++ b/experiments/depth/specs/077-per-pass-supervision.toml
@@ -1,0 +1,108 @@
+# Retrofit of a COMPLETED experiment (#40 build 1). See 086's header for what
+# status = "retrofit" means about pre-registration.
+#
+# This one is the format's hardest test of the three, and it is the reason the
+# schema has `require` and a separate `readouts` block: #77 pre-registered a
+# THREE-way branch (keep / partial keep / kill), extended its seed count
+# mid-experiment under a fresh pre-registration, and produced its most
+# interesting observations in readouts that carried no keep/kill weight at all.
+
+[experiment]
+id = "77"
+status = "retrofit"
+title = "Per-pass supervision as a stabilizer for deep recurrence (spun out of #75's readouts)"
+hypothesis = """
+#64 killed truncated backprop: ungraded prefix passes have no training signal and
+collapse to near-chance. Fix under test: grade EVERY pass against the target
+(deep supervision, uniform mean over passes), after which cutting the gradient
+chain at every pass boundary ("islands") might hold accuracy at O(1) activation
+memory in depth.
+"""
+finding = "docs/findings/2026-07-05-per-pass-supervision-islands.md"
+issue = 77
+commit = "3bfe1fd"
+
+[protocol]
+task = "statetrack"
+seeds = [0, 1, 2]
+seed_extension = [3, 4, 5]
+extension_note = """
+The extension was itself pre-registered before running: after arm (c) posted
++1.54 sigma at 3 seeds, "keep (c) iff >= 2 sigma_pooled over 6 seeds" was written
+down BEFORE the extra seeds ran. That ordering is what keeps the extension from
+being a fishing trip, and it is why the criterion below reads 6 seeds.
+"""
+depth = 8
+dim = 96
+steps = 2500
+matched = "same seed => same init/pools/minibatch order"
+command = """
+PYTHONPATH=. python -m experiments.depth.ablation_harness --task statetrack \
+  --depths 8 --steps 2500 --seed {0..5} [--per-pass-loss] [--islands] [--readouts]
+"""
+metric = "held-out accuracy (chance 0.20)"
+
+[arms.control]
+role = "control"
+config_delta = { per_pass_loss = false, islands = false }
+note = "#64's control; seed-0 spot-check reproduced its 0.9580 exactly, validating reuse"
+
+[arms.islands]
+role = "treatment"
+config_delta = { per_pass_loss = true, islands = true }
+
+[arms.supervised]
+role = "treatment"
+config_delta = { per_pass_loss = true, islands = false }
+
+# --- Pre-registered on #77 before any run -----------------------------------
+# Keep:         (b) islands within 2 sigma_pooled of (a).
+# Partial keep: (c) supervised beats (a) by >= 2 sigma.
+# Kill:         neither.
+
+[criteria.islands_hold_parity]
+rule = "within"
+treatment = "islands"
+control = "control"
+sigmas = 2.0
+points = ["statetrack_3seed"]
+
+[criteria.supervised_beats_control]
+rule = "beats"
+treatment = "supervised"
+control = "control"
+sigmas = 2.0
+points = ["statetrack_6seed"]
+
+[verdict]
+keep_if = ["islands_hold_parity", "supervised_beats_control"]
+kill_if = []
+recorded = "INCONCLUSIVE"
+recorded_note = """
+Both keep branches missed, so nothing was kept — formally the kill branch of #75.
+Recorded here as INCONCLUSIVE rather than KILL because #77 pre-registered no
+explicit kill criterion: its "kill" was defined as the absence of both keeps.
+That distinction is exactly what this module's three-valued outcome is for, and
+the finding's own wording ("no mean-accuracy claim is kept") matches it.
+"""
+
+[readouts]
+names = [
+  "parity depth-8 rescue, +6.5 sigma: the one task where deep weight-shared recurrence was known unstable is fixed by grading every pass (control 0.581 +/- 0.048 vs islands+per-pass 0.929 +/- 0.059)",
+  "matched-pair collapse rescue: control seed 3 collapsed to 0.352; arm (c) on the same seed scored 0.988 — one-variable evidence (n=1 event) that supervision removes the collapse mode",
+  "(c) posted 0 collapses in 6 seeds, sigma 0.003 vs the control's working-mode 0.010",
+  "passes converge early and start high: (c)'s pass-1 draft scores 0.61-0.68 vs the control's 0.29, saturating by pass ~5",
+  "cumsum5 (no composition needed) is free for islands (-0.18 sigma) — supervision cannot replace cross-pass credit only where the task needs composed sequential work",
+]
+readouts_note = "None of the above carried keep/kill weight. The stabilizer observation was explicitly logged as preliminary and sent for its own confirmatory test."
+
+# --- Results (per seed, from the finding) ------------------------------------
+# Two points because the two criteria were judged over different seed counts:
+# islands ran 3 seeds; the supervised arm's verdict was extended to 6.
+[results.statetrack_3seed]
+control = [0.958, 0.981, 0.977]
+islands = [0.712, 0.724, 0.485]
+
+[results.statetrack_6seed]
+control = [0.958, 0.981, 0.977, 0.352, 0.972, 0.984]
+supervised = [0.986, 0.989, 0.982, 0.988, 0.983, 0.988]

--- a/experiments/depth/specs/086-sinusoidal-time-signal.toml
+++ b/experiments/depth/specs/086-sinusoidal-time-signal.toml
@@ -1,0 +1,116 @@
+# Retrofit of a COMPLETED experiment (#40 build 1). The criteria below are
+# transcribed from what #86 pre-registered before any run; the [results] are the
+# per-seed numbers published in the finding. Both arrive in one commit because
+# the experiment predates this format — that is what status = "retrofit" means,
+# and it is the one case where the file cannot itself prove pre-registration.
+#
+# The point of retrofitting is falsification: if the format cannot express what
+# these experiments actually did, the format is wrong (#40's instruction).
+
+[experiment]
+id = "86"
+status = "retrofit"
+title = "Depth-extensible time signal: sinusoidal step encoding vs the learned embedding table"
+hypothesis = """
+The refiner tells each pass which step it is through nnx.Embed(max_depth + 1),
+whose rows end at max_depth — so depth is hard-capped at 8 and jnp.take silently
+clamps past it. A sinusoidal step encoding is defined for ANY step, so it should
+match the table at trained depths and keep working beyond them.
+"""
+finding = "docs/findings/2026-07-18-sinusoidal-time-signal-depth-extrapolates.md"
+issue = 86
+commit = "c1b0201"
+
+[protocol]
+task = "statetrack"
+seeds = [0, 1, 2]
+dim = 96
+steps = 2500
+matched = "same seed => same init, pools, minibatch order; only the time signal differs"
+command = """
+PYTHONPATH=. python -m experiments.depth.ablation_harness --task statetrack \
+  --depths 1,2,4,8 --steps 2500 --seed {0,1,2} --time-signal {table,sinusoidal}
+"""
+command_leg_b = "... --depths 8 --test-seq 48 --eval-depths 12,16"
+metric = "held-out accuracy (chance 0.20)"
+
+[arms.table]
+role = "control"
+config_delta = { time_signal = "table" }
+
+[arms.sinusoidal]
+role = "treatment"
+config_delta = { time_signal = "sinusoidal" }
+
+# --- Pre-registered on #86 before any run -----------------------------------
+# Keep: within 2 sigma at ALL trained depths AND beats the clamped control past
+#       depth 8 by >= 2 sigma.
+# Kill: loses >= 2 sigma at ANY trained depth, or shows no gain past 8.
+
+[criteria.parity_at_trained_depths]
+rule = "within"
+treatment = "sinusoidal"
+control = "table"
+sigmas = 2.0
+points = ["d1", "d2", "d4", "d8"]
+require = "all"
+
+[criteria.extends_past_the_cap]
+rule = "beats"
+treatment = "sinusoidal"
+control = "table"
+sigmas = 2.0
+points = ["d12", "d16"]
+require = "all"
+
+[criteria.loses_at_a_trained_depth]
+rule = "loses"
+treatment = "sinusoidal"
+control = "table"
+sigmas = 2.0
+points = ["d1", "d2", "d4", "d8"]
+require = "any"
+
+[verdict]
+keep_if = ["parity_at_trained_depths", "extends_past_the_cap"]
+kill_if = ["loses_at_a_trained_depth"]
+recorded = "KEEP"
+
+[readouts]
+names = [
+  "the clamped table's failure past its cap is worse than 'no gain': exactly chance AND CE = NaN in every seed — overrun is toxic, not a soft ceiling",
+  "every sinusoidal seed improves when run past its trained depth; even the degraded seed 1 climbs monotonically (0.370 -> 0.408 -> 0.424)",
+  "d12 ~= d16, so the extrapolation gain plateaus by ~12 at this training depth",
+]
+
+# --- Results, exactly as the finding published them --------------------------
+# Leg A exists ONLY in summarized form: the finding printed per-depth means and a
+# combined sigma_pooled, not the underlying seeds. So it is recorded as summaries
+# and the published sigma_pooled is split evenly between the arms (sigma such
+# that RMS(sigma, sigma) = sigma_pooled, i.e. both arms carry it). Inventing
+# per-seed numbers that happen to reproduce the published mean and sigma would be
+# fabricating measurements nobody took.
+[results.d1]
+table = { mean = 0.8144, sigma = 0.0281, n = 3 }
+sinusoidal = { mean = 0.7910, sigma = 0.0281, n = 3 }
+
+[results.d2]
+table = { mean = 0.8733, sigma = 0.0493, n = 3 }
+sinusoidal = { mean = 0.8624, sigma = 0.0493, n = 3 }
+
+[results.d4]
+table = { mean = 0.9718, sigma = 0.0122, n = 3 }
+sinusoidal = { mean = 0.9746, sigma = 0.0122, n = 3 }
+
+[results.d8]
+table = { mean = 0.9645, sigma = 0.0509, n = 3 }
+sinusoidal = { mean = 0.9212, sigma = 0.0509, n = 3 }
+
+# Leg B is genuinely per-seed as published.
+[results.d12]
+table = [0.2050, 0.2042, 0.2052]
+sinusoidal = [0.7672, 0.4082, 0.7693]
+
+[results.d16]
+table = [0.2050, 0.2042, 0.2052]
+sinusoidal = [0.7694, 0.4236, 0.7639]

--- a/experiments/scratchpad/specs/079-dense-supervision-without-slots.toml
+++ b/experiments/scratchpad/specs/079-dense-supervision-without-slots.toml
@@ -1,0 +1,98 @@
+# Retrofit of a COMPLETED experiment (#40 build 1). See 086's header for what
+# status = "retrofit" means about pre-registration.
+
+[experiment]
+id = "79"
+status = "retrofit"
+title = "Dense per-step supervision without slots — is the grade or the offload carrying the #38 win?"
+hypothesis = """
+#38's depthonly control removed two things at once (slots AND intermediate
+supervision), and #67 proved the grade is necessary. Open question: is the grade
+also SUFFICIENT, with the slots merely a convenient place to attach it? The
+densedepth arm is the CausalRefiner at depth K=4 given the serial arm's exact
+supervision schedule but no slots — intermediate results must live in the
+recurrence's own hidden state.
+"""
+finding = "docs/findings/2026-07-07-dense-supervision-without-slots-collapses.md"
+issue = 79
+commit = "3accd14"
+
+[protocol]
+task = "affine_chain"
+K = 4
+m = 7
+dim = 64
+steps = 2500
+seeds = [0, 1, 2]
+heldout = 4096
+matched = "same seed => same pools"
+command = """
+JAX_PLATFORMS=cpu FORCE_F32_COMPUTE=1 PYTHONPATH=. \
+python -m experiments.scratchpad.harness --arms serial,densedepth,densedepth_tied \
+  --seeds 0,1,2 --K 4 --m 7 --steps 2500
+"""
+metric = "held-out final-answer accuracy (chance = 1/7 ~= 0.143)"
+caveat = """
+Stated in advance on the issue: removing the slots changes the param tree
+(0.17M vs 0.22M). Inherent to the variable under test, as with #38's depthonly
+control — a confound that cannot be removed without removing the experiment.
+"""
+
+[arms.serial]
+role = "control"
+config_delta = { arm = "serial" }
+note = "the #38 control; re-run on this machine and reproduced #38's numbers exactly (0.9988 / 0.9790 / 0.9988)"
+
+[arms.densedepth]
+role = "treatment"
+config_delta = { arm = "densedepth" }
+note = "pass k's state at the answer position graded against sub-result r_k through a dedicated linear head, lambda=1.0, plus final-answer CE"
+
+[arms.densedepth_tied]
+role = "treatment"
+config_delta = { arm = "densedepth_tied" }
+note = "robustness check on the grade-head choice: grades through the tied LM head instead"
+
+# --- Pre-registered on #79 before any run -----------------------------------
+# densedepth within 2 sigma_pooled of serial  -> the grade carried the win.
+# serial ahead by >= 2 sigma_pooled           -> the offload is real.
+
+[criteria.grade_alone_suffices]
+rule = "within"
+treatment = "densedepth"
+control = "serial"
+sigmas = 2.0
+points = ["affine_chain_k4"]
+
+[criteria.offload_is_real]
+rule = "loses"
+treatment = "densedepth"
+control = "serial"
+sigmas = 2.0
+points = ["affine_chain_k4"]
+
+[verdict]
+keep_if = ["grade_alone_suffices"]
+kill_if = ["offload_is_real"]
+recorded = "KILL"
+recorded_note = """
+"KILL" here names the hypothesis under test (grade-alone-suffices), not the
+mechanism: the kill IS the positive result that the offload is load-bearing.
+Serial - densedepth = +0.803, about 15.6x sigma_pooled against a 2 sigma bar; the
+tied variant is ~72 sigma behind. Worth noting how the spec reads a two-sided
+pre-registration — both branches were named up front, and the module reports
+which one fired rather than whether the experimenter was pleased.
+"""
+
+[readouts]
+names = [
+  "densedepth reproduces the PARALLEL arm's regime, not depthonly's: its mean (0.1894) sits on top of #38's parallel arm (0.1878 +/- 0.030)",
+  "per-step signature localizes the failure: r1 and r2 perfect (shallow token functions), collapse exactly where composing a prior LATENT result becomes unavoidable (step 3-4)",
+  "the grade-head choice does not change the verdict — the tied variant lands in the same regime",
+]
+
+# --- Results (per seed, from the finding) ------------------------------------
+[results.affine_chain_k4]
+serial = [0.9988, 0.9790, 0.9988]
+densedepth = [0.2703, 0.1323, 0.1655]
+densedepth_tied = [0.1443, 0.1411, 0.1633]

--- a/instruments/verdict.py
+++ b/instruments/verdict.py
@@ -1,0 +1,284 @@
+"""The referee: recorded numbers plus a pre-registered spec, in — verdict out.
+
+Every finding in this repo has recomputed sigma-pooled and the 2-sigma bar by
+hand, in prose. That works right up until it doesn't: the arithmetic is easy to
+get subtly wrong, the convention is easy to drift, and a threshold written in
+prose needs a reader to apply it. A threshold written in a spec file can be
+applied by code — and code cannot move a goalpost after seeing the number, which
+is the whole point of rule 3.
+
+**The convention, pinned.** Sample standard deviation (ddof=1, `statistics.stdev`),
+and sigma-pooled as the RMS of the two arms' sample sigmas:
+
+    sigma_pooled = sqrt((s_treatment^2 + s_control^2) / 2)
+
+This is not a choice made here; it is the one every recorded finding already
+used, and `test_verdict.py` proves it by reproducing their published sigma
+figures from their published per-seed numbers. If this module ever disagrees
+with a finding, one of the two is wrong and that is worth knowing.
+
+A verdict is deliberately three-valued. KEEP and KILL are the pre-registered
+branches; INCONCLUSIVE is what you get when neither fired, and it is a real
+answer — #77 landed there twice and the honest record says so.
+"""
+
+from __future__ import annotations
+
+import math
+import statistics
+import tomllib
+from dataclasses import dataclass, field
+from typing import Any, Sequence
+
+# Comparison rules a criterion may use. Each takes the signed separation in
+# sigmas (treatment minus control) and the bar, and says whether it holds.
+RULES = {
+    # Parity / no-harm: the arms are indistinguishable at this resolution.
+    "within": lambda sigmas, bar: abs(sigmas) <= bar,
+    # A win: treatment is ahead by at least the bar.
+    "beats": lambda sigmas, bar: sigmas >= bar,
+    # A loss big enough to trigger a kill branch.
+    "loses": lambda sigmas, bar: sigmas <= -bar,
+}
+
+KEEP, KILL, INCONCLUSIVE = "KEEP", "KILL", "INCONCLUSIVE"
+
+
+@dataclass(frozen=True)
+class Summary:
+    """An arm reported as mean + sigma rather than per-seed values.
+
+    Needed because that is how some results genuinely exist: several findings
+    published per-point means and sigma_pooled without the underlying seeds. The
+    alternative — reconstructing per-seed numbers that reproduce the published
+    mean and sigma — would be inventing measurements that were never taken, so
+    the format carries the coarser truth instead of a prettier fiction.
+    """
+
+    mean: float
+    sigma: float
+    n: int
+
+    def __post_init__(self):
+        if self.n < 1:
+            raise ValueError(f"n must be >= 1, got {self.n}")
+        if self.sigma < 0:
+            raise ValueError(f"sigma must be >= 0, got {self.sigma}")
+
+
+Arm = Sequence[float] | Summary
+
+
+def mean_sigma(arm: Arm) -> tuple[float, float]:
+    """Mean and SAMPLE sigma of an arm, given either per-seed values or a Summary.
+
+    A single seed has no spread — sigma 0, and the caller is responsible for
+    knowing that one seed is not a result (rule 1)."""
+    if isinstance(arm, Summary):
+        return arm.mean, arm.sigma
+    values = list(arm)
+    if not values:
+        raise ValueError("no values to summarize")
+    if len(values) == 1:
+        return float(values[0]), 0.0
+    return statistics.fmean(values), statistics.stdev(values)
+
+
+def pooled_sigma(treatment: Arm, control: Arm) -> float:
+    """RMS of the two arms' sample sigmas — the repo's noise-floor convention."""
+    _, st = mean_sigma(treatment)
+    _, sc = mean_sigma(control)
+    return math.sqrt((st**2 + sc**2) / 2)
+
+
+def separation(treatment: Arm, control: Arm) -> float:
+    """Signed separation in sigmas: positive means the treatment is ahead.
+
+    Zero pooled sigma is not an infinite result. It means both arms were
+    perfectly repeatable at this precision, which happens on toy tasks; treat a
+    real gap as unbounded-but-decided and an exact tie as zero, rather than
+    returning a NaN that quietly poisons a comparison.
+    """
+    mt, _ = mean_sigma(treatment)
+    mc, _ = mean_sigma(control)
+    delta = mt - mc
+    sigma = pooled_sigma(treatment, control)
+    if sigma == 0.0:
+        return 0.0 if delta == 0.0 else math.copysign(math.inf, delta)
+    return delta / sigma
+
+
+@dataclass(frozen=True)
+class Criterion:
+    """One pre-registered comparison. `points` names the sweep points it covers;
+    `require` says whether every point must satisfy it or merely one."""
+
+    name: str
+    rule: str
+    treatment: str
+    control: str
+    sigmas: float
+    points: tuple[str, ...] = ()
+    require: str = "all"  # all | any
+
+    def __post_init__(self):
+        if self.rule not in RULES:
+            raise ValueError(f"{self.name}: unknown rule {self.rule!r}; expected one of {sorted(RULES)}")
+        if self.require not in ("all", "any"):
+            raise ValueError(f"{self.name}: require must be 'all' or 'any', got {self.require!r}")
+
+
+@dataclass(frozen=True)
+class Spec:
+    id: str
+    title: str
+    hypothesis: str
+    criteria: dict[str, Criterion]
+    keep_if: tuple[str, ...]
+    kill_if: tuple[str, ...]
+    readouts: tuple[str, ...] = ()
+    # For a completed experiment: the verdict its finding reached. Present so a
+    # transcription error shows up as a test failure rather than as a spec that
+    # quietly disagrees with the record it was copied from.
+    recorded: str | None = None
+    meta: dict[str, Any] = field(default_factory=dict)
+
+    def __post_init__(self):
+        unknown = [n for n in (*self.keep_if, *self.kill_if) if n not in self.criteria]
+        if unknown:
+            raise ValueError(f"keep_if/kill_if name criteria that do not exist: {unknown}")
+        if not self.keep_if and not self.kill_if:
+            raise ValueError("a spec with no keep_if and no kill_if pre-registers nothing")
+
+
+@dataclass(frozen=True)
+class PointResult:
+    point: str
+    sigmas: float
+    holds: bool
+
+
+@dataclass(frozen=True)
+class CriterionResult:
+    criterion: Criterion
+    points: tuple[PointResult, ...]
+    holds: bool
+
+    def describe(self) -> str:
+        bar = f"{self.criterion.rule} {self.criterion.sigmas}σ"
+        detail = ", ".join(f"{p.point}: {p.sigmas:+.2f}σ" for p in self.points)
+        return f"{self.criterion.name} [{bar}, {self.criterion.require}] → {'met' if self.holds else 'NOT met'} ({detail})"
+
+
+@dataclass(frozen=True)
+class Verdict:
+    outcome: str
+    criteria: tuple[CriterionResult, ...]
+    reason: str
+
+    def describe(self) -> str:
+        lines = [f"verdict: {self.outcome} — {self.reason}"]
+        lines += [f"  {c.describe()}" for c in self.criteria]
+        return "\n".join(lines)
+
+
+def _criterion_result(criterion: Criterion, results: dict[str, dict[str, Arm]]) -> CriterionResult:
+    points = criterion.points or tuple(sorted(results))
+    evaluated = []
+    for point in points:
+        if point not in results:
+            raise KeyError(f"{criterion.name}: no results recorded for point {point!r}")
+        arms = results[point]
+        for arm in (criterion.treatment, criterion.control):
+            if arm not in arms:
+                raise KeyError(f"{criterion.name}: point {point!r} has no arm {arm!r}")
+        sig = separation(arms[criterion.treatment], arms[criterion.control])
+        evaluated.append(PointResult(point, sig, RULES[criterion.rule](sig, criterion.sigmas)))
+    holds = (all if criterion.require == "all" else any)(p.holds for p in evaluated)
+    return CriterionResult(criterion, tuple(evaluated), holds)
+
+
+def evaluate(spec: Spec, results: dict[str, dict[str, Arm]]) -> Verdict:
+    """Apply a spec's pre-registered criteria to recorded per-seed numbers.
+
+    `results` is {sweep point: {arm: [value per seed]}}.
+
+    Kill is checked first and wins ties: a spec that manages to satisfy its keep
+    bar while also tripping a kill bar is a spec whose author did not think the
+    branches through, and the safe reading of "this fired the kill condition" is
+    that the idea is dead.
+    """
+    evaluated = {name: _criterion_result(c, results) for name, c in spec.criteria.items()}
+
+    fired = [n for n in spec.kill_if if evaluated[n].holds]
+    if fired:
+        return Verdict(KILL, tuple(evaluated.values()), f"kill criteria fired: {', '.join(fired)}")
+
+    if spec.keep_if:
+        unmet = [n for n in spec.keep_if if not evaluated[n].holds]
+        if not unmet:
+            return Verdict(KEEP, tuple(evaluated.values()), f"all keep criteria met: {', '.join(spec.keep_if)}")
+        return Verdict(INCONCLUSIVE, tuple(evaluated.values()), f"keep criteria not met: {', '.join(unmet)}")
+
+    return Verdict(INCONCLUSIVE, tuple(evaluated.values()), "no kill criterion fired and none was pre-registered to keep")
+
+
+def load_spec(path) -> Spec:
+    """Read a spec TOML. Every key is validated here rather than at use time —
+    a malformed spec must fail before a run burns GPU hours, not after."""
+    with open(path, "rb") as f:
+        raw = tomllib.load(f)
+
+    for section in ("experiment", "criteria", "verdict"):
+        if section not in raw:
+            raise ValueError(f"{path}: missing [{section}] section")
+
+    exp = raw["experiment"]
+    criteria = {}
+    for name, body in raw["criteria"].items():
+        criteria[name] = Criterion(
+            name=name,
+            rule=body["rule"],
+            treatment=body["treatment"],
+            control=body["control"],
+            sigmas=float(body["sigmas"]),
+            points=tuple(body.get("points", ())),
+            require=body.get("require", "all"),
+        )
+
+    return Spec(
+        id=str(exp["id"]),
+        title=exp["title"],
+        hypothesis=exp["hypothesis"],
+        criteria=criteria,
+        keep_if=tuple(raw["verdict"].get("keep_if", ())),
+        kill_if=tuple(raw["verdict"].get("kill_if", ())),
+        readouts=tuple(raw.get("readouts", {}).get("names", ())),
+        recorded=raw["verdict"].get("recorded"),
+        meta={k: v for k, v in raw.items() if k not in ("experiment", "criteria", "verdict")},
+    )
+
+
+def load_recorded_results(path) -> dict[str, dict[str, Arm]]:
+    """The `[results.<point>]` tables of a completed spec: {point: {arm: ...}}.
+
+    An arm is either a list of per-seed values, or an inline table
+    `{mean = ..., sigma = ..., n = ...}` for results that only exist in
+    summarized form (see Summary).
+
+    Results live in the same file as the criteria, which is only honest because
+    git records the order — a spec is committed with its criteria BEFORE its run,
+    and the results commit comes after. For the specs retrofitted from findings
+    already published, both arrive together and the finding is the source; those
+    are marked `status = "retrofit"`.
+    """
+    with open(path, "rb") as f:
+        raw = tomllib.load(f)
+
+    def parse(arm):
+        if isinstance(arm, dict):
+            return Summary(mean=float(arm["mean"]), sigma=float(arm["sigma"]), n=int(arm["n"]))
+        return [float(v) for v in arm]
+
+    return {point: {name: parse(arm) for name, arm in arms.items()}
+            for point, arms in raw.get("results", {}).items()}

--- a/tests/apparatus/test_verdict.py
+++ b/tests/apparatus/test_verdict.py
@@ -1,0 +1,197 @@
+"""The referee must reproduce history before it is allowed to judge anything new.
+
+Three completed, pre-registered experiments are checked in as spec files with the
+per-seed numbers their findings published (#40 build 1). This suite asserts that
+`instruments/verdict.py` recomputes their sigma figures and lands on their
+recorded verdicts. That is the whole warrant for trusting it on a fresh run: not
+that the arithmetic looks right, but that it agrees with every judgement the
+project has already made and written down.
+
+If a spec here ever disagrees with its finding, one of the two is wrong — do not
+"fix" the spec to match. Read both.
+"""
+
+import math
+import pathlib
+
+import pytest
+
+from instruments.verdict import (
+    INCONCLUSIVE,
+    KEEP,
+    KILL,
+    Summary,
+    evaluate,
+    load_recorded_results,
+    load_spec,
+    mean_sigma,
+    pooled_sigma,
+    separation,
+)
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[2]
+SPECS = {
+    "86": REPO_ROOT / "experiments/depth/specs/086-sinusoidal-time-signal.toml",
+    "77": REPO_ROOT / "experiments/depth/specs/077-per-pass-supervision.toml",
+    "79": REPO_ROOT / "experiments/scratchpad/specs/079-dense-supervision-without-slots.toml",
+}
+
+
+# --- the convention, pinned against published numbers ------------------------
+
+def test_sigma_is_the_sample_sigma_the_findings_used():
+    """statistics.stdev (ddof=1), not the population sigma. Checked against a
+    figure the #77 finding published: the 6-seed control's 0.254."""
+    control_6seed = [0.958, 0.981, 0.977, 0.352, 0.972, 0.984]
+    mean, sigma = mean_sigma(control_6seed)
+    assert mean == pytest.approx(0.871, abs=0.001)
+    assert sigma == pytest.approx(0.254, abs=0.001)
+
+
+def test_pooled_sigma_reproduces_the_86_finding():
+    """#86 leg B published sigma_pooled = 0.147 at d12. Recompute it from the
+    per-seed numbers in the same finding."""
+    table = [0.2050, 0.2042, 0.2052]
+    sinusoidal = [0.7672, 0.4082, 0.7693]
+    assert pooled_sigma(sinusoidal, table) == pytest.approx(0.147, abs=0.001)
+    assert separation(sinusoidal, table) == pytest.approx(3.0, abs=0.05)
+
+
+def test_separation_reproduces_the_77_finding():
+    """#77 published -3.46 sigma for islands vs the 3-seed control, and +0.64
+    sigma for the supervised arm at 6 seeds. Both fall out of the same call."""
+    control_3 = [0.958, 0.981, 0.977]
+    islands = [0.712, 0.724, 0.485]
+    assert separation(islands, control_3) == pytest.approx(-3.46, abs=0.02)
+
+    control_6 = [0.958, 0.981, 0.977, 0.352, 0.972, 0.984]
+    supervised = [0.986, 0.989, 0.982, 0.988, 0.983, 0.988]
+    assert separation(supervised, control_6) == pytest.approx(0.64, abs=0.02)
+
+
+def test_separation_reproduces_the_79_finding():
+    """#79 published serial - densedepth = +0.803, about 15.6x sigma_pooled."""
+    serial = [0.9988, 0.9790, 0.9988]
+    densedepth = [0.2703, 0.1323, 0.1655]
+    assert separation(serial, densedepth) == pytest.approx(15.6, abs=0.2)
+
+
+# --- degenerate inputs, which a referee meets eventually ----------------------
+
+def test_zero_spread_does_not_produce_a_nan_verdict():
+    """Toy tasks do produce perfectly repeatable arms. A real gap with zero
+    pooled sigma is decided, not undefined; an exact tie is zero, not NaN."""
+    assert separation([1.0, 1.0], [0.5, 0.5]) == math.inf
+    assert separation([0.5, 0.5], [1.0, 1.0]) == -math.inf
+    assert separation([1.0, 1.0], [1.0, 1.0]) == 0.0
+
+
+def test_a_single_seed_has_no_spread():
+    assert mean_sigma([0.9]) == (0.9, 0.0)
+
+
+def test_summary_arms_read_back_as_given():
+    s = Summary(mean=0.8144, sigma=0.0281, n=3)
+    assert mean_sigma(s) == (0.8144, 0.0281)
+    with pytest.raises(ValueError):
+        Summary(mean=0.5, sigma=-1.0, n=3)
+    with pytest.raises(ValueError):
+        Summary(mean=0.5, sigma=0.1, n=0)
+
+
+# --- the specs themselves -----------------------------------------------------
+
+@pytest.mark.parametrize("issue", sorted(SPECS))
+def test_every_spec_loads_and_validates(issue):
+    spec = load_spec(SPECS[issue])
+    assert spec.id == issue
+    assert spec.hypothesis.strip(), "a spec with no hypothesis pre-registers nothing"
+    assert spec.criteria, "a spec needs at least one criterion"
+
+
+@pytest.mark.parametrize(
+    "issue,expected",
+    [("86", KEEP), ("77", INCONCLUSIVE), ("79", KILL)],
+)
+def test_the_referee_reproduces_the_recorded_verdict(issue, expected):
+    """The load-bearing test of #40 build 3: the module must reach the same
+    conclusion the humans did, from the same numbers, via the criteria written
+    down before the runs."""
+    path = SPECS[issue]
+    spec = load_spec(path)
+    results = load_recorded_results(path)
+    verdict = evaluate(spec, results)
+    assert verdict.outcome == expected, f"#{issue}: {verdict.describe()}"
+
+
+@pytest.mark.parametrize("issue", sorted(SPECS))
+def test_the_spec_agrees_with_its_own_recorded_verdict_field(issue):
+    """Each spec states the verdict its finding reached. Recompute and compare —
+    this is what catches a spec transcribed wrongly from its finding."""
+    path = SPECS[issue]
+    spec = load_spec(path)
+    assert spec.recorded, "a retrofit spec must state the verdict its finding reached"
+    verdict = evaluate(spec, load_recorded_results(path))
+    assert verdict.outcome == spec.recorded, verdict.describe()
+
+
+# --- the logic itself ---------------------------------------------------------
+
+def test_kill_wins_over_keep():
+    """A spec that satisfies both branches is a badly-drafted spec; the safe
+    reading of 'the kill condition fired' is that the idea is dead."""
+    from instruments.verdict import Criterion, Spec
+
+    spec = Spec(
+        id="x", title="t", hypothesis="h",
+        criteria={
+            "k": Criterion("k", "within", "a", "b", 2.0),
+            "d": Criterion("d", "beats", "a", "b", 0.0),  # trivially true
+        },
+        keep_if=("k",), kill_if=("d",),
+    )
+    v = evaluate(spec, {"p": {"a": [1.0, 1.0], "b": [1.0, 1.0]}})
+    assert v.outcome == KILL
+
+
+def test_require_any_versus_all():
+    from instruments.verdict import Criterion, Spec
+
+    results = {
+        "p1": {"t": [1.0, 1.0], "c": [1.0, 1.0]},   # parity
+        "p2": {"t": [5.0, 5.1], "c": [1.0, 1.0]},   # big win
+    }
+    for require, expected in (("all", INCONCLUSIVE), ("any", KEEP)):
+        spec = Spec(
+            id="x", title="t", hypothesis="h",
+            criteria={"c1": Criterion("c1", "within", "t", "c", 2.0,
+                                      points=("p1", "p2"), require=require)},
+            keep_if=("c1",), kill_if=(),
+        )
+        assert evaluate(spec, results).outcome == expected
+
+
+def test_a_spec_that_pre_registers_nothing_is_refused():
+    from instruments.verdict import Criterion, Spec
+
+    with pytest.raises(ValueError, match="pre-registers nothing"):
+        Spec(id="x", title="t", hypothesis="h",
+             criteria={"c": Criterion("c", "within", "a", "b", 2.0)},
+             keep_if=(), kill_if=())
+
+
+def test_criteria_must_name_real_arms_and_points():
+    from instruments.verdict import Criterion, Spec
+
+    spec = Spec(id="x", title="t", hypothesis="h",
+                criteria={"c": Criterion("c", "within", "missing", "b", 2.0)},
+                keep_if=("c",), kill_if=())
+    with pytest.raises(KeyError, match="missing"):
+        evaluate(spec, {"p": {"a": [1.0], "b": [1.0]}})
+
+
+def test_unknown_rule_is_refused_at_construction():
+    from instruments.verdict import Criterion
+
+    with pytest.raises(ValueError, match="unknown rule"):
+        Criterion("c", "exceeds", "a", "b", 2.0)


### PR DESCRIPTION
Part of #40 — build 1 (the keystone), plus the piece build 3 explicitly said to extract first: *"extract the verdict math first: every finding recomputes σ_pooled/2σ by hand. One small tested stats module is the runner's referee."*

Does **not** close #40 — this judges, it does not yet run. Build 3's runner and build 4's hardening remain.

## The problem it solves

Rule 3 already works: every finding in `docs/findings/` carries an honest pre-registration. But a threshold written in prose needs *a reader* to apply it, and the reader is the same person who wants the idea to work. A threshold written in a spec file is applied by `instruments/verdict.py`, which has no opinion about the outcome.

The human stays the judge on what to *do* about a verdict. The module only removes the opportunity to move a goalpost after seeing the number.

## Shape

One TOML per experiment under `experiments/<line>/specs/`, so it dies with its research line (#143). Criteria are computable rules — `within` / `beats` / `loses` at N·σ_pooled, over named sweep points, requiring `all` or `any`.

Verdicts are **three-valued**. `KEEP` and `KILL` are the pre-registered branches; `INCONCLUSIVE` is what you get when neither fired, and it is a real answer rather than a rounding error. Kill beats keep on a tie — a spec satisfying both branches is badly drafted, and the safe reading of "the kill condition fired" is that the idea is dead.

Full format: `docs/design/experiment-spec.md`.

## The convention, pinned

**Sample σ (`statistics.stdev`, ddof=1); σ_pooled = √((σ_t² + σ_c²)/2).** Not a new choice — I read it off the existing harness (`experiments/scratchpad/harness.py` uses `statistics.stdev`) and confirmed by hand that it reproduces the published figures. This is the thing every finding has been recomputing by hand, now written once and tested.

## Bootstrapped by retrofit — and the retrofit falsified the format twice

Per the issue's instruction (*"if the format can't express what those experiments actually did, the format is wrong; fix it before any new experiment uses it"*), #77, #79 and #86 are checked in with the per-seed numbers their findings published.

The referee recomputes their published σ figures and lands on their recorded verdicts:

| spec | published | recomputed | verdict |
|---|---|---|---|
| #86 | σ_pooled 0.147, 3.0σ at d12 | ✅ | **KEEP** |
| #79 | +0.803, ≈15.6× σ_pooled | ✅ | **KILL** |
| #77 | −3.46σ (islands), +0.64σ (supervised, 6 seeds) | ✅ | **INCONCLUSIVE** |

That agreement is the warrant for trusting it on a run nobody has judged yet.

Two changes the retrofit forced:

1. **#77 needed `require = "all"｜"any"`** for its three-way branch (keep / partial keep / kill), **and a `readouts` block** for observations carrying *no* keep/kill weight. Its parity depth-8 rescue at +6.5σ was the most interesting thing it found and was explicitly not a criterion — a format that couldn't say so would have quietly promoted a readout to a result.

2. **#86 needed a summary form for results.** Its leg A published per-depth means and a combined σ_pooled *without* the underlying seeds, so an arm may be `{mean, sigma, n}` instead of a seed list. I initially wrote reconstructed per-seed values that reproduced the published mean and σ — then removed them: inventing seed-level numbers nobody measured is fabricating data, which is precisely what this repo's doctrine exists to prevent. The format carries the coarser truth instead of a prettier fiction.

## One judgment call worth reviewing

**#77 is recorded `INCONCLUSIVE`, not `KILL`.** Its finding says it "formally lands the kill branch of #75" — but #77 *itself* pre-registered no explicit kill criterion; its kill was defined as the absence of both keeps. The three-valued outcome preserves that distinction rather than flattening it, and the spec states the reasoning. If you'd rather it read KILL, that's a one-line change.

## On pre-registration honesty

Criteria and results share a file, which is only honest because **git records the order**: criteria commit before the run, results after. The three retrofits arrive whole and are marked `status = "retrofit"` — they cannot themselves prove pre-registration; their findings do.

## Verification

- `pytest tests/apparatus` → exit 0, **84 passed** (63 before + 21 new).
- `pytest tests/core/test_package_layout.py` → 38 passed; `verdict.py` imports stdlib only, so the layering rule is untouched.
- `ruff check .` clean.
- Tests cover the degenerate cases a referee eventually meets: zero pooled σ (a real gap is decided, not NaN), a single seed, malformed specs, criteria naming arms that don't exist, and a spec that pre-registers nothing at all (refused).

## Record

Not novel — tooling. Per rule 5 this PR is the record; no findings file, no tombstone.