### PR TITLE
Record #66's gates: chunked attention stays off at seq 512

### DIFF
--- a/instruments/mem_profile.py
+++ b/instruments/mem_profile.py
@@ -10,6 +10,13 @@ model + optimizer at the *current config*, compile the real grad step, and repor
      biggest buffers (e.g. a ``f32[1,512,50304]`` logit slab) so a mystery transient
      becomes a shape you can point at.
 
+Read (2) with care: it aggregates **cumulative** bytes (per-occurrence size x how many
+times the shape appears), so it ranks allocation *traffic*, not what is resident at the
+peak. Only (1) is peak. Confusing the two is what motivated #66, whose top-table entry
+read 37 GiB against a real peak of 0.582 GiB — a 64x gap — and the resulting chunked
+attention bought nothing. Before optimizing a shape here, check it is actually a
+meaningful fraction of temp/scratch.
+
 Static analysis (1) and the HLO scan (2) work even when actually running would OOM, so
 this is usable precisely when you need it most. ``--run`` additionally executes one step
 and reads the driver's peak / largest-allocation stats (skip it if the config OOMs).
@@ -98,9 +105,13 @@ def main():
     print(f"  temp / scratch  (PEAK transient activations): {_gib(tmp)}  <-- what OOMs a run")
     print(f"  ~grad-step footprint (arg+out+temp):         {_gib(arg + out + tmp)}")
 
-    print(f"\n=== largest {args.top} tensor shapes in the compiled HLO (total bytes) ===")
+    print(f"\n=== largest {args.top} tensor shapes in the compiled HLO ===")
+    print("  NOT peak memory: this is CUMULATIVE bytes over every occurrence in the")
+    print("  program (size x count). A shape can top this table and be irrelevant to")
+    print(f"  the peak above — compare against temp/scratch ({_gib(tmp)}), not to itself.")
     for shape, (count, total) in _top_hlo_shapes(compiled.as_text(), args.top):
-        print(f"  {_gib(total)}  x{count:<4}  {shape}")
+        per = total / count if count else 0
+        print(f"  {_gib(total)} cumulative = {_gib(per)} x{count:<5}  {shape}")
 
     if args.run:
         print("\n=== executing one step (driver stats) ===")

--- a/trm/config.py
+++ b/trm/config.py
@@ -84,10 +84,20 @@ if TIME_SIGNAL not in ("table", "sinusoidal"):
     raise SystemExit(
         f"TIME_SIGNAL={TIME_SIGNAL!r} is not a known time signal; "
         f"use one of table, sinusoidal (unset defaults to 'sinusoidal')")
-# Blockwise memory-lean attention for the refiner (#66): removes the O(seq²)
-# score/probability transients that dominate the grad-step peak (mem_profile).
-# Opt-in until the dim960 GPU fit-test + wall-clock bench pass on the box;
-# same math as stock attention up to float summation order.
+# Blockwise memory-lean attention for the refiner (#66): walks queries in blocks so
+# the full seq² score matrix never exists, recomputing block scores in the backward.
+# Same math as stock attention up to float summation order (f16 parity pinned in
+# tests/core/test_chunked_attention.py).
+#
+# STAYS OFF at seq 512 — gates run 2026-08-03 on the RTX 2060, both memory gates FAILED:
+#   peak (dim960/depth8, real f16):  4.58 -> 4.63 GB      (+1.1%, i.e. slightly worse)
+#   wall-clock, 3 matched trials:     449.6 -> 509.5 ms    (+13.3%, bar was <=+10%)
+# The premise didn't hold: one score matrix is 15x512x512x4B ~= 15 MB against a ~4.6 GB
+# peak, and remat already recomputes those activations rather than storing them — so
+# chunking re-solved a solved problem and added per-block buffers on top. What made it
+# look worthwhile was mem_profile's HLO table, which aggregates CUMULATIVE bytes, not
+# peak; the two sit 64x apart in that report (now labelled, see instruments/mem_profile).
+# Re-test if #23 widens the context: seq² grows 4x at 1024 and the trade may invert.
 CHUNKED_ATTENTION = os.environ.get("CHUNKED_ATTENTION", "0") == "1"
 # Plan A: number of causal encoder layers beneath the single shared refine block
 # (which is looped up to MAX_STEPS_LIMIT times). Tuned to land the param count


### PR DESCRIPTION
## What ran

All four gates from #66, on the RTX 2060.

| gate | result |
|---|---|
| 1. f16 parity (`RUN_TESTS_ON_GPU=1`) | **PASS** — 5/5, no skips |
| 2. peak memory, dim960/depth8, real f16 | **FAIL** — 4.58 → 4.63 GB (**+1.1%**) |
| 3. wall-clock, 3 matched trials each | **FAIL** — 449.6 → 509.5 ms (**+13.3%**, bar was ≤+10%) |
| 4. flip the default | **not taken** — gates 2 and 3 failed |

Gate 3 detail — off: 447.5 / 449.8 / 451.4 ms, on: 504.6 / 511.1 / 512.7 ms. Within-arm spread ~1%, so the delta is nowhere near the noise.

Note the headroom smoke defaults to the old dim512/16-head config; gate 2 was re-run at `--dim 960 --heads 15` to hit the shipping arch.

## Verdict

The pre-registered outcome for a gate-3 failure was "the flag stays opt-in for memory-bound configs only," so `CHUNKED_ATTENTION` was already defaulting correctly and **no behaviour changes in this PR**. What changes is the record.

The mechanism worked exactly as designed — `f32[15,512,512]` really did become `f32[15,128,512]`. The *premise* is what failed:

- One score matrix is `15 × 512 × 512 × 4B ≈ 15 MB` against a ~4.6 GB peak — a third of a percent.
- Remat is already on, so those activations were being recomputed rather than stored. Chunking re-solved a solved problem and added its own per-block buffers, which is why peak went slightly **up**.

Concrete consequence for the run plan: **no `BATCH_SIZE` headroom was freed**, which removes one of the two reasons #66 was sequenced ahead of #156.

Kept, not tombstoned — the implementation and its parity tests stay. At seq 1024 the `seq²` term grows 4× and the trade may invert, so this is worth re-testing under #23.

## The instrument that caused it

`mem_profile`'s HLO table aggregates **cumulative** bytes (per-occurrence size × how many times the shape appears), a few lines below the actual peak figure. It read `37 GiB` on a shape whose real peak contribution was `0.582 GiB` — a 64× gap — and that is what made chunked attention look worth building.

It now prints per-occurrence size next to the total and states plainly that it is not peak memory:

```
=== largest 4 tensor shapes in the compiled HLO ===
  NOT peak memory: this is CUMULATIVE bytes over every occurrence in the
  program (size x count). A shape can top this table and be irrelevant to
  the peak above — compare against temp/scratch (  0.582 GiB), not to itself.
   37.354 GiB cumulative =   0.015 GiB x2550   f32[15,512,512]
    9.535 GiB cumulative =   0.180 GiB x53     f32[50304,960]
```

Non-novel by the doctrine's test — blockwise attention being a long-sequence optimization is settled; this PR is the record. Ruff clean.

Closes #66

🤖 Generated with [Claude Code](https://claude.com/claude-code)