### PR TITLE
docs: Muon's dtype caveat is resolved; the partition is the real hazard

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -149,7 +149,12 @@ them to both arms. Ordered certain-small-first:
   the masked AdamW we already run. Cheapest, try first.
 - **Muon optimizer** — #26: orthogonalized-momentum updates for 2D matrices; strong
   recent sample-efficiency/wall-clock wins — the lever a single-GPU run wants most.
-  Validate at tiny scale and in f16 (Newton-Schulz likely needs f32).
+  The old "Newton-Schulz likely needs f32" caveat is **resolved**: optax's `mu_dtype`
+  is storage-only (bf16 momentum promotes against our f32 grads, NS runs in f32, the
+  cast back is for storage) — the same trick `optimizers.py` already runs for Adam's
+  first moment. The live hazard is instead the **partition**: optax routes params by
+  `ndim == 2`, which sends our tied `nnx.Embed` table to Muon, and a wrong partition
+  trains happily and silently. Plan, criteria, and sources live on #26.
 
 ## Beyond proof + scale — far future
 - **RL post-training** — #29: preference / reasoning elicitation. On the AGI path but


### PR DESCRIPTION
Follow-up to #154, same Phase 2 block.

`ROADMAP.md` told readers Newton-Schulz "likely needs f32", which naturally
reads as a trade against the bf16 momentum we want for the VRAM win. Reading
`optax/contrib/_muon.py` at **v0.2.6** (the version pinned in
`requirements.txt:5`) shows there is no trade — `mu_dtype` is storage-only:

- L277 stored bf16 momentum meets our f32 grads (MultiSteps accumulator,
  `grad_step.py:161`) and promotes to f32
- L290-293 Newton-Schulz runs on that f32 value
- L306 the cast back to bf16 happens after the math, for storage

Identical to the storage-only pattern `optimizers.py:30-35` already runs for
Adam's first moment, validated by `instruments/bf16_mu_smoke.py`.

The line now carries the hazard that *is* live and was undocumented: optax
labels params `'muon' if x.ndim == 2 else 'adam'` (L395-397), so our tied
`nnx.Embed` table lands on Muon. A wrong partition trains fine and the loss
still falls, so it is a silent failure — #26 now specifies the guard test.

Doc-only, no issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)