### PR TITLE
#40 build 4: the #16 saga's watchdog and sentinel, promoted into one process that cannot race

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -245,7 +245,7 @@ have different param trees, so a run of one cannot resume the other's checkpoint
 | **Model — control/graveyard** | `trm/model/reasoner.py` (UniversalReasoner) |
 | **Training loop** | `trm/train/` — `trainer.py` (loop + data pipeline), `start.py` (entry), `grad_step.py`, `losses.py`, `optimizers.py`, `schedules.py`, `validation.py` (held-out probe) |
 | **Data** | `trm/data/` — `prefill.py` (tokenize corpus → `runs/data/`), `loaders.py`, `curation/` |
-| **Persistence & run state** | `trm/runtime/` — `checkpoints.py`, `restore.py` (rebuild a skeleton + load weights), `run_tracker.py`, `metrics.py`, `monitor.py` |
+| **Persistence & run state** | `trm/runtime/` — `checkpoints.py`, `restore.py` (rebuild a skeleton + load weights), `run_tracker.py`, `metrics.py`, `monitor.py`, `supervisor.py` (unattended runs: budget stop, plateau/divergence/stall kills, crash relaunch, GPU lock, disk precheck, heartbeat — `python -m trm.runtime.supervisor`) |
 | **Inference** | `trm/infer.py` |
 | **Experiment specs** | `experiments/<line>/specs/*.toml` — the pre-registration as a file a machine can apply (hypothesis, arms, criteria, kill/keep bars), refereed by `instruments/verdict.py` and run by `python -m instruments.experiment <spec>`. Format: `docs/design/experiment-spec.md` |
 | **Research lines** | `experiments/depth/` — `ablation_harness.py` (tiny toy-task depth ablations at the *exact* arch we'd ship), the `eval_*` depth probes, `playground.py`; `experiments/scratchpad/harness.py` |

--- a/docs/AUTONOMY.md
+++ b/docs/AUTONOMY.md
@@ -122,6 +122,28 @@ serial GPU. So it needs:
   unnoticed because no tracked artifact showed liveness.
 - **Resource guards in code, not prose**: disk-headroom precheck, GPU serial-queue
   lock (one job at a time), a compute-budget cap.
+
+Both now exist as `trm/runtime/supervisor.py` (#40 build 4), promoted from the
+bash scripts the #16 base-run campaign wrote under fire:
+
+```bash
+python -m trm.runtime.supervisor --stop-step 2289 --run-dir runs/run_X \
+    --log runs/base.log --issue 16 -- --new-run
+```
+
+It enforces the token budget (the trainer has no hard stop), kills a CE-plateau
+SFT auto-flip that would contaminate a pretrain run, kills a diverging warm
+restart, restarts a wedged one, relaunches after a real crash within a retry
+budget, and heartbeats into a pinned issue. Preflight refuses to launch onto a
+nearly-full disk or a card another run already holds.
+
+**Why it is one process.** The originals were a watchdog and a sentinel talking
+through marker lines in a log, so "did it crash, or did the watchdog stop it?"
+was answered by reading a file the watchdog had not finished writing — and a
+clean finish landing in that window read as a crash and got relaunched. The
+supervisor owns its child, and every decision comes from one pure function whose
+guards are evaluated *before* liveness. `tests/core/test_supervisor.py` states
+that original bug as an assertion.
 - **Resumability**: state visible enough that a fresh session knows exactly where
   the loop left off and continues without re-deriving context.
 

--- a/tests/core/test_supervisor.py
+++ b/tests/core/test_supervisor.py
@@ -1,0 +1,361 @@
+"""The unattended-run guards, and the race that made them worth writing down.
+
+The #16 base run was supervised by two bash processes talking through marker
+lines in a log file. The sentinel asked "the trainer is gone — did it crash, or
+did the watchdog stop it?" by grepping a file the watchdog had not finished
+writing, and in that window it read a *completed* run as a crash and relaunched
+it. The fix in production was a longer sleep, which narrows the window without
+closing it.
+
+`trm/runtime/supervisor.py` closes it by making the decision a pure function
+whose guards are evaluated before liveness. The load-bearing test in this file
+is `test_a_finished_run_is_not_a_crash_even_though_the_process_is_gone` — it is
+the original bug, stated as an assertion.
+"""
+
+import os
+import subprocess
+import sys
+import textwrap
+
+import pytest
+
+from trm.runtime.supervisor import (
+    BUDGET_COMPLETE,
+    CONTINUE,
+    CRASHED,
+    GAVE_UP,
+    GIVE_UP,
+    KILL,
+    KILLED_DIVERGENCE,
+    KILLED_PLATEAU,
+    RELAUNCH,
+    RESTART,
+    RUNNING,
+    STALLED,
+    STOP,
+    WALLCLOCK_COMPLETE,
+    GpuLock,
+    Limits,
+    Observation,
+    Preflight,
+    State,
+    check_disk_headroom,
+    decide,
+    plateau_in,
+    read_progress,
+)
+
+LIMITS = Limits(stop_step=1000, max_ce=6.5, divergence_checks=2, max_retries=2)
+
+
+def obs(**kw):
+    base = dict(step=10, ce=3.0, plateau_detected=False, alive=True, elapsed_hours=0.0)
+    return Observation(**{**base, **kw})
+
+
+# --- the race the original got wrong ------------------------------------------
+
+def test_a_finished_run_is_not_a_crash_even_though_the_process_is_gone():
+    """THE regression test. The trainer reached its budget and exited; the
+    supervisor looks a moment later and sees a dead process. The original
+    sentinel called this a crash and relaunched a completed run."""
+    decision = decide(obs(step=1000, alive=False), LIMITS, State())
+    assert decision.outcome == BUDGET_COMPLETE
+    assert decision.action == STOP
+
+
+def test_a_deliberate_kill_is_not_a_crash_either():
+    """Same shape, other guards: a plateau kill or a divergence kill must not
+    come back as a relaunchable crash on the next look."""
+    assert decide(obs(alive=False, plateau_detected=True), LIMITS, State()).outcome == KILLED_PLATEAU
+
+    state = State(divergence_streak=1)
+    assert decide(obs(alive=False, ce=99.0), LIMITS, state).outcome == KILLED_DIVERGENCE
+
+
+def test_a_genuine_crash_before_budget_still_relaunches():
+    """The guard-first ordering must not have made every death look clean."""
+    state = State()
+    decision = decide(obs(step=400, alive=False), LIMITS, state)
+    assert (decision.action, decision.outcome) == (RELAUNCH, CRASHED)
+    assert state.retries_used == 1
+
+
+# --- the decision table -------------------------------------------------------
+
+def test_a_healthy_run_is_left_alone():
+    decision = decide(obs(step=500, ce=3.2), LIMITS, State())
+    assert (decision.action, decision.outcome) == (CONTINUE, RUNNING)
+
+
+def test_plateau_outranks_everything():
+    """A CE-plateau SFT flip silently contaminates a pretrain run, so it is worth
+    killing an otherwise healthy — even a finished-looking — run."""
+    decision = decide(obs(step=1000, plateau_detected=True), LIMITS, State())
+    assert (decision.action, decision.outcome) == (KILL, KILLED_PLATEAU)
+
+
+def test_divergence_needs_a_streak_not_a_blip():
+    """One bad reading is noise; the guard exists for a warm restart that is
+    actually blowing up, and killing a run on a single spike wastes it."""
+    state = State()
+    assert decide(obs(ce=99.0), LIMITS, state).action == CONTINUE
+    assert state.divergence_streak == 1
+    assert decide(obs(ce=99.0), LIMITS, state).outcome == KILLED_DIVERGENCE
+
+
+def test_a_recovered_ce_clears_the_streak():
+    state = State()
+    decide(obs(ce=99.0), LIMITS, state)
+    decide(obs(ce=3.0), LIMITS, state)
+    assert state.divergence_streak == 0
+    assert decide(obs(ce=99.0), LIMITS, state).action == CONTINUE, "the streak restarted"
+
+
+@pytest.mark.parametrize("bad", [float("nan"), float("inf"), -float("inf"), 7.0])
+def test_non_finite_and_out_of_band_ce_both_count_as_divergence(bad):
+    state = State(divergence_streak=1)
+    assert decide(obs(ce=bad), LIMITS, state).outcome == KILLED_DIVERGENCE
+
+
+def test_a_missing_ce_is_not_divergence():
+    """A run that has not logged a metric row yet is young, not broken —
+    treating None as divergence would kill every run at startup."""
+    state = State()
+    assert decide(obs(ce=None), LIMITS, state).action == CONTINUE
+    assert state.divergence_streak == 0
+
+
+def test_retries_are_finite():
+    state = State()
+    for expected in (RELAUNCH, RELAUNCH, GIVE_UP):
+        assert decide(obs(step=1, alive=False), LIMITS, state).action == expected
+    assert decide(obs(step=1, alive=False), LIMITS, state).outcome == GAVE_UP
+
+
+def test_the_wallclock_cap_stops_a_run_that_is_making_progress():
+    limits = Limits(stop_step=10_000, max_hours=8.0)
+    decision = decide(obs(step=500, elapsed_hours=8.1), limits, State())
+    assert (decision.action, decision.outcome) == (STOP, WALLCLOCK_COMPLETE)
+
+
+def test_the_budget_stop_outranks_the_wallclock_cap():
+    """Both firing at once means the run finished; report the reason that is
+    about the science, not the one about the clock."""
+    limits = Limits(stop_step=1000, max_hours=1.0)
+    assert decide(obs(step=1000, elapsed_hours=99.0), limits, State()).outcome == BUDGET_COMPLETE
+
+
+def test_a_wedged_run_is_restarted_even_though_it_is_alive():
+    """The motivating failure: a detached job stalled three days unnoticed,
+    because a process that is alive and doing nothing looks exactly like a
+    process that is working."""
+    limits = Limits(stop_step=10_000, stall_polls=3, max_retries=1)
+    state = State()
+    for _ in range(3):
+        assert decide(obs(step=42), limits, state).action == CONTINUE
+    decision = decide(obs(step=42), limits, state)
+    assert (decision.action, decision.outcome) == (RESTART, STALLED)
+
+
+def test_progress_clears_the_stall_counter():
+    limits = Limits(stop_step=10_000, stall_polls=2)
+    state = State()
+    decide(obs(step=42), limits, state)
+    decide(obs(step=42), limits, state)
+    decide(obs(step=43), limits, state)  # it moved
+    assert state.stalled_polls == 0
+    assert decide(obs(step=43), limits, state).action == CONTINUE
+
+
+def test_a_stall_does_not_outrank_a_finished_run():
+    """A run sitting at its stop step is done, not wedged. Restarting it would
+    be the sentinel bug wearing a different hat."""
+    limits = Limits(stop_step=100, stall_polls=1)
+    state = State()
+    decide(obs(step=100), limits, state)
+    assert decide(obs(step=100), limits, state).outcome == BUDGET_COMPLETE
+
+
+def test_a_dead_process_is_not_counted_as_stalled():
+    """Otherwise a crash would burn a retry as a stall and then another as a
+    crash, halving the relaunch budget."""
+    limits = Limits(stop_step=10_000, stall_polls=2, max_retries=5)
+    state = State()
+    decide(obs(step=7, alive=False), limits, state)
+    assert state.stalled_polls == 0
+
+
+def test_stall_restarts_are_finite():
+    limits = Limits(stop_step=10_000, stall_polls=1, max_retries=1)
+    state = State()
+    decide(obs(step=5), limits, state)
+    assert decide(obs(step=5), limits, state).action == RESTART
+    decide(obs(step=5), limits, state)
+    assert decide(obs(step=5), limits, state).outcome == GAVE_UP
+
+
+# --- reading the run ----------------------------------------------------------
+
+def test_read_progress_takes_the_last_complete_row(tmp_path):
+    csv_path = tmp_path / "metrics.csv"
+    csv_path.write_text("step,ce,loss\n10,3.5,3.6\n20,3.1,3.2\n")
+    assert read_progress(csv_path) == (20, 3.1)
+
+
+def test_a_torn_final_line_falls_back_to_the_last_good_row(tmp_path):
+    """The trainer appends to this file while the supervisor reads it. A partial
+    row is normal; reading it as 'no progress' would look like a stalled run."""
+    csv_path = tmp_path / "metrics.csv"
+    csv_path.write_text("step,ce,loss\n10,3.5,3.6\n20,3.1,3.2\n30,")
+    assert read_progress(csv_path) == (30, None)
+
+    csv_path.write_text("step,ce,loss\n10,3.5,3.6\n,,\n")
+    assert read_progress(csv_path) == (10, 3.5)
+
+
+def test_a_missing_or_empty_metrics_file_reads_as_no_progress(tmp_path):
+    assert read_progress(tmp_path / "nope.csv") == (0, None)
+    (tmp_path / "empty.csv").write_text("step,ce\n")
+    assert read_progress(tmp_path / "empty.csv") == (0, None)
+
+
+def test_plateau_detection_matches_the_trainers_own_wording(tmp_path):
+    log = tmp_path / "train.log"
+    log.write_text("Step 0100 | CE: 3.5\n")
+    assert not plateau_in(log)
+    log.write_text("Step 0100 | CE: 3.5\n🔄 CE Plateau Detected — switching phase\n")
+    assert plateau_in(log)
+    assert not plateau_in(tmp_path / "absent.log")
+
+
+# --- preflight ----------------------------------------------------------------
+
+def test_disk_headroom_refuses_a_nearly_full_disk(tmp_path):
+    """A long run that fills the disk dies with a corrupt final checkpoint — it
+    costs the compute AND the artifact, which is the worst trade available."""
+    with pytest.raises(Preflight, match="free"):
+        check_disk_headroom(tmp_path, min_free_gb=1e9)
+    assert check_disk_headroom(tmp_path, min_free_gb=0.0) > 0
+
+
+def test_the_gpu_lock_is_a_serial_queue(tmp_path):
+    first = GpuLock(tmp_path / "gpu.lock", label="run-a")
+    first.acquire()
+    with pytest.raises(Preflight, match="one run at a time"):
+        GpuLock(tmp_path / "gpu.lock", label="run-b").acquire()
+    first.release()
+    GpuLock(tmp_path / "gpu.lock", label="run-b").acquire()  # now free
+
+
+def test_a_stale_lock_is_taken_over_not_respected(tmp_path):
+    """A lock nobody can clear turns one crash into a card that stays idle until
+    a human notices — worse than no lock at all."""
+    path = tmp_path / "gpu.lock"
+    dead = subprocess.Popen([sys.executable, "-c", "pass"])
+    dead.wait()
+    path.write_text(f"{dead.pid} long-gone\n")
+
+    lock = GpuLock(path, label="new-run")
+    lock.acquire()
+    assert lock.holder()[0] == os.getpid()
+
+
+def test_an_unreadable_lock_is_stale(tmp_path):
+    path = tmp_path / "gpu.lock"
+    path.write_text("garbage written by a half-finished process\n")
+    GpuLock(path).acquire()
+
+
+def test_releasing_never_removes_someone_elses_lock(tmp_path):
+    """A supervisor that took over a stale lock must not delete whatever
+    replaced it — that would hand the card to two runs at once."""
+    path = tmp_path / "gpu.lock"
+    mine = GpuLock(path, label="mine")
+    mine.acquire()
+    path.write_text("999999 someone-else\n")
+    mine.release()
+    assert path.exists(), "we only ever remove our own lock"
+
+
+def test_the_lock_releases_on_the_way_out_of_a_with_block(tmp_path):
+    path = tmp_path / "gpu.lock"
+    with pytest.raises(RuntimeError):
+        with GpuLock(path, label="x"):
+            raise RuntimeError("the run blew up")
+    assert not path.exists()
+
+
+# --- the loop, against a real child process -----------------------------------
+
+def _supervisor_over(tmp_path, script: str, limits: Limits, **kw):
+    from trm.runtime.supervisor import Supervisor
+
+    child = tmp_path / "child.py"
+    child.write_text(textwrap.dedent(script))
+    reported = []
+    sup = Supervisor(
+        command=(sys.executable, str(child)),
+        limits=limits,
+        log_path=tmp_path / "train.log",
+        metrics_csv=tmp_path / "metrics.csv",
+        poll_seconds=0.2,
+        heartbeat_every=1,
+        report=reported.append,
+        **kw,
+    )
+    return sup, reported
+
+
+def test_the_supervisor_stops_a_child_that_reaches_the_budget(tmp_path):
+    csv_path = tmp_path / "metrics.csv"
+    sup, reported = _supervisor_over(tmp_path, f"""
+        import time, pathlib
+        p = pathlib.Path({str(csv_path)!r})
+        p.write_text("step,ce\\n")
+        for step in range(0, 200, 10):
+            p.write_text("step,ce\\n" + f"{{step}},3.0\\n")
+            time.sleep(0.1)
+        time.sleep(60)
+    """, Limits(stop_step=50, max_retries=0))
+
+    assert sup.run() == BUDGET_COMPLETE
+    assert any("BUDGET_COMPLETE" in line for line in reported)
+
+
+def test_the_supervisor_relaunches_a_crashing_child_then_gives_up(tmp_path):
+    sup, reported = _supervisor_over(tmp_path, """
+        import sys
+        sys.exit(1)
+    """, Limits(stop_step=10_000, max_retries=1))
+
+    assert sup.run() == GAVE_UP
+    assert sum("relaunched" in line for line in reported) == 1
+
+
+def test_the_heartbeat_survives_github_being_unreachable(tmp_path, monkeypatch, capsys):
+    """A supervisor that died because the network blipped would abandon a
+    running job over something that has nothing to do with the run."""
+    from trm.runtime import supervisor as sup_mod
+
+    def explode(*a, **k):
+        raise OSError("gh: command not found")
+
+    monkeypatch.setattr(sup_mod.subprocess, "run", explode)
+    sup_mod.github_reporter(16)("still going")
+    out = capsys.readouterr().out
+    assert "still going" in out, "the message still reaches the local log"
+    assert "heartbeat to #16 failed" in out
+
+
+def test_the_supervisor_kills_a_child_that_trips_the_plateau_guard(tmp_path):
+    log = tmp_path / "train.log"
+    log.parent.mkdir(parents=True, exist_ok=True)
+    sup, _ = _supervisor_over(tmp_path, """
+        import time
+        print("CE Plateau Detected", flush=True)
+        time.sleep(60)
+    """, Limits(stop_step=10_000, max_retries=0))
+
+    assert sup.run() == KILLED_PLATEAU

--- a/trm/runtime/supervisor.py
+++ b/trm/runtime/supervisor.py
@@ -1,0 +1,456 @@
+"""Unattended training supervision — the #16 saga's aux scripts, promoted (#40 build 4).
+
+Six launch attempts on the base run produced three bash scripts: a watchdog that
+stopped the trainer at its token budget and killed it if the CE-plateau detector
+tried to flip a pretrain run into SFT, a sentinel that relaunched it after a
+crash, and a divergence guard added when the warm restart risked blowing up.
+They worked, and one of them shipped a bug that is worth keeping in mind
+forever.
+
+**The bug, and why this is one process.** The watchdog and the sentinel were
+separate processes that communicated by writing and grepping marker lines in a
+log. So the sentinel's question — "the trainer is gone; did it crash, or did the
+watchdog stop it?" — was answered by reading a file the watchdog had not
+finished writing. A clean finish lands its marker ~60s after the process dies,
+and in that window the sentinel read a completed run as a crash and relaunched
+it. The production fix was to sleep 90 seconds and re-check, which narrows the
+window without closing it.
+
+Here there is no window. One process owns the child, so "did I stop it?" is a
+fact it already has, and the answer comes from `decide()` — a pure function over
+an observation — rather than from the filesystem. The ordering that removes the
+race is one line of that function: **guards are evaluated before liveness**, so a
+run that reached its budget is complete whether or not the process is still up.
+
+Nothing here is clever. The point is that the decisions are now *stated*, in a
+function that can be tested against the exact situation that fooled the original.
+
+    python -m trm.runtime.supervisor --stop-step 2289 --issue 16 -- --new-run
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import datetime
+import math
+import os
+import pathlib
+import shutil
+import signal
+import subprocess
+import sys
+import time
+from dataclasses import dataclass, field
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[2]
+RUNS_DIR = REPO_ROOT / "runs"
+GPU_LOCK = RUNS_DIR / ".gpu.lock"
+
+# What the supervisor decided to do about the child.
+CONTINUE, STOP, KILL, RELAUNCH, GIVE_UP = "CONTINUE", "STOP", "KILL", "RELAUNCH", "GIVE_UP"
+RESTART = "RESTART"  # kill a wedged child, then relaunch it
+
+# How the whole thing ended. RUNNING is the only non-terminal one.
+RUNNING = "RUNNING"
+BUDGET_COMPLETE = "BUDGET_COMPLETE"
+WALLCLOCK_COMPLETE = "WALLCLOCK_COMPLETE"
+KILLED_PLATEAU = "KILLED_PLATEAU"
+KILLED_DIVERGENCE = "KILLED_DIVERGENCE"
+CRASHED = "CRASHED"
+STALLED = "STALLED"
+GAVE_UP = "GAVE_UP"
+
+# A terminal outcome the supervisor chose. Anything else that stops the child is
+# a crash, and a crash is the only thing worth relaunching.
+DELIBERATE = (BUDGET_COMPLETE, WALLCLOCK_COMPLETE, KILLED_PLATEAU, KILLED_DIVERGENCE)
+
+
+@dataclass(frozen=True)
+class Limits:
+    """Every bound the supervisor enforces, in one place.
+
+    `stop_step` exists because the trainer has no hard token stop — the budget
+    is enforced from outside, at the opt step whose checkpoint covers it.
+    """
+
+    stop_step: int
+    max_ce: float = 6.5
+    divergence_checks: int = 2  # consecutive bad readings before killing
+    # Polls with no step progress before the run counts as wedged. Generous by
+    # default: startup compilation is minutes long and logs nothing, and the
+    # motivating failure was three DAYS of silence, not three polls.
+    stall_polls: int = 12
+    max_retries: int = 2
+    max_hours: float | None = None
+    min_free_gb: float = 20.0
+
+
+@dataclass(frozen=True)
+class Observation:
+    """One look at the run: what the metrics say, what the log says, is it alive."""
+
+    step: int
+    ce: float | None
+    plateau_detected: bool
+    alive: bool
+    elapsed_hours: float = 0.0
+
+
+@dataclass
+class State:
+    """What the supervisor remembers between looks."""
+
+    divergence_streak: int = 0
+    retries_used: int = 0
+    last_step: int = -1
+    stalled_polls: int = 0
+
+
+@dataclass(frozen=True)
+class Decision:
+    action: str
+    outcome: str
+    reason: str
+
+
+def _is_diverged(ce: float | None, max_ce: float) -> bool:
+    """A missing CE is not divergence — it is a run that has not logged yet."""
+    if ce is None:
+        return False
+    return math.isnan(ce) or math.isinf(ce) or ce > max_ce
+
+
+def decide(obs: Observation, limits: Limits, state: State) -> Decision:
+    """What to do about the run right now. Pure: no I/O, no signals, no clock.
+
+    The order is the design. Guards come first and liveness comes last, so a run
+    that hit its budget reads as complete even if the process is already gone —
+    which is precisely the case the original sentinel got wrong when a clean stop
+    landed inside its polling window. There is no timing assumption to tune here;
+    a finished run is finished because the numbers say so.
+
+    Plateau outranks everything: the CE-plateau detector flipping a pretrain run
+    into SFT would silently contaminate the very thing the run exists to produce,
+    so it is worth killing a run that is otherwise perfectly healthy.
+    """
+    if obs.step > state.last_step:
+        state.last_step = obs.step
+        state.stalled_polls = 0
+    elif obs.alive:
+        state.stalled_polls += 1
+
+    if obs.plateau_detected:
+        return Decision(KILL, KILLED_PLATEAU,
+                        "CE-plateau SFT auto-flip detected; killing to protect the pretrain run")
+
+    if _is_diverged(obs.ce, limits.max_ce):
+        streak = state.divergence_streak + 1
+        state.divergence_streak = streak
+        if streak >= limits.divergence_checks:
+            return Decision(KILL, KILLED_DIVERGENCE,
+                            f"CE={obs.ce} outside the sane band for {streak} consecutive checks")
+    else:
+        state.divergence_streak = 0
+
+    if obs.step >= limits.stop_step:
+        return Decision(STOP, BUDGET_COMPLETE,
+                        f"reached opt step {obs.step} >= budget stop {limits.stop_step}")
+
+    if limits.max_hours is not None and obs.elapsed_hours >= limits.max_hours:
+        return Decision(STOP, WALLCLOCK_COMPLETE,
+                        f"ran {obs.elapsed_hours:.1f}h >= the {limits.max_hours}h cap")
+
+    # A wedged run is the hazard that motivated all of this: a detached job once
+    # stalled for three days unnoticed, because a process that is alive and doing
+    # nothing looks exactly like a process that is working. It is alive, so it
+    # has to be killed before it can be relaunched.
+    if obs.alive and state.stalled_polls >= limits.stall_polls:
+        if state.retries_used >= limits.max_retries:
+            return Decision(GIVE_UP, GAVE_UP,
+                            f"wedged at step {obs.step} and {limits.max_retries} relaunches were used")
+        state.retries_used += 1
+        state.stalled_polls = 0
+        return Decision(RESTART, STALLED,
+                        f"no progress past step {obs.step} for {limits.stall_polls} polls "
+                        f"(restart {state.retries_used}/{limits.max_retries})")
+
+    if not obs.alive:
+        if state.retries_used >= limits.max_retries:
+            return Decision(GIVE_UP, GAVE_UP,
+                            f"died before budget and {limits.max_retries} relaunches were used")
+        state.retries_used += 1
+        return Decision(RELAUNCH, CRASHED,
+                        f"died at step {obs.step} before budget "
+                        f"(relaunch {state.retries_used}/{limits.max_retries})")
+
+    return Decision(CONTINUE, RUNNING, f"step {obs.step}/{limits.stop_step}")
+
+
+# --- preflight ----------------------------------------------------------------
+
+class Preflight(Exception):
+    """A reason not to start. Raised before anything expensive happens."""
+
+
+def check_disk_headroom(path: pathlib.Path, min_free_gb: float) -> float:
+    """Refuse to launch onto a nearly-full disk.
+
+    The root filesystem on this box runs close to full, and a long run that
+    fills it dies partway with a corrupt final checkpoint — the worst failure
+    mode available, because it costs the compute AND the artifact.
+    """
+    free_gb = shutil.disk_usage(path).free / 1e9
+    if free_gb < min_free_gb:
+        raise Preflight(
+            f"only {free_gb:.1f}GB free at {path}, need {min_free_gb}GB — "
+            f"archive to the HDD before launching (never delete runs/data/)")
+    return free_gb
+
+
+def _pid_alive(pid: int) -> bool:
+    try:
+        os.kill(pid, 0)
+    except (ProcessLookupError, ValueError):
+        return False
+    except PermissionError:
+        return True  # exists, owned by someone else
+    return True
+
+
+class GpuLock:
+    """The single RTX 2060 is a serial queue; this is the queue.
+
+    A stale lock — the holder died without releasing — is taken over rather than
+    respected. A lock nobody can clear is worse than no lock: it turns one crash
+    into a card that stays idle until a human notices.
+    """
+
+    def __init__(self, path: pathlib.Path = GPU_LOCK, label: str = ""):
+        self.path = path
+        self.label = label
+        self.held = False
+
+    def holder(self) -> tuple[int, str] | None:
+        if not self.path.exists():
+            return None
+        try:
+            pid_text, _, label = self.path.read_text().strip().partition(" ")
+            return int(pid_text), label
+        except ValueError:
+            return None  # unreadable lock is a stale lock
+
+    def acquire(self) -> None:
+        current = self.holder()
+        if current and _pid_alive(current[0]):
+            raise Preflight(
+                f"the GPU is held by pid {current[0]} ({current[1] or 'unlabelled'}) — "
+                f"one run at a time on this card")
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        self.path.write_text(f"{os.getpid()} {self.label}\n")
+        self.held = True
+
+    def release(self) -> None:
+        """Only ever removes our own lock — a supervisor that took over a stale
+        lock must not delete whatever replaced it."""
+        current = self.holder()
+        if self.held and current and current[0] == os.getpid():
+            self.path.unlink(missing_ok=True)
+        self.held = False
+
+    def __enter__(self):
+        self.acquire()
+        return self
+
+    def __exit__(self, *exc):
+        self.release()
+        return False
+
+
+# --- reading the run ----------------------------------------------------------
+
+def read_progress(metrics_csv: pathlib.Path) -> tuple[int, float | None]:
+    """Last (step, ce) in the trainer's metrics CSV; (0, None) if it has none yet.
+
+    Tolerant on purpose: this file is being appended to by another process, so a
+    torn final line is normal and must not read as a crashed run.
+    """
+    try:
+        with metrics_csv.open() as f:
+            rows = list(csv.DictReader(f))
+    except (OSError, csv.Error):
+        return 0, None
+    for row in reversed(rows):
+        try:
+            step = int(float(row["step"]))
+        except (KeyError, TypeError, ValueError):
+            continue
+        try:
+            ce = float(row["ce"])
+        except (KeyError, TypeError, ValueError):
+            ce = None
+        return step, ce
+    return 0, None
+
+
+def plateau_in(log_path: pathlib.Path) -> bool:
+    try:
+        return "CE Plateau Detected" in log_path.read_text(errors="replace")
+    except OSError:
+        return False
+
+
+# --- the loop -----------------------------------------------------------------
+
+@dataclass
+class Supervisor:
+    """Launches the trainer, watches it, and stops it for a stated reason."""
+
+    command: tuple[str, ...]
+    limits: Limits
+    log_path: pathlib.Path
+    metrics_csv: pathlib.Path
+    poll_seconds: float = 300.0
+    heartbeat_every: int = 12  # polls between status reports
+    report: object = print  # callable(str); the heartbeat's destination
+    env: dict = field(default_factory=dict)
+
+    def launch(self) -> subprocess.Popen:
+        self.log_path.parent.mkdir(parents=True, exist_ok=True)
+        env = {**os.environ, "PYTHONPATH": str(REPO_ROOT), "PYTHONUNBUFFERED": "1", **self.env}
+        log = self.log_path.open("a")
+        return subprocess.Popen(self.command, cwd=REPO_ROOT, env=env,
+                                stdout=log, stderr=subprocess.STDOUT)
+
+    def stop(self, proc: subprocess.Popen, grace: float = 60.0) -> None:
+        """TERM, then KILL. The grace period is for the trainer to finish writing
+        a checkpoint — killing it mid-write is how a run loses its last hour."""
+        if proc.poll() is not None:
+            return
+        proc.send_signal(signal.SIGTERM)
+        try:
+            proc.wait(timeout=grace)
+        except subprocess.TimeoutExpired:
+            proc.kill()
+            proc.wait(timeout=30)
+
+    def observe(self, proc: subprocess.Popen, started: float) -> Observation:
+        step, ce = read_progress(self.metrics_csv)
+        return Observation(
+            step=step, ce=ce,
+            plateau_detected=plateau_in(self.log_path),
+            alive=proc.poll() is None,
+            elapsed_hours=(time.time() - started) / 3600.0,
+        )
+
+    def run(self) -> str:
+        """Supervise to a terminal outcome, relaunching after real crashes only."""
+        state = State()
+        proc = self.launch()
+        started = time.time()
+        self.report(f"▶ supervising pid {proc.pid}: {' '.join(self.command)}")
+        polls = 0
+
+        while True:
+            time.sleep(self.poll_seconds)
+            polls += 1
+            obs = self.observe(proc, started)
+            decision = decide(obs, self.limits, state)
+
+            if polls % self.heartbeat_every == 0 or decision.action != CONTINUE:
+                self.report(f"{_stamp()} {decision.outcome}: {decision.reason}"
+                            + (f" (ce={obs.ce})" if obs.ce is not None else ""))
+
+            if decision.action == CONTINUE:
+                continue
+            if decision.action in (STOP, KILL):
+                self.stop(proc)
+                return decision.outcome
+            if decision.action == GIVE_UP:
+                return decision.outcome
+            if decision.action in (RELAUNCH, RESTART):
+                if decision.action == RESTART:
+                    self.stop(proc)  # wedged, so it is still up and has to go
+                proc = self.launch()
+                started = time.time()
+                self.report(f"{_stamp()} relaunched as pid {proc.pid}")
+
+
+def _stamp() -> str:
+    return datetime.datetime.now().strftime("%F %T")
+
+
+def github_reporter(issue: int):
+    """Heartbeat into a pinned issue, so state lives where CLAUDE.md says it does.
+
+    Never fatal: a supervisor that dies because GitHub was unreachable would
+    abandon a running job over a network blip.
+    """
+    def report(message: str) -> None:
+        print(message, flush=True)
+        try:
+            subprocess.run(["gh", "issue", "comment", str(issue), "--body", message],
+                           check=False, capture_output=True, timeout=60)
+        except (OSError, subprocess.SubprocessError) as exc:
+            print(f"(heartbeat to #{issue} failed: {exc})", flush=True)
+    return report
+
+
+def main(argv=None) -> int:
+    ap = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    ap.add_argument("--stop-step", type=int, required=True,
+                    help="opt step whose checkpoint covers the token budget (the trainer has no hard stop)")
+    ap.add_argument("--run-dir", type=pathlib.Path, required=True,
+                    help="the run folder holding metrics.csv")
+    ap.add_argument("--log", type=pathlib.Path, required=True, help="where trainer stdout goes")
+    ap.add_argument("--issue", type=int, default=None, help="pinned issue to heartbeat into")
+    ap.add_argument("--max-ce", type=float, default=Limits.max_ce)
+    ap.add_argument("--max-retries", type=int, default=Limits.max_retries)
+    ap.add_argument("--stall-polls", type=int, default=Limits.stall_polls,
+                    help="polls with no step progress before the run counts as wedged")
+    ap.add_argument("--max-hours", type=float, default=None)
+    ap.add_argument("--min-free-gb", type=float, default=Limits.min_free_gb)
+    ap.add_argument("--poll-seconds", type=float, default=300.0)
+    ap.add_argument("--no-gpu-lock", action="store_true",
+                    help="for a CPU run; the lock exists for the single card")
+    ap.add_argument("trainer_args", nargs="*",
+                    help="passed through to trm.train.start (put them after --)")
+    args = ap.parse_args(argv)
+
+    limits = Limits(stop_step=args.stop_step, max_ce=args.max_ce,
+                    stall_polls=args.stall_polls, max_retries=args.max_retries,
+                    max_hours=args.max_hours, min_free_gb=args.min_free_gb)
+
+    try:
+        free = check_disk_headroom(RUNS_DIR if RUNS_DIR.exists() else REPO_ROOT, limits.min_free_gb)
+    except Preflight as exc:
+        print(f"preflight: {exc}", file=sys.stderr)
+        return 1
+    print(f"preflight: {free:.1f}GB free")
+
+    supervisor = Supervisor(
+        command=(sys.executable, "-m", "trm.train.start", *args.trainer_args),
+        limits=limits,
+        log_path=args.log,
+        metrics_csv=args.run_dir / "metrics.csv",
+        poll_seconds=args.poll_seconds,
+        report=github_reporter(args.issue) if args.issue else print,
+    )
+
+    lock = GpuLock(label=f"stop_step={args.stop_step}")
+    try:
+        if not args.no_gpu_lock:
+            lock.acquire()
+        outcome = supervisor.run()
+    except Preflight as exc:
+        print(f"preflight: {exc}", file=sys.stderr)
+        return 1
+    finally:
+        lock.release()
+
+    print(f"outcome: {outcome}")
+    return 0 if outcome in DELIBERATE else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
Closes #40 — the last of its four builds.

Six launch attempts on the base run produced three bash scripts, still sitting in the repo root as gitignored `aux_*.sh`: a **watchdog** (stop at the token budget, kill a CE-plateau SFT auto-flip), a **sentinel** (relaunch after a crash), and a **divergence guard** added when the warm restart risked blowing up. They worked. One of them shipped a bug worth keeping forever.

## The race, and why this is one process

The watchdog and the sentinel were separate processes communicating by writing and grepping marker lines in a log. So the sentinel's question — *"the trainer is gone; did it crash, or did the watchdog stop it?"* — was answered by reading a file the watchdog **had not finished writing**. A clean finish lands its marker ~60s after the process dies, and inside that window the sentinel read a *completed* run as a crash and relaunched it. The production fix was `sleep 90` and re-check, which narrows the window without closing it.

`trm/runtime/supervisor.py` closes it by construction. One process owns the child, so "did I stop it?" is a fact it already holds, and every decision comes from `decide()` — a pure function over an observation; no I/O, no signals, no clock. **The ordering is the entire fix: guards are evaluated before liveness**, so a run that reached its budget is complete whether or not the process is still up. There is no timing assumption left to tune.

## What it does

```bash
python -m trm.runtime.supervisor --stop-step 2289 --run-dir runs/run_X \
    --log runs/base.log --issue 16 -- --new-run
```

| guard | why it outranks what it outranks |
|---|---|
| plateau kill | an SFT auto-flip silently contaminates the very thing a pretrain run exists to produce — worth killing a healthy run for |
| divergence kill | needs a *streak*, not a blip; killing on one spike wastes a good run |
| budget stop | the trainer has no hard token stop, so the budget is enforced from outside |
| wall-clock cap | the compute-budget cap, for runs without a clean step target |
| stall restart | see below |
| crash relaunch | finite retries, then it stands down and says so |

A missing CE reads as a young run, not a broken one — otherwise every run dies at startup.

## One guard beyond the issue's list

`docs/AUTONOMY.md` names stalled loss as a documented hazard, and its motivating failure is a detached job that **hung for three days unnoticed** — because a process that is alive and doing nothing looks exactly like one that is working. None of the aux scripts caught that: divergence needs a bad number, crash-relaunch needs a dead process, and a wedged run offers neither. So: no step progress for N polls → kill and restart, against the same retry budget.

## Resource guards, in code rather than prose

- **Disk-headroom preflight** — a run that fills the disk loses the compute *and* the final checkpoint, the worst trade available. (Root fs on this box runs close to full.)
- **GPU serial-queue lock** — one job at a time on the single card. Stale locks are *taken over*, never respected: a lock nobody can clear turns one crash into a card that stays idle until a human notices. Release only ever removes our own lock, so a takeover can't hand the card to two runs at once.
- **Compute budget** — stop step plus an optional wall-clock cap.
- **Heartbeat** to a pinned issue, and it can never be fatal — a supervisor that died because GitHub was unreachable would abandon a running job over a network blip.

## Tests

34 in `tests/core/`. The load-bearing one is `test_a_finished_run_is_not_a_crash_even_though_the_process_is_gone` — the original bug, stated as an assertion. Also the full decision table, the stall counter, the torn-CSV-line case (the trainer appends while the supervisor reads), lock takeover/release semantics, and three cases driving a real child process to a terminal outcome.

Local: `tests/core` exit 0, `tests/apparatus` exit 0, `ruff check .` clean.

**Note:** the aux scripts still invoke `start_training.py`, which #143 renamed to `python -m trm.train.start`. They were already broken — which is its own argument for having promoted them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)